### PR TITLE
accepts anomaly records as both lists and tuples; closes issue #1831

### DIFF
--- a/nupic/algorithms/anomaly_likelihood.py
+++ b/nupic/algorithms/anomaly_likelihood.py
@@ -480,7 +480,7 @@ def _anomalyScoreMovingAverage(anomalyScores,
   for record in anomalyScores:
 
     # Skip (but log) records without correct number of entries
-    if not isinstance(record, list) or len(record) != 3:
+    if not isinstance(record, list or tuple) or len(record) != 3:
       if verbosity >= 1:
         print "Malformed record:", record
       continue


### PR DESCRIPTION
Addresses the issue discussed for [commit e6e2e6c](https://github.com/numenta/nupic/commit/e6e2e6c1d182624fab96bea7f5ed1d900ed4dbb8)
@rhyolight @cogmission this fixes #1912, allowing NAB to run the NuPIC detector.