### PR TITLE
Include nupic.core Cap'n Proto schemas in NuPIC bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ nupic/bindings/*algorithms.*
 nupic/bindings/*iorange.*
 nupic/bindings/*math.*
 nupic/bindings/*.cxx
+nupic/bindings/proto/*.capnp
 
 # Pip stuff
 dist/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -480,3 +480,6 @@ install(FILES
         "${PROJECT_BINARY_DIR}/${SWIG_MODULE_${LIB_MODULE_ALGORITHMS}_REAL_NAME}.so"
         "${PROJECT_BUILD_TEMP_DIR}/${LIB_MODULE_ALGORITHMS}.py"
         DESTINATION ${PROJECT_SOURCE_DIR}/nupic/bindings)
+install(DIRECTORY "${NUPIC_CORE}/include/nupic/proto/"
+        DESTINATION "${PROJECT_SOURCE_DIR}/nupic/bindings/proto"
+        FILES_MATCHING PATTERN "*.capnp")

--- a/nupic/bindings/proto/__init__.py
+++ b/nupic/bindings/proto/__init__.py
@@ -1,0 +1,22 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have purchased from
+# Numenta, Inc. a separate commercial license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Directory for Cap'n Proto schema files from nupic.core."""


### PR DESCRIPTION
Takes all .capnp files from `$NUPIC_CORE/src/nupic/proto` and puts them in `$NUPIC/nupic/bindings/proto/`.