### PR TITLE
Revert "Updates nupic.core to latest built SHA."

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = 'b6b8f1ed211008099031fca752459760c2d3baf3'
+NUPIC_CORE_COMMITISH = '9b5802c3a7ecb682c6e94df311b2acafdb1e9550'


### PR DESCRIPTION
Fixes #1910. Reverts numenta/nupic#1904

Doing this to fix the current build. numenta/nupic#1904 was merged prematurely, probably because Travis has not been posting statuses properly. My fault, I'm sure. 