### PR TITLE
Fixes bug in mmGetCellActivityPlot

### DIFF
--- a/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py
+++ b/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py
@@ -420,8 +420,9 @@ class TemporalMemoryMonitorMixin(MonitorMixinBase):
 
     # If the trace contains ConnectionsCell, convert them to int
     cellTrace = self._mmTraces[activityType].data
-    for i in xrange(len(cellTrace)):
-      cellTrace[i] = self.getCellIndices(cellTrace[i])
+    for i in xrange(len(cellTrace))
+      if not isinstance(cellTrace[i], int):
+        cellTrace[i] = self.getCellIndices(cellTrace[i])
 
     return self.mmGetCellTracePlot(cellTrace, self.numberOfCells(),
                                    activityType, title, showReset, resetShading)

--- a/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py
+++ b/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py
@@ -421,7 +421,7 @@ class TemporalMemoryMonitorMixin(MonitorMixinBase):
     # If the trace contains ConnectionsCell, convert them to int
     cellTrace = self._mmTraces[activityType].data
     for i in xrange(len(cellTrace)):
-        cellTrace[i] = self.getCellIndices(cellTrace[i])
+      cellTrace[i] = self.getCellIndices(cellTrace[i])
 
     return self.mmGetCellTracePlot(cellTrace, self.numberOfCells(),
                                    activityType, title, showReset, resetShading)

--- a/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py
+++ b/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py
@@ -420,8 +420,7 @@ class TemporalMemoryMonitorMixin(MonitorMixinBase):
 
     # If the trace contains ConnectionsCell, convert them to int
     cellTrace = self._mmTraces[activityType].data
-    for i in xrange(len(cellTrace))
-      if not isinstance(cellTrace[i], int):
+    for i in xrange(len(cellTrace)):
         cellTrace[i] = self.getCellIndices(cellTrace[i])
 
     return self.mmGetCellTracePlot(cellTrace, self.numberOfCells(),

--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -846,4 +846,7 @@ class TemporalMemory(object):
 
   @staticmethod
   def getCellIndex(cell):
-    return cell.idx
+    if not isinstance(cell, int):
+      return cell.idx
+    else:
+      return cell


### PR DESCRIPTION
@chetan51 Please take a look when you get a chance

This PR is meant to fix a bug in Line 421-424 of temporal_memory_monitor_mixin.py This piece of code covert traces that contain ConnectionsCell to int. However, the traces could also contain int  in many cases, and this conversion caused an error ('int' object has no attribute 'idx'). 

I tried to fix this by add an additional logic in the getCellIndices function in temporal_memory.py

