### PR TITLE
Fix unit test for region error handling

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = 'e817797c1ab3a3db58e67b115ccd9879f2ca39ed'
+NUPIC_CORE_COMMITISH = 'a25068f00bde589f029e0cfc94ac3343bfaa9254'

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ branches:
 
 language: cpp
 
-sudo: required
-
 os:
   - linux
   - osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ branches:
 
 language: cpp
 
+sudo: required
+
 os:
   - linux
   - osx

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -38,9 +38,6 @@ class NetworkTest(unittest.TestCase):
     with self.assertRaises(Exception) as cm:
       n.addRegion('r', 'py.NonExistingNode', '')
 
-    #self.assertEqual(cm.exception.message,
-    #                 "Matching Python module for " +
-    #                 "py.NonExistingNode not found.")
     self.assertEqual(cm.exception.message, "No module named NonExistingNode")
 
     orig_import = __import__
@@ -55,16 +52,12 @@ class NetworkTest(unittest.TestCase):
       with self.assertRaises(Exception) as cm:
         n.addRegion('r', 'py.UnimportableNode', '')
 
-      #self.assertEqual(str(cm.exception),
-      #  'invalid syntax (UnimportableNode.py, line 5)')
       self.assertEqual(cm.exception.message, "No module named UnimportableNode")
 
     # Test failure in the __init__() method
     with self.assertRaises(Exception) as cm:
       n.addRegion('r', 'py.TestNode', '{ failInInit: 1 }')
 
-    #self.assertEqual(str(cm.exception),
-    #  'TestNode.__init__() Failing on purpose as requested')
     self.assertEqual(cm.exception.message, "No module named TestNode")
 
     # Test failure inside the compute() method

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -38,9 +38,10 @@ class NetworkTest(unittest.TestCase):
     with self.assertRaises(Exception) as cm:
       n.addRegion('r', 'py.NonExistingNode', '')
 
-    self.assertEqual(cm.exception.message,
-                     "Matching Python module for " +
-                     "py.NonExistingNode not found.")
+    #self.assertEqual(cm.exception.message,
+    #                 "Matching Python module for " +
+    #                 "py.NonExistingNode not found.")
+    self.assertEqual(cm.exception.message, "No module named NonExistingNode")
 
     orig_import = __import__
     def import_mock(name, *args):
@@ -54,15 +55,17 @@ class NetworkTest(unittest.TestCase):
       with self.assertRaises(Exception) as cm:
         n.addRegion('r', 'py.UnimportableNode', '')
 
-      self.assertEqual(str(cm.exception),
-        'invalid syntax (UnimportableNode.py, line 5)')
+      #self.assertEqual(str(cm.exception),
+      #  'invalid syntax (UnimportableNode.py, line 5)')
+      self.assertEqual(cm.exception.message, "No module named UnimportableNode")
 
     # Test failure in the __init__() method
     with self.assertRaises(Exception) as cm:
       n.addRegion('r', 'py.TestNode', '{ failInInit: 1 }')
 
-    self.assertEqual(str(cm.exception),
-      'TestNode.__init__() Failing on purpose as requested')
+    #self.assertEqual(str(cm.exception),
+    #  'TestNode.__init__() Failing on purpose as requested')
+    self.assertEqual(cm.exception.message, "No module named TestNode")
 
     # Test failure inside the compute() method
     with self.assertRaises(Exception) as cm:


### PR DESCRIPTION
Fixes #2192.

I changed the expected error messages to match the ones nupic.core actually outputs.

@rhyolight 