### PR TITLE
Modified TPRegion to output the indices needed for the Union Pooler

### DIFF
--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -517,7 +517,8 @@ class TPRegion(PyRegion):
       size = activeLearnCells.shape[0] * activeLearnCells.shape[1]
       outputs['lrnActiveStateT'][:] = activeLearnCells.reshape(size)
 
-    if self.unionMode:
+    unionMode = getattr(self, "unionMode", False)
+    if unionMode:
       # Reshape so we are dealing with 1D arrays
       activeState = self._tfdr.getActiveState().reshape(-1).astype('float32')
       predictedState = self._tfdr.getPredictedState().reshape(-1).astype('float32')

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -211,7 +211,7 @@ def _getAdditionalSpecs(temporalImp, kwargs={}):
       constraints='bool'),
 
     computePredictedActiveCellIndices=dict(
-      description='1 if an union input is computed',
+      description='1 if indices are needed',
       accessMode='Create',
       dataType='UInt32',
       count=1,

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -518,13 +518,14 @@ class TPRegion(PyRegion):
       outputs['lrnActiveStateT'][:] = activeLearnCells.reshape(size)
 
     if self.unionMode:
-      activeState = self._tfdr.getActiveState()
-      predictedState = self._tfdr.getPredictedState()
+      # Reshape so we are dealing with 1D arrays
+      activeState = self._tfdr.getActiveState().reshape(-1).astype('float32')
+      predictedState = self._tfdr.getPredictedState().reshape(-1).astype('float32')
       activeIndices = set(numpy.where(activeState != 0)[0])
       predictedIndices= set(numpy.where(predictedState != 0)[0])
       predictedActiveIndices = activeIndices & predictedIndices
-      outputs["activeCellsIndices"] = numpy.array(list(activeIndices), dtype=bool)
-      outputs["predictedActiveCellsIndices"] = numpy.array(list(predictedActiveIndices), dtype=bool)
+      outputs["activeCellsIndices"] = numpy.array(list(activeIndices), dtype=int)
+      outputs["predictedActiveCellsIndices"] = numpy.array(list(predictedActiveIndices), dtype=int)
 
 
   #############################################################################

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -210,7 +210,7 @@ def _getAdditionalSpecs(temporalImp, kwargs={}):
       count=1,
       constraints='bool'),
 
