### PR TITLE
Upgrade pycapnp version to 0.5.5, allowing use of absolute imports

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -5,7 +5,7 @@ mock==1.0.1
 ordereddict==1.1
 pillow==2.3.0
 psutil==1.0.1
-pycapnp==0.5.4
+pycapnp==0.5.5
 pytest==2.4.2
 pytest-cov==1.6
 pytest-xdist==1.8

--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -5,7 +5,7 @@ mock==1.0.1
 ordereddict==1.1
 pillow==2.3.0
 psutil==1.0.1
-pycapnp==0.5.1
+pycapnp==0.5.4
 pytest==2.4.2
 pytest-cov==1.6
 pytest-xdist==1.8

--- a/nupic/encoders/adaptivescalar.capnp
+++ b/nupic/encoders/adaptivescalar.capnp
@@ -1,6 +1,6 @@
 @0xf11485b8c813b489;
 
-using import "../movingaverage.capnp".MovingAverageProto;
+using import "/nupic/movingaverage.capnp".MovingAverageProto;
 
 # Next ID: 10
 struct AdaptiveScalarEncoderProto {

--- a/nupic/encoders/category.capnp
+++ b/nupic/encoders/category.capnp
@@ -1,6 +1,6 @@
 @0xb639caa166140b0f;
 
-using import "scalar.capnp".ScalarEncoderProto;
+using import "/nupic/encoders/scalar.capnp".ScalarEncoderProto;
 
 # Next ID: 5
 struct CategoryEncoderProto {

--- a/nupic/encoders/date.capnp
+++ b/nupic/encoders/date.capnp
@@ -1,6 +1,6 @@
 @0x9b23d989c61ef9e5;
 
-using import "scalar.capnp".ScalarEncoderProto;
+using import "/nupic/encoders/scalar.capnp".ScalarEncoderProto;
 
 struct DateEncoderProto {
   name @0 :Text;

--- a/nupic/encoders/delta.capnp
+++ b/nupic/encoders/delta.capnp
@@ -1,6 +1,6 @@
 @0xdf5bd1fedf76298f;
 
-using import "adaptivescalar.capnp".AdaptiveScalarEncoderProto;
+using import "/nupic/encoders/adaptivescalar.capnp".AdaptiveScalarEncoderProto;
 
 struct DeltaEncoderProto {
   width @0 :UInt32;

--- a/nupic/encoders/log.capnp
+++ b/nupic/encoders/log.capnp
@@ -1,6 +1,6 @@
 @0x94b5c39874f24431;
 
-using import "scalar.capnp".ScalarEncoderProto;
+using import "/nupic/encoders/scalar.capnp".ScalarEncoderProto;
 
 struct LogEncoderProto {
   verbosity @0 :UInt8;

--- a/nupic/encoders/multi.capnp
+++ b/nupic/encoders/multi.capnp
@@ -1,17 +1,17 @@
 @0xf07c1f24bf12fe13;
 
-using import "adaptivescalar.capnp".AdaptiveScalarEncoderProto;
-using import "category.capnp".CategoryEncoderProto;
-using import "coordinate.capnp".CoordinateEncoderProto;
-using import "date.capnp".DateEncoderProto;
-using import "delta.capnp".DeltaEncoderProto;
-using import "geospatial_coordinate.capnp".GeospatialCoordinateEncoderProto;
-using import "log.capnp".LogEncoderProto;
-using import "pass_through.capnp".PassThroughEncoderProto;
-using import "random_distributed_scalar.capnp".RandomDistributedScalarEncoderProto;
-using import "scalar.capnp".ScalarEncoderProto;
-using import "sdrcategory.capnp".SDRCategoryEncoderProto;
-using import "sparse_pass_through_encoder.capnp".SparsePassThroughEncoderProto;
+using import "/nupic/encoders/adaptivescalar.capnp".AdaptiveScalarEncoderProto;
+using import "/nupic/encoders/category.capnp".CategoryEncoderProto;
+using import "/nupic/encoders/coordinate.capnp".CoordinateEncoderProto;
+using import "/nupic/encoders/date.capnp".DateEncoderProto;
+using import "/nupic/encoders/delta.capnp".DeltaEncoderProto;
+using import "/nupic/encoders/geospatial_coordinate.capnp".GeospatialCoordinateEncoderProto;
+using import "/nupic/encoders/log.capnp".LogEncoderProto;
+using import "/nupic/encoders/pass_through.capnp".PassThroughEncoderProto;
+using import "/nupic/encoders/random_distributed_scalar.capnp".RandomDistributedScalarEncoderProto;
+using import "/nupic/encoders/scalar.capnp".ScalarEncoderProto;
+using import "/nupic/encoders/sdrcategory.capnp".SDRCategoryEncoderProto;
+using import "/nupic/encoders/sparse_pass_through_encoder.capnp".SparsePassThroughEncoderProto;
 
 # Next ID: 3
 struct MultiEncoderProto {

--- a/nupic/encoders/random_distributed_scalar.capnp
+++ b/nupic/encoders/random_distributed_scalar.capnp
@@ -1,6 +1,6 @@
 @0xa4f79e07a0df410d;
 
-using import "../bindings/proto/RandomProto.capnp".RandomProto;
+using import "/nupic/bindings/proto/RandomProto.capnp".RandomProto;
 
 # Next ID: 10
 struct RandomDistributedScalarEncoderProto {

--- a/nupic/encoders/sdrcategory.capnp
+++ b/nupic/encoders/sdrcategory.capnp
@@ -1,6 +1,6 @@
 @0x8017c9c04559354c;
 
-using import "../bindings/proto/RandomProto.capnp".RandomProto;
+using import "/nupic/bindings/proto/RandomProto.capnp".RandomProto;
 
 # Next ID: 7
 struct SDRCategoryEncoderProto {


### PR DESCRIPTION
Fixes #2012

cc @scottpurdy 