### PR TITLE
Adding OS X to requirements of audiostream readme.

### DIFF
--- a/examples/audiostream/README.md
+++ b/examples/audiostream/README.md
@@ -7,6 +7,7 @@ or become more familiar with your speech pattern.
 
 ## Requirements
 
+- Mac OS X
 - [matplotlib](http://matplotlib.org/)
 - [pyaudio](http://people.csail.mit.edu/hubert/pyaudio/)
 


### PR DESCRIPTION
Fixes #1955.