### PR TITLE
Use gcc in default docker configuration to match nupic.core binary release.

### DIFF
--- a/coreos-vagrant/Vagrantfile
+++ b/coreos-vagrant/Vagrantfile
@@ -13,8 +13,8 @@ $num_instances = 1
 $update_channel = "alpha"
 $enable_serial_logging = false
 $vb_gui = false
-$vb_memory = 1024
-$vb_cpus = 1
+$vb_memory = 4096
+$vb_cpus = 2
 
 # Attempt to apply the deprecated environment variable NUM_INSTANCES to
 # $num_instances while allowing config.rb to override it

--- a/docker/ubuntu/Dockerfile
+++ b/docker/ubuntu/Dockerfile
@@ -6,19 +6,17 @@ MAINTAINER Allan Costa <allaninocencio@yahoo.com.br>
 RUN apt-get update
 RUN apt-get install -y wget
 RUN apt-get install -y git-core
-RUN apt-get install -y clang
+RUN apt-get install -y gcc g++
 RUN apt-get install -y cmake
-RUN apt-get install -y python2.7
-RUN apt-get install -y python2.7-dev
-RUN apt-get install -y zlib1g-dev
-RUN apt-get install -y bzip2
-RUN apt-get install -y libyaml-dev
-RUN apt-get install -y libyaml-0-2
+RUN apt-get install -y python2.7 python 2.7-dev
+RUN apt-get install -y zlib1g-dev bzip2 libyaml-dev libyaml-0-2
 RUN wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py -O - | python
+RUN pip install --upgrade setuptools
+RUN pip install wheel
 
-# Use clang
-ENV CC clang
-ENV CXX clang++
+# Use gcc to match nupic.core binary
+ENV CC gcc
+ENV CXX g++
 
 # Set enviroment variables needed by NuPIC
 ENV NUPIC /usr/local/src/nupic


### PR DESCRIPTION
Also increases resources in coreos configuration.

Not sure if there's an issue for this yet, but will create one if not.

@rhyolight @allanino This works for me in the included CoreOS+Vagrant configuration.

Fixes #1802 