### PR TITLE
Run OPF experiment without source checkout

### DIFF
--- a/nupic/frameworks/opf/experiment_runner.py
+++ b/nupic/frameworks/opf/experiment_runner.py
@@ -41,6 +41,8 @@ from nupic.frameworks.opf.modelfactory import ModelFactory
 from nupic.frameworks.opf.opftaskdriver import OPFTaskDriver
 from nupic.frameworks.opf.opfutils import (InferenceElement, matchPatterns,
                                            validateOpfJsonValue)
+from nupic.support import initLogging
+
 
 
 g_defaultCheckpointExtension = ".nta"
@@ -833,3 +835,28 @@ class PeriodicActivityMgr(object):
           act.iteratorHolder[0] = None
 
     return True
+
+
+
+def main():
+  """ Module-level entry point.  Run according to options in sys.argv
+
+  Usage: python -m python -m nupic.frameworks.opf.experiment_runner
+
+  """
+  initLogging(verbose=True)
+
+  # Initialize pseudo-random number generators (PRNGs)
+  #
+  # This will fix the seed that is used by numpy when generating 'random'
+  # numbers. This allows for repeatability across experiments.
+  initExperimentPrng()
+
+  # Run it!
+  runExperiment(sys.argv[1:])
+
+
+
+if __name__ == "__main__":
+  main()
+

--- a/scripts/run_opf_experiment.py
+++ b/scripts/run_opf_experiment.py
@@ -24,27 +24,7 @@
 It executes a single experiment.
 """
 
-
-import sys
-
-from nupic.frameworks.opf.experiment_runner import (runExperiment,
-                                                    initExperimentPrng)
-import nupic.support
-
-
-
-def main():
-  """Run according to options in sys.argv"""
-  nupic.support.initLogging(verbose=True)
-
-  # Initialize pseudo-random number generators (PRNGs)
-  #
-  # This will fix the seed that is used by numpy when generating 'random'
-  # numbers. This allows for repeatability across experiments.
-  initExperimentPrng()
-
-  # Run it!
-  runExperiment(sys.argv[1:])
+from nupic.frameworks.opf.experiment_runner import main
 
 
 


### PR DESCRIPTION
Shift bulk of run_opf_experiment.py into experiment_runner.py for cli-friendly python module.  This lets you run an experiment by invoking `python -m nupic.frameworks.opf.experiment_runner <path to experiment>` with only the binary installation and without needing access to scripts/run_opf_experiment.py (not included in binary).

Meanwhile, this maintains existing functionality of run_opf_experiment.py for non-binary installations.

See discussion in https://github.com/numenta/nupic/issues/1920#issuecomment-78571236 for motivation.

Fixes #1921

