### PR TITLE
FunctionSource fixes and test

### DIFF
--- a/nupic/data/functionsource.py
+++ b/nupic/data/functionsource.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013,2015, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #

--- a/nupic/data/functionsource.py
+++ b/nupic/data/functionsource.py
@@ -54,8 +54,10 @@ class FunctionSource(object):
 
     if hasReset and not hasSequenceId:
       self._sequenceInfoType = self.SEQUENCEINFO_RESET_ONLY
+      self._prevSequenceId = 0
     elif not hasReset and hasSequenceId:
       self._sequenceInfoType = self.SEQUENCEINFO_SEQUENCEID_ONLY
+      self._prevSequenceId = None
     elif hasReset and hasSequenceId:
       self._sequenceInfoType = self.SEQUENCEINFO_BOTH
     else:
@@ -66,7 +68,7 @@ class FunctionSource(object):
 
     # Automatically add _sequenceId and _reset fields
     if self._sequenceInfoType == self.SEQUENCEINFO_SEQUENCEID_ONLY:
-      sequenceId =  result[self.sequenceIdFieldName]
+      sequenceId = result[self.sequenceIdFieldName]
       reset = sequenceId != self._prevSequenceId
       self._prevSequenceId = sequenceId
     elif self._sequenceInfoType == self.SEQUENCEINFO_NONE:
@@ -76,11 +78,9 @@ class FunctionSource(object):
       reset = result[self.resetFieldName]
       if reset:
         self._prevSequenceId += 1
-        sequenceId = self._prevSequenceId
-      else:
-        sequenceId = self._prevSequenceId
+      sequenceId = self._prevSequenceId
     elif self._sequenceInfoType == self.SEQUENCEINFO_BOTH:
-      reset = result[self._resetFieldName]
+      reset = result[self.resetFieldName]
       sequenceId = result[self.sequenceIdFieldName]
     else:
       raise RuntimeError("Internal error -- sequence info type not set in RecordSensor")
@@ -97,7 +97,13 @@ class FunctionSource(object):
 
 
   def __getstate__(self):
-    state = dict(state=self.state)
+    state = dict(
+      state = self.state,
+      resetFieldName = self.resetFieldName,
+      sequenceIdFieldName = self.sequenceIdFieldName,
+      sequenceInfoType = self._sequenceInfoType,
+      prevSequenceId = getattr(self, "_prevSequenceId", None)
+      )
     func = dict()
     func['code'] = marshal.dumps(self.func.func_code)
     func['name'] = self.func.func_name
@@ -113,3 +119,7 @@ class FunctionSource(object):
     self.func.func_doc = funcinfo['doc']
 
     self.state = state['state']
+    self.resetFieldName = state['resetFieldName']
+    self.sequenceIdFieldName = state['sequenceIdFieldName']
+    self._sequenceInfoType = state['sequenceInfoType']
+    self._prevSequenceId = state['prevSequenceId']

--- a/tests/unit/nupic/data/functionsource_test.py
+++ b/tests/unit/nupic/data/functionsource_test.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""
+Unit tests for functionsource.
+"""
+
+import unittest2 as unittest
+import pickle
+
+from nupic.data import FunctionSource
+
+def dataFunction(stat):
+  ret = {"reset": 0, "sequence": 0, "data": 0}
+  if stat is not None:
+    val = stat.get('val', 0) + 1
+    ret["val"] = stat["val"] = val
+  return ret
+
+class FunctionSourceTest(unittest.TestCase):
+  def testFunctionSource(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName=None, sequenceIdFieldName=None)
+    self.assertIsNotNone(fs)
+    r = fs.getNextRecordDict()
+    self.assertIsNotNone(r)
+
+  def testFunctionSourceReset(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName="reset", sequenceIdFieldName=None)
+    self.assertIsNotNone(fs)
+    r = fs.getNextRecordDict()
+    self.assertIsNotNone(r)
+      
+  def testFunctionSourceSequence(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName=None, sequenceIdFieldName="sequence")
+    self.assertIsNotNone(fs)
+    r = fs.getNextRecordDict()
+    self.assertIsNotNone(r)
+      
+  def testFunctionSourceResetAndSequence(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName="reset", sequenceIdFieldName="sequence")
+    self.assertIsNotNone(fs)
+    r = fs.getNextRecordDict()
+    self.assertIsNotNone(r)
+      
+  def testFunctionSourceState(self):
+    state = dict(val=100)
+    fs = FunctionSource(dataFunction, state=state, resetFieldName="reset", sequenceIdFieldName="sequence")
+    self.assertIsNotNone(fs)
+    r = fs.getNextRecordDict()
+    self.assertIsNotNone(r)
+    r = fs.getNextRecordDict()
+    r = fs.getNextRecordDict()
+    self.assertEqual(103, state["val"])
+
+  def testFunctionSourcePickle(self):
+    state = dict(val=100)
+    fs = FunctionSource(dataFunction, state=state, resetFieldName="reset", sequenceIdFieldName="sequence")
+    self.assertIsNotNone(fs)
+    r = fs.getNextRecordDict()    
+    self.assertIsNotNone(r)
+    
+    pkl = pickle.dumps(fs)
+    
+    fs2 = pickle.loads(pkl)
+    
+    r = fs2.getNextRecordDict()
+    r = fs2.getNextRecordDict()
+    self.assertEqual(103, fs2.state["val"])
+
+if __name__ == "__main__":
+  unittest.main()

--- a/tests/unit/nupic/data/functionsource_test.py
+++ b/tests/unit/nupic/data/functionsource_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -24,46 +24,59 @@
 Unit tests for functionsource.
 """
 
