### PR TITLE
Updates NuPIC to latest nupic.core SHA

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = 'ed979c992bbf5d188af338a35a775185c9f8c46f'
+NUPIC_CORE_COMMITISH = '9a19cbdb41a60041ec7ced3a4bacedc75aed7938'


### PR DESCRIPTION
I'm not sure why the tooling server didn't do this automatically.