### PR TITLE
Removes isDelta method from encoder base class.

### DIFF
--- a/nupic/encoders/base.py
+++ b/nupic/encoders/base.py
@@ -85,13 +85,6 @@ class Encoder(object):
     raise Exception("getWidth must be implemented by all subclasses")
 
   ############################################################################
-  def isDelta(self):
-    """
-    @returns true if the underlying encoder works on deltas
-    """
-    return False
-
-  ############################################################################
   def encodeIntoArray(self, inputData, output):
     """
     Encodes inputData and puts the encoded value into the numpy output array,

--- a/nupic/encoders/delta.py
+++ b/nupic/encoders/delta.py
@@ -82,9 +82,6 @@ class DeltaEncoder(AdaptiveScalarEncoder):
   def setFieldStats(self, fieldName, fieldStatistics):
     pass
   ############################################################################
-  def isDelta(self):
-    return True
-  ############################################################################
   def getBucketIndices(self, input, learn=None):
     return self._adaptiveScalarEnc.getBucketIndices(input, learn)
   ############################################################################

--- a/nupic/frameworks/opf/clamodel.py
+++ b/nupic/frameworks/opf/clamodel.py
@@ -41,7 +41,7 @@ from nupic.frameworks.opf.model import Model
 from nupic.algorithms.anomaly import Anomaly
 from nupic.data import SENTINEL_VALUE_FOR_MISSING_DATA
 from nupic.data.fieldmeta import FieldMetaSpecial, FieldMetaInfo
-from nupic.encoders import MultiEncoder
+from nupic.encoders import MultiEncoder, DeltaEncoder
 from nupic.engine import Network
 from nupic.support.fshelpers import makeDirectoryFromAbsolutePath
 from nupic.frameworks.opf.opfutils import (InferenceType,
@@ -731,7 +731,7 @@ class CLAModel(Model):
 
     # Convert the absolute values to deltas if necessary
     # The bucket index should be handled correctly by the underlying delta encoder
-    if self._classifierInputEncoder.isDelta():
+    if isinstance(self._classifierInputEncoder, DeltaEncoder):
       # Make the delta before any values have been seen 0 so that we do not mess up the
       # range for the adaptive scalar encoder.
       if not hasattr(self,"_ms_prevVal"):
@@ -815,7 +815,7 @@ class CLAModel(Model):
       # ---------------------------------------------------------------------
       # If we have a delta encoder, we have to shift our predicted output value
       #  by the sum of the deltas
-      if self._classifierInputEncoder.isDelta():
+      if isinstance(self._classifierInputEncoder, DeltaEncoder):
         # Get the prediction history for this number of timesteps.
         # The prediction history is a store of the previous best predicted values.
         # This is used to get the final shift from the current absolute value.

--- a/tests/unit/nupic/encoders/scalarspace_test.py
+++ b/tests/unit/nupic/encoders/scalarspace_test.py
@@ -24,7 +24,7 @@
 
 import unittest2 as unittest
 
-from nupic.encoders.scalarspace import ScalarSpaceEncoder
+from nupic.encoders.scalarspace import ScalarSpaceEncoder, DeltaEncoder
 
 
 #########################################################################
@@ -35,10 +35,12 @@ class ScalarSpaceEncoderTest(unittest.TestCase):
   def testScalarSpaceEncoder(self):
     """scalar space encoder"""
     # use of forced=True is not recommended, but used in the example for readibility, see scalar.py
-    sse = ScalarSpaceEncoder(1,1,2,False,2,1,1,None,0,False,"delta", forced=True)
-    self.assertTrue(sse.isDelta())
-    sse = ScalarSpaceEncoder(1,1,2,False,2,1,1,None,0,False,"absolute", forced=True)
-    self.assertFalse(sse.isDelta())
+    sse = ScalarSpaceEncoder(1,1,2,False,2,1,1,None,0,False,"delta",
+                             forced=True)
+    self.assertTrue(isinstance(sse, DeltaEncoder))
+    sse = ScalarSpaceEncoder(1,1,2,False,2,1,1,None,0,False,"absolute",
+                             forced=True)
+    self.assertFalse(isinstance(sse, DeltaEncoder))
 
      
 ###########################################


### PR DESCRIPTION
CLAModel now uses `isinstance(encoder, DeltaEncoder)` to special case the delta encoder.

@subutai please review

fixes #1829 