### PR TITLE
Fix MANIFEST.in capnp include.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,4 +12,4 @@ recursive-include external/darwin64 swig *.a
 recursive-include external/linux64 swig *.a
 
 recursive-include nupic/datafiles *.csv *.txt
-recursive-include *.capnp
+recursive-include nupic *.capnp


### PR DESCRIPTION
Required for capnp files to be included in eggs.

fixes #2259 

@rhyolight please review
@jcasner @unixorn  fyi