### PR TITLE
Remove pylint. It is optional so developers can install if they want.

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -6,7 +6,6 @@ ordereddict==1.1
 pillow==2.3.0
 psutil==1.0.1
 pycapnp==0.5.1
-pylint==1.1.0
 pytest==2.4.2
 pytest-cov==1.6
 pytest-xdist==1.8


### PR DESCRIPTION
fixes #1957

@rhyolight please review