### PR TITLE
Topology for PassThrough encoders

### DIFF
--- a/nupic/encoders/base.py
+++ b/nupic/encoders/base.py
@@ -127,9 +127,10 @@ class Encoder(object):
     call.
 
     @param inputData TODO: document
-    @returns a numpy array with the encoded representation of inputData
+    @returns a numpy array with the encoded representation of inputData; 
+             keeping its shape (size)
     """
-    output = numpy.zeros((self.getWidth(),), dtype=defaultDtype)
+    output = numpy.zeros(shape=numpy.shape(inputData), dtype=defaultDtype)
     self.encodeIntoArray(inputData, output)
     return output
 

--- a/nupic/encoders/base.py
+++ b/nupic/encoders/base.py
@@ -127,10 +127,9 @@ class Encoder(object):
     call.
 
     @param inputData TODO: document
-    @returns a numpy array with the encoded representation of inputData; 
-             keeping its shape (size)
+    @returns a numpy array with the encoded representation of inputData
     """
-    output = numpy.zeros(shape=numpy.shape(inputData), dtype=defaultDtype)
+    output = numpy.zeros((self.getWidth(),), dtype=defaultDtype)
     self.encodeIntoArray(inputData, output)
     return output
 

--- a/nupic/encoders/pass_through_encoder.py
+++ b/nupic/encoders/pass_through_encoder.py
@@ -76,9 +76,9 @@ class PassThroughEncoder(Encoder):
   ############################################################################
   def encodeIntoArray(self, input, output):
     """See method description in base.py"""
-    if numpy.shape(input) != numpy.shape(output):
-      raise ValueError("Different shapes  (%s) and output (%s)." % (
-          numpy.shape(input), numpy.shape(output)))
+    if len(input) != len(output):
+      raise ValueError("Different input (%i) and output (%i) sizes." % (
+          len(input), len(output)))
 
     # check for requested sparsity in input data
     if self.w is not None and sum(input) != self.w:

--- a/nupic/encoders/pass_through_encoder.py
+++ b/nupic/encoders/pass_through_encoder.py
@@ -76,9 +76,9 @@ class PassThroughEncoder(Encoder):
   ############################################################################
   def encodeIntoArray(self, input, output):
     """See method description in base.py"""
-    if len(input) != len(output):
-      raise ValueError("Different input (%i) and output (%i) sizes." % (
-          len(input), len(output)))
+    if numpy.shape(input) != numpy.shape(output):
+      raise ValueError("Different shapes  (%s) and output (%s)." % (
+          numpy.shape(input), numpy.shape(output)))
 
     # check for requested sparsity in input data
     if self.w is not None and sum(input) != self.w:

--- a/nupic/encoders/pass_through_encoder.py
+++ b/nupic/encoders/pass_through_encoder.py
@@ -21,7 +21,7 @@
 
 import numpy
 from nupic.data.fieldmeta import FieldMetaType
-from nupic.encoders.base import Encoder
+from nupic.encoders.base import Encoder, defaultDtype
 
 
 
@@ -74,11 +74,26 @@ class PassThroughEncoder(Encoder):
     return [0]
 
   ############################################################################
+  def encode(self, inputData):
+    """overrides encode() from base.Encoder to implement
+       dimensionality - the output has the same dimensionality as the input; 
+       eg 1D -> 1D, 2D -> 2D, ...
+
+      @param inputData
+      @returns a numpy array with the encoded representation of inputData; 
+               keeping its shape (size)
+      @returns a numpy array with the encoded representation of inputData
+    """
+    output = numpy.zeros(shape=numpy.shape(inputData), dtype=defaultDtype)
+    self.encodeIntoArray(inputData, output)
+    return output
+
+  ############################################################################
   def encodeIntoArray(self, input, output):
     """See method description in base.py"""
-    if len(input) != len(output):
-      raise ValueError("Different input (%i) and output (%i) sizes." % (
-          len(input), len(output)))
+    if numpy.shape(input) != numpy.shape(output):
+      raise ValueError("Different shapes  (%s) and output (%s)." % (
+          numpy.shape(input), numpy.shape(output)))
 
     # check for requested sparsity in input data
     if self.w is not None and sum(input) != self.w:

--- a/nupic/encoders/pass_through_encoder.py
+++ b/nupic/encoders/pass_through_encoder.py
@@ -36,10 +36,10 @@ class PassThroughEncoder(Encoder):
   ############################################################################
   def __init__(self, n, w=None, name="pass_through", forced=False, verbosity=0):
     """
-    n -- is the total #bits in output
-    w -- is used to normalize the sparsity of the output, exactly w bits ON,
+    @param n -- is the total #bits in output
+    @param w -- is used to check the sparsity of the output, exactly w bits ON,
          if None (default) - do not alter the input, just pass it further.
-    forced -- if forced, encode will accept any data, and just return it back.
+    @param forced -- if forced, encode will accept any data, and just return it back.
     """
     self.n = n
     self.w = w