-import unittest2 as unittest
 import pickle
+import unittest
 
 from nupic.data import FunctionSource
+
+
 
 def dataFunction(stat):
   ret = {"reset": 0, "sequence": 0, "data": 0}
   if stat is not None:
-    val = stat.get('val', 0) + 1
+    val = stat.get("val", 0) + 1
     ret["val"] = stat["val"] = val
   return ret
 
 class FunctionSourceTest(unittest.TestCase):
-  def testFunctionSource(self):
-    fs = FunctionSource(dataFunction, state=None, resetFieldName=None, sequenceIdFieldName=None)
+
+
+  def testDefaultArgs(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName=None,
+                        sequenceIdFieldName=None)
     self.assertIsNotNone(fs)
     r = fs.getNextRecordDict()
     self.assertIsNotNone(r)
 
-  def testFunctionSourceReset(self):
-    fs = FunctionSource(dataFunction, state=None, resetFieldName="reset", sequenceIdFieldName=None)
+
+  def testResetField(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName="reset",
+                        sequenceIdFieldName=None)
     self.assertIsNotNone(fs)
     r = fs.getNextRecordDict()
     self.assertIsNotNone(r)
-      
-  def testFunctionSourceSequence(self):
-    fs = FunctionSource(dataFunction, state=None, resetFieldName=None, sequenceIdFieldName="sequence")
+
+
+  def testSequenceField(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName=None,
+                        sequenceIdFieldName="sequence")
     self.assertIsNotNone(fs)
     r = fs.getNextRecordDict()
     self.assertIsNotNone(r)
-      
-  def testFunctionSourceResetAndSequence(self):
-    fs = FunctionSource(dataFunction, state=None, resetFieldName="reset", sequenceIdFieldName="sequence")
+
+
+  def testResetAndSequenceFields(self):
+    fs = FunctionSource(dataFunction, state=None, resetFieldName="reset",
+                        sequenceIdFieldName="sequence")
     self.assertIsNotNone(fs)
     r = fs.getNextRecordDict()
     self.assertIsNotNone(r)
-      
-  def testFunctionSourceState(self):
+
+
+  def testState(self):
     state = dict(val=100)
-    fs = FunctionSource(dataFunction, state=state, resetFieldName="reset", sequenceIdFieldName="sequence")
+    fs = FunctionSource(dataFunction, state=state, resetFieldName="reset",
+                        sequenceIdFieldName="sequence")
     self.assertIsNotNone(fs)
     r = fs.getNextRecordDict()
     self.assertIsNotNone(r)
@@ -71,20 +84,26 @@ class FunctionSourceTest(unittest.TestCase):
     r = fs.getNextRecordDict()
     self.assertEqual(103, state["val"])
 
-  def testFunctionSourcePickle(self):
+
+  def testPickle(self):
     state = dict(val=100)
-    fs = FunctionSource(dataFunction, state=state, resetFieldName="reset", sequenceIdFieldName="sequence")
+    fs = FunctionSource(dataFunction, state=state, resetFieldName="reset",
+                        sequenceIdFieldName="sequence")
     self.assertIsNotNone(fs)
-    r = fs.getNextRecordDict()    
+    r = fs.getNextRecordDict()
     self.assertIsNotNone(r)
-    
+
     pkl = pickle.dumps(fs)
-    
+    self.assertIsNotNone(pkl)
+
     fs2 = pickle.loads(pkl)
-    
+    self.assertIsNotNone(fs2)
+
     r = fs2.getNextRecordDict()
     r = fs2.getNextRecordDict()
     self.assertEqual(103, fs2.state["val"])
+
+
 
 if __name__ == "__main__":
   unittest.main()


### PR DESCRIPTION
Fixes #2068
- Fixed invalid reference to self._resetFieldName (typo)
- Initialized self._prevSequenceId in necessary cases
- Pickling now captures all state
- Added unit test