### PR TITLE
Faking extensions to get platform-specific wheels.

### DIFF
--- a/ci/travis/after_success-release-linux.sh
+++ b/ci/travis/after_success-release-linux.sh
@@ -32,10 +32,19 @@ sudo pip install twine || exit
 echo "Creating distribution files..."
 # This release build creates the source distribution. All other release builds
 # should not.
-python setup.py sdist bdist bdist_wheel || exit
+python setup.py sdist bdist || exit
 
 echo "Created the following distribution files:"
 ls -l dist
 
 echo "Attempting to upload all distribution files to PyPi..."
 twine upload dist/* -u "${PYPI_USERNAME}" -p "${PYPI_PASSWD}"
+
+# I want to create the linux wheel here just to see what gets produced with the
+# intent to later upload it to a place other than PyPi, because PyPi rejects
+# linux platform wheel files.
+# See: https://bitbucket.org/pypa/pypi-metadata-formats/issue/15/enhance-the-platform-tag-definition-for
+python setup.py bdist_wheel || exit
+echo "Created the following linux platform wheel:"
+ls dist/*.whl
+echo "Not doing anything with this wheel at this time."

--- a/ci/travis/after_success-release-linux.sh
+++ b/ci/travis/after_success-release-linux.sh
@@ -29,20 +29,13 @@ pip install wheel --user || exit
 echo "Installing twine..."
 sudo pip install twine || exit
 
-# Creates wheel in dist/nupic-0.0.X-py2-none-any.whl
-echo "Creating wheel..."
-python setup.py bdist_wheel || exit
+echo "Creating distribution files..."
+# This release build creates the source distribution. All other release builds
+# should not.
+python setup.py sdist bdist bdist_wheel || exit
 
-generic_filename=`ls dist/*.whl`
-echo "Wheel created at ${generic_filename}."
+echo "Created the following distribution files:"
+ls -l dist
 
-# Change the name of the wheel based on our platform...
-platform=`python -c "import distutils.util; print distutils.util.get_platform()"` || exit
-new_filename=$(echo $generic_filename | sed -e "s/any/${platform}/")
-# This is an attempt to get the right platform for linux pypi.
-# See: https://mail.python.org/pipermail/distutils-sig/2014-October/025173.html
-new_filename=$(echo $new_filename | sed -e "s/py2/cpy27/")
-mv $generic_filename $new_filename
-echo "Moved wheel to ${new_filename} before ${platform} deployment."
-
-sudo twine upload "$new_filename" -u "${PYPI_USERNAME}" -p "${PYPI_PASSWD}"
+echo "Attempting to upload all distribution files to PyPi..."
+twine upload dist/* -u "${PYPI_USERNAME}" -p "${PYPI_PASSWD}"

--- a/setup.py
+++ b/setup.py
@@ -118,9 +118,9 @@ def setupNupic():
   packages = findPackages(repositoryDir)
   requires = findRequirements(repositoryDir)
 
-  # This is a fake extension meant to fake out wheel to produce
-  # platform-specific .whl files. Without this, wheel assumed the binary file
-  # will be platform-independent, and we don't want that.
+  # This meant to fake out wheel to produce platform-specific .whl files. 
+  # Without this, wheel assumes the binary file will be platform-independent, 
+  # and we don't want that.
   fakeExtension = Extension(
       "fake-extension",
       swig_opts=[],

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import shutil
 import sys
 import os
 import subprocess
-from setuptools import setup
+from setuptools import setup, Extension
 
 """
 This file only will call CMake process to generate scripts, build, and then
@@ -118,10 +118,26 @@ def setupNupic():
   packages = findPackages(repositoryDir)
   requires = findRequirements(repositoryDir)
 
+  # This is a fake extension meant to fake out wheel to produce
+  # platform-specific .whl files. Without this, wheel assumed the binary file
+  # will be platform-independent, and we don't want that.
+  fakeExtension = Extension(
+      "fake-extension",
+      swig_opts=[],
+      extra_compile_args=[],
+      define_macros=[],
+      extra_link_args=[],
+      include_dirs=[],
+      libraries=[],
+      sources=[],
+      extra_objects=[]
+  )
+
   # Setup library
   os.chdir(repositoryDir)
   setup(
     name = "nupic",
+    ext_modules=[fakeExtension],
     version = version,
     packages = packages,
     install_requires = requires,


### PR DESCRIPTION
Also starts producing and uploading sdist and bdist along with
bdist_wheel files to pypi. This does not fix the fact that linux
platform wheels cannot be uploaded to pypi, but it does at least create
the linux wheel file.

Fixes #1729.