@@ -80,9 +80,9 @@ class PassThroughEncoder(Encoder):
       raise ValueError("Different input (%i) and output (%i) sizes." % (
           len(input), len(output)))
 
+    # check for requested sparsity in input data
     if self.w is not None and sum(input) != self.w:
-      raise ValueError("Input has %i bits but w was set to %i." % (
-          sum(input), self.w))
+      raise ValueError("Input has %i bits but w was set to %i." % (sum(input), self.w))
 
     output[:] = input[:]
 

--- a/nupic/encoders/sparse_pass_through_encoder.py
+++ b/nupic/encoders/sparse_pass_through_encoder.py
@@ -22,7 +22,7 @@
 import numpy
 
 from nupic.encoders import pass_through_encoder
-
+from nupic.encoders.base import defaultDtype
 
 ############################################################################
 class SparsePassThroughEncoder(pass_through_encoder.PassThroughEncoder):
@@ -48,6 +48,16 @@ class SparsePassThroughEncoder(pass_through_encoder.PassThroughEncoder):
     super(SparsePassThroughEncoder, self).__init__(
         n, w, name, forced, verbosity)
 
+  
+  def encode(self, inputData):
+    """override - act like Encoder.encode() not PassThrough.encode()
+       TODO: remove when dimensionality implemented same way as in PassThrough
+    """
+    output = numpy.zeros((self.getWidth(),), dtype=defaultDtype)
+    self.encodeIntoArray(inputData, output)
+    return output
+
+    
   ############################################################################
   def encodeIntoArray(self, input, output):
     """ See method description in base.py """

--- a/nupic/encoders/sparse_pass_through_encoder.py
+++ b/nupic/encoders/sparse_pass_through_encoder.py
@@ -26,23 +26,24 @@ from nupic.encoders import pass_through_encoder
 
 ############################################################################
 class SparsePassThroughEncoder(pass_through_encoder.PassThroughEncoder):
-  """Convert a bitmap encoded as array indicies to an SDR
+  """Converts a sparse (index encoded) bitmap to a dense array ("SDR")
 
   Each encoding is an SDR in which w out of n bits are turned on.
   The input should be an array or string of indicies to turn on
-  Note: the value for n must equal input length * w
-  i.e. for n=8 w=1 [0,2,5] => 101001000
-    or for n=8 w=1 "0,2,5" => 101001000
+  Note: the value for n must equal (input length) * w
 
-  i.e. for n=24 w=3 [0,2,5] => 111000111000000111000000000
-    or for n=24 w=3 "0,2,5" => 111000111000000111000000000
+  i.e. for n=9 w=1 [0,2,5] => 101001000
+    or for n=9 w=1 "0,2,5" => 101001000
+
+  i.e. for n=27 w=3 [0,2,5] => 111000111000000111000000000
+    or for n=27 w=3 "0,2,5" => 111000111000000111000000000
   """
 
   ############################################################################
   def __init__(self, n, w=None, name="sparse_pass_through", forced=False, verbosity=0):
     """
-    n is the total bits in input
-    w is the number of bits used to encode each input bit
+    @param n is the total bits in the original input
+    @param w is the number of bits used to encode each (orig) input bit:
     """
     super(SparsePassThroughEncoder, self).__init__(
         n, w, name, forced, verbosity)

--- a/tests/unit/nupic/encoders/pass_through_encoder_test.py
+++ b/tests/unit/nupic/encoders/pass_through_encoder_test.py
@@ -69,6 +69,17 @@ class PassThroughEncoderTest(unittest.TestCase):
     self.assertEqual(sum_real, sum_expected)
 
 
+  def testEncode2DArray(self):
+    """encoding a 2D array"""
+    e = self._encoder(self.n, name=self.name)
+    bitmap = numpy.zeros(shape=(3,3), dtype=numpy.uint8) # 2D 3x3 matrix
+    bitmap[0,0] = 1
+    bitmap[1,2] = 1
+    out = e.encode(bitmap)
+    self.assertTrue((bitmap == out).all(), "bitmaps are not equal! IN= %s, OUT=%s" % (bitmap, out))
+
+
+
   def testClosenessScores(self):
     """Compare two bitmaps for closeness"""
     e = self._encoder(self.n, name=self.name)


### PR DESCRIPTION
Encoders return output in same dimensions as the input; 
now used for PassThrough encoder 
Fixes #2062 