### PR TITLE
Fixes #1903 - Re-use Connections class in SP

### DIFF
--- a/nupic/research/spatial_pooler.py
+++ b/nupic/research/spatial_pooler.py
@@ -1253,7 +1253,7 @@ class SpatialPooler(object):
 
     # As each column has only one segment, we can reference it with own column's
     # index
-    if index in self.connections._segmentsForElement:
+    if index in self.connections._segmentsForCell:
       synapses = set(self.connections.synapsesForSegment(index))
       for synapse in synapses:
         self.connections.destroySynapse(synapse)

--- a/nupic/research/spatial_pooler.py
+++ b/nupic/research/spatial_pooler.py
@@ -1359,7 +1359,8 @@ class SpatialPooler(object):
     """
     overlaps = numpy.zeros(self._numColumns).astype(realDType)
     for i in xrange(self._numColumns):
-      inputIndices = self._getInputIndicesFromSynapsesForColumn(i)
+      inputIndices = self._getInputIndicesFromSynapsesForColumn(i,
+                                                                onlyConnected=True)
       overlaps[i] = inputVector[inputIndices].sum()
     overlaps[overlaps < self._stimulusThreshold] = 0
     return overlaps


### PR DESCRIPTION
Fixes: https://github.com/numenta/nupic/issues/1903
Depends: https://github.com/numenta/nupic/issues/1449

Ladies and gentlemen, now SP also has connections! Connections class is a prime by @chetan51 which allow us to separate net specification from net state. This seems simple but has a lot of implications to make nupic easier to understanding and mantaining. This class is so abstract when comes to segments and synapses that I managed adapt it to SP without need create any additional method but only re-using the existing ones.

Some important changes:

- `_potentialPools` was removed: Now SP create synapses to all input bits that are in potential area of a column. So when methods like `_adaptSynapses`, `_bumpUpWeakColumns`, `_updatePermanencesForColumn`, need update synapses's permanencies, they don't need handle a `mapPotential` but simply handle directly such synapses of the column or get the indices of the input bits which they are connected.

- `_permanences` was removed: Now SP uses a dict to get permanencies from an individual column and put them into a temporary numpy array to perform changes (`perm`). After permanencies operations is done, SP updates the synapses of a column with the new permanencies values (using _updatePermanencesForColumn method).

I compared the performance without or with these changes and I feel litle difference. But it is desirable we have more eyes on this.

This PR still is not ready because I still have to implement serialization for Connections and more tests are need to we find areas for improvement. 

TODO:
- [X] Move Connections class from TemporalMemory into a separated file.
- [X] Adapt SP to use Connections.
- [ ] Create serialization for Connections.
- [ ] Compare performance.
