### PR TITLE
Removed stripNeverLearned from SP.compute and updated nupic.core

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = '140a176ef1f53bb5014e60cec5a26ecc0498d23e'
+NUPIC_CORE_COMMITISH = '917f48c0de7c47359c92487db7c4967020140a45'

--- a/nupic/regions/SPRegion.py
+++ b/nupic/regions/SPRegion.py
@@ -590,12 +590,13 @@ class SPRegion(PyRegion):
     inputVector = numpy.array(rfInput[0]).astype('uint32')
     outputVector = numpy.zeros(self._sfdr.getNumColumns()).astype('uint32')
 
-    # Switch to using a random SP if learning mode is off and the SP hasn't
-    # learned anything yet.
+    # Don't strip unlearned columns if learning is off and the SP hasn't
+    # learned anything yet. This acts as a random SP.
     if (not self.learningMode) and (self._sfdr.getIterationLearnNum() == 0):
-      self._sfdr.compute(inputVector, self.learningMode, outputVector, False)
+      self._sfdr.compute(inputVector, self.learningMode, outputVector)
     else:
       self._sfdr.compute(inputVector, self.learningMode, outputVector)
+      self._sfdr.stripUnlearnedColumns(outputVector)
 
     self._spatialPoolerOutput[:] = outputVector[:]
 

--- a/nupic/research/spatial_pooler.py
+++ b/nupic/research/spatial_pooler.py
@@ -724,9 +724,9 @@ class SpatialPooler(object):
     since you would end up with no active columns.
 
     @param activeArray: An array whose size is equal to the number of columns.
-        Each column in this array will be checked to see if it has been active
-        before. If a column is active but it hasn't been learned, it will be
-        disabled.
+        Any columns marked as active with an activeDutyCycle of 0 have
+        never been activated before and therefore are not active due to
+        learning. Any of these (unlearned) columns will be disabled (set to 0).
     """
     neverLearned = numpy.where(self._activeDutyCycles == 0)[0]
     activeArray[neverLearned] = 0

--- a/nupic/research/spatial_pooler.py
+++ b/nupic/research/spatial_pooler.py
@@ -655,7 +655,7 @@ class SpatialPooler(object):
     connectedCounts[:] = self._connectedCounts[:]
 
 
-  def compute(self, inputVector, learn, activeArray, stripNeverLearned=True):
+  def compute(self, inputVector, learn, activeArray):
     """
     This is the primary public method of the SpatialPooler class. This
     function takes a input vector and outputs the indices of the active columns.
@@ -678,13 +678,6 @@ class SpatialPooler(object):
     @param activeArray: An array whose size is equal to the number of columns.
         Before the function returns this array will be populated with 1's at
         the indices of the active columns, and 0's everywhere else.
-    @param stripNeverLearned: If True and learn=False, then columns that
-        have never learned will be stripped out of the active columns. This
-        should be set to False when using a random SP with learning disabled.
-        NOTE: This parameter should be set explicitly as the default will
-        likely be changed to False in the near future and if you want to retain
-        the current behavior you should additionally pass the resulting
-        activeArray to the stripUnlearnedColumns method manually.
     """
     if not isinstance(inputVector, numpy.ndarray):
       raise TypeError("Input vector must be a numpy array, not %s" %
@@ -717,25 +710,26 @@ class SpatialPooler(object):
       if self._isUpdateRound():
         self._updateInhibitionRadius()
         self._updateMinDutyCycles()
-    elif stripNeverLearned:
-      activeColumns = self.stripUnlearnedColumns(activeColumns)
 
     activeArray.fill(0)
     if activeColumns.size > 0:
       activeArray[activeColumns] = 1
 
 
-  def stripUnlearnedColumns(self, activeColumns):
+  def stripUnlearnedColumns(self, activeArray):
     """Removes the set of columns who have never been active from the set of
     active columns selected in the inhibition round. Such columns cannot
     represent learned pattern and are therefore meaningless if only inference
     is required. This should not be done when using a random, unlearned SP
     since you would end up with no active columns.
 
-    @param activeColumns: An array containing the indices of the active columns
+    @param activeArray: An array whose size is equal to the number of columns.
+        Each column in this array will be checked to see if it has been active
+        before. If a column is active but it hasn't been learned, it will be
+        disabled.
     """
     neverLearned = numpy.where(self._activeDutyCycles == 0)[0]
-    return numpy.array(list(set(activeColumns) - set(neverLearned)))
+    activeArray[neverLearned] = 0
 
 
   def _updateMinDutyCycles(self):

--- a/tests/unit/nupic/research/spatial_pooler_compute_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_compute_test.py
@@ -60,12 +60,6 @@ class SpatialPoolerComputeTest(unittest.TestCase):
     y = numpy.zeros(columnDimensions, dtype = uintType)
     dutyCycles = numpy.zeros(columnDimensions, dtype = uintType)
 
-    # With learning off and no prior training we should get no winners
-    for v in inputMatrix:
-      y.fill(0)
-      sp.compute(v, False, y)
-      self.assertEqual(0,y.sum())
-
     # With learning on we should get the requested number of winners
     for v in inputMatrix:
       y.fill(0)

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -213,26 +213,30 @@ class SpatialPoolerTest(unittest.TestCase):
     sp = self._sp
 
     sp._activeDutyCycles = numpy.array([0.5, 0.1, 0, 0.2, 0.4, 0])
-    activeColumns = numpy.array([0, 1, 2, 4])
-    stripped = sp.stripUnlearnedColumns(activeColumns)
+    activeArray = numpy.array([1, 1, 1, 0, 1, 0])
+    sp.stripUnlearnedColumns(activeArray)
+    stripped = numpy.where(activeArray == 1)[0]
     trueStripped = [0, 1, 4]
     self.assertListEqual(trueStripped, list(stripped))
 
     sp._activeDutyCycles = numpy.array([0.9, 0, 0, 0, 0.4, 0.3])
-    activeColumns = numpy.array(range(6))
-    stripped = sp.stripUnlearnedColumns(activeColumns)
+    activeArray = numpy.ones(6)
+    sp.stripUnlearnedColumns(activeArray)
+    stripped = numpy.where(activeArray == 1)[0]
     trueStripped = [0, 4, 5]
     self.assertListEqual(trueStripped, list(stripped))
 
     sp._activeDutyCycles = numpy.array([0, 0, 0, 0, 0, 0])
-    activeColumns = numpy.array(range(6))
-    stripped = sp.stripUnlearnedColumns(activeColumns)
+    activeArray = numpy.ones(6)
+    sp.stripUnlearnedColumns(activeArray)
+    stripped = numpy.where(activeArray == 1)[0]
     trueStripped = []
     self.assertListEqual(trueStripped, list(stripped))
 
     sp._activeDutyCycles = numpy.ones(6)
-    activeColumns = numpy.array(range(6))
-    stripped = sp.stripUnlearnedColumns(activeColumns)
+    activeArray = numpy.ones(6)
+    sp.stripUnlearnedColumns(activeArray)
+    stripped = numpy.where(activeArray == 1)[0]
     trueStripped = range(6)
     self.assertListEqual(trueStripped, list(stripped))
 


### PR DESCRIPTION
Fixes #2278

Removed stripNeverLearned from ```SP.compute``` and updated ```SP.stripUnlearnedColumns``` to be consistent with nupic.core implementation.

@scottpurdy Please review