### PR TITLE
Remove unnecessary build flag and fix a bug that was causing duplicated ...

### DIFF
--- a/scripts/run_nupic_tests
+++ b/scripts/run_nupic_tests
@@ -28,8 +28,8 @@ from pkg_resources import (
   get_distribution
 )
 from optparse import OptionParser
+from subprocess import call
 
-import pytest
 
 
 try:
@@ -245,14 +245,14 @@ def main(parser, parse_args):
             else arg
           for arg in args
         ]
-      testStatus = pytest.main(specific_args + [test])
+      testStatus = call(["py.test"] + specific_args + [test])
       # exitStatus defaults to 0, if any test returns non-0, we'll set it.
       if testStatus is not 0:
         exitStatus = testStatus
 
   else:
     # Standard tests
-    exitStatus = pytest.main(args + list(tests))
+    exitStatus = call(["py.test"] + args + list(tests))
 
   return exitStatus
 

--- a/setup.py
+++ b/setup.py
@@ -341,7 +341,6 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness):
   commonLinkFlags = [
     "-m" + bitness,
     "-fPIC",
-    "-L" + pythonPrefix + "/lib",
     "-L" + nupicCoreReleaseDir + "/lib",
     "-lkj",
     "-lcapnp",
@@ -420,7 +419,7 @@ def getExtensionModules(nupicCoreReleaseDir, platform, bitness):
   for define in commonDefines:
     item = "-D" + define[0]
     if define[1]:
-      item += define[0] + "=" + define[1]
+      item += "=" + define[1]
     swigFlags.append(item)
   for includeDir in commonIncludeDirs:
     item = "-I" + includeDir


### PR DESCRIPTION
...definition names.

@rhyolight this fixes #1813 for me.

The other, unrelated bug fixed here is that `-DNTA_PYTHON_SUPPORTNTA_PYTHON_SUPPORT=2.7` was being added instead of `-DNTA_PYTHON_SUPPORT=2.7`