### PR TITLE
Make logging to file optional

### DIFF
--- a/nupic/support/__init__.py
+++ b/nupic/support/__init__.py
@@ -402,7 +402,7 @@ def initLogging(verbose=False, console='stdout', consoleLevel='DEBUG'):
   #   module
   configFilename = 'nupic-logging.conf'
   configFilePath = resource_filename("nupic.support", configFilename)
-  configLogDir   = os.environ.get('NTA_LOG_DIR', None)
+  configLogDir = os.environ.get('NTA_LOG_DIR', None)
 
   # Load in the logging configuration file
   if verbose:


### PR DESCRIPTION
This is a follow-up on #1970 and supersedes that PR. The changes make logging to files optional in that it only happens if the $NTA_LOG_DIR is set. This allows to finally get rid of the $NUPIC dependency in the code base which was used to compute the default logging directory.

The $NUPIC dependencies in the tests are still around and will be tackled in a second PR.

Fixes #2006.