-    unionMode=dict(
+    computePredictedActiveCellIndices=dict(
       description='1 if an union input is computed',
       accessMode='Create',
       dataType='UInt32',
@@ -305,7 +305,7 @@ class TPRegion(PyRegion):
                cellsSavePath='',
                temporalImp=gDefaultTemporalImp,
                anomalyMode=False,
-               unionMode=False,
+               computePredictedActiveCellIndices=False,
 
                **kwargs):
 
@@ -322,7 +322,7 @@ class TPRegion(PyRegion):
     self.learningMode   = True      # Start out with learning enabled
     self.inferenceMode  = False
     self.anomalyMode    = anomalyMode
-    self.unionMode = unionMode
+    self.computePredictedActiveCellIndices = computePredictedActiveCellIndices
     self.topDownMode    = False
     self.columnCount    = columnCount
     self.inputWidth     = inputWidth
@@ -517,8 +517,8 @@ class TPRegion(PyRegion):
       size = activeLearnCells.shape[0] * activeLearnCells.shape[1]
       outputs['lrnActiveStateT'][:] = activeLearnCells.reshape(size)
 
-    unionMode = getattr(self, "unionMode", False)
-    if unionMode:
+    computePredictedActiveCellIndices = getattr(self, "computePredictedActiveCellIndices", False)
+    if computePredictedActiveCellIndices:
       # Reshape so we are dealing with 1D arrays
       activeState = self._tfdr.getActiveState().reshape(-1).astype('float32')
       predictedState = self._tfdr.getPredictedState().reshape(-1).astype('float32')

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -526,6 +526,7 @@ class TPRegion(PyRegion):
       predictedActiveIndices = numpy.intersect1d(activeIndices, predictedIndices)
       outputs["activeCells"].fill(0)
       outputs["activeCells"][activeIndices] = 1
+      outputs["predictedActiveCells"].fill(0)
       outputs["predictedActiveCells"][predictedActiveIndices] = 1
 
 

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -517,8 +517,7 @@ class TPRegion(PyRegion):
       size = activeLearnCells.shape[0] * activeLearnCells.shape[1]
       outputs['lrnActiveStateT'][:] = activeLearnCells.reshape(size)
 
-    computePredictedActiveCellIndices = getattr(self, "computePredictedActiveCellIndices", False)
-    if computePredictedActiveCellIndices:
+    if self.computePredictedActiveCellIndices:
       # Reshape so we are dealing with 1D arrays
       activeState = self._tfdr.getActiveState().reshape(-1).astype('float32')
       predictedState = self._tfdr.getPredictedState().reshape(-1).astype('float32')
@@ -776,6 +775,9 @@ class TPRegion(PyRegion):
 
     if not hasattr(self, 'storeDenseOutput'):
       self.storeDenseOutput = False
+
+    if not hasattr(self, 'computePredictedActiveCellIndices'):
+      self.computePredictedActiveCellIndices = False
 
     self.__dict__.update(state)
     self._loaded = True

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -211,7 +211,7 @@ def _getAdditionalSpecs(temporalImp, kwargs={}):
       constraints='bool'),
 
     computePredictedActiveCellIndices=dict(
-      description='1 if indices are needed',
+      description='1 if active and predicted active indices should be computed',
       accessMode='Create',
       dataType='UInt32',
       count=1,
@@ -521,12 +521,12 @@ class TPRegion(PyRegion):
       # Reshape so we are dealing with 1D arrays
       activeState = self._tfdr.getActiveState().reshape(-1).astype('float32')
       predictedState = self._tfdr.getPredictedState().reshape(-1).astype('float32')
-      activeIndices = set(numpy.where(activeState != 0)[0])
-      predictedIndices= set(numpy.where(predictedState != 0)[0])
-      predictedActiveIndices = activeIndices & predictedIndices
+      activeIndices = numpy.where(activeState != 0)[0]
+      predictedIndices= numpy.where(predictedState != 0)[0]
+      predictedActiveIndices = numpy.intersect1d(activeIndices, predictedIndices)
       outputs["activeCells"].fill(0)
-      outputs["activeCells"][list(activeIndices)] = 1
-      outputs["predictedActiveCells"][list(predictedActiveIndices)] = 1
+      outputs["activeCells"][activeIndices] = 1
+      outputs["predictedActiveCells"][predictedActiveIndices] = 1
 
 
   #############################################################################

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -862,9 +862,9 @@ class TPRegion(PyRegion):
     elif name == 'lrnActiveStateT':
       return self.outputWidth
     elif name == "activeCellsIndices":
-      return 1
+      return self.outputWidth
     elif name == "predictedActiveCellsIndices":
-      return 1
+      return self.outputWidth
     else:
       raise Exception("Invalid output name specified")
 

--- a/nupic/regions/TPRegion.py
+++ b/nupic/regions/TPRegion.py
@@ -524,8 +524,9 @@ class TPRegion(PyRegion):
       activeIndices = set(numpy.where(activeState != 0)[0])
       predictedIndices= set(numpy.where(predictedState != 0)[0])
       predictedActiveIndices = activeIndices & predictedIndices
-      outputs["activeCellsIndices"] = numpy.array(list(activeIndices), dtype=int)
-      outputs["predictedActiveCellsIndices"] = numpy.array(list(predictedActiveIndices), dtype=int)
+      outputs["activeCells"].fill(0)
+      outputs["activeCells"][list(activeIndices)] = 1
+      outputs["predictedActiveCells"][list(predictedActiveIndices)] = 1
 
 
   #############################################################################
@@ -586,15 +587,15 @@ class TPRegion(PyRegion):
           regionLevel=True,
           isDefaultOutput=False),
 
-        activeCellsIndices=dict(
-          description="The indices of the cells that are active",
+        activeCells=dict(
+          description="The cells that are active",
           dataType='Real32',
           count=0,
           regionLevel=True,
           isDefaultOutput=False),
 
-        predictedActiveCellsIndices=dict(
-          description="The indices of the cells that are active and predicted",
+        predictedActiveCells=dict(
+          description="The cells that are active and predicted",
           dataType='Real32',
           count=0,
           regionLevel=True,
@@ -864,9 +865,9 @@ class TPRegion(PyRegion):
       return self.columnCount
     elif name == 'lrnActiveStateT':
       return self.outputWidth
-    elif name == "activeCellsIndices":
+    elif name == "activeCells":
       return self.outputWidth
-    elif name == "predictedActiveCellsIndices":
+    elif name == "predictedActiveCells":
       return self.outputWidth
     else:
       raise Exception("Invalid output name specified")


### PR DESCRIPTION
The Union Pooler needs to know the active indices from the output of the temporal memory and which ones were predicted and active.  Originally, TPRegion only outputted the active bits SDR.  Now, it outputs the indices of the active bits and the indices of the active bits that were predicted.

For numenta/nupic.research#69
Fixes #2081

@ryan @scottpurdy 