### PR TITLE
Fix TP non "fixed-sized" mode

### DIFF
--- a/nupic/research/TP.py
+++ b/nupic/research/TP.py
@@ -85,8 +85,8 @@ class TP(ConsolePrinterMixin):
                maxLrnBacktrack=5,
                maxAge=100000,
                maxSeqLength=32,
-               maxSegmentsPerCell=-1,
-               maxSynapsesPerSegment=-1,
+               maxSegmentsPerCell=0,
+               maxSynapsesPerSegment=0,
                outputType='normal',
               ):
     """

--- a/nupic/research/TP.py
+++ b/nupic/research/TP.py
@@ -123,7 +123,8 @@ class TP(ConsolePrinterMixin):
                   is used to turn on "fixed size CLA" mode. When in effect,
                   globalDecay is not applicable and must be set to 0 and
                   maxAge must be set to 0. When this is used (> 0),
-                  maxSynapsesPerSegment must also be > 0.
+                  maxSynapsesPerSegment must also be > 0. For not fixed-sized HTM
+                  use 0.
 
     @param maxSynapsesPerSegment The maximum number of synapses allowed in a segment.
                   This is used to turn on "fixed size CLA" mode. When in effect,
@@ -158,7 +159,8 @@ class TP(ConsolePrinterMixin):
     assert pamLength > 0, "This implementation must have pamLength > 0"
 
     # Fixed size CLA mode?
-    if maxSegmentsPerCell != -1 or maxSynapsesPerSegment != -1:
+    if (maxSegmentsPerCell != 0 or maxSynapsesPerSegment != 0):
+      print maxSegmentsPerCell, maxSynapsesPerSegment
       assert (maxSegmentsPerCell > 0 and maxSynapsesPerSegment > 0)
       assert (globalDecay == 0.0)
       assert (maxAge == 0)
@@ -2837,7 +2839,7 @@ class TP(ConsolePrinterMixin):
     @returns cell index
     """
     # Not fixed size CLA, just choose a cell randomly
-    if self.maxSegmentsPerCell < 0:
+    if self.maxSegmentsPerCell <= 0:
       if self.cellsPerColumn > 1:
         # Don't ever choose the start cell (cell # 0) in each column
         i = self._random.getUInt32(self.cellsPerColumn-1) + 1

--- a/nupic/research/TP.py
+++ b/nupic/research/TP.py
@@ -120,17 +120,16 @@ class TP(ConsolePrinterMixin):
                   limit how much the TP tries to learn.
 
     @param maxSegmentsPerCell The maximum number of segments allowed on a cell. This
-                  is used to turn on "fixed size CLA" mode. When in effect,
-                  globalDecay is not applicable and must be set to 0 and
-                  maxAge must be set to 0. When this is used (> 0),
-                  maxSynapsesPerSegment must also be > 0. For not fixed-sized HTM
-                  use 0.
+                  is used to turn on "fixed size CLA" mode (value > 0). 
+                  When in effect, globalDecay, maxAge params are ignored (=0).
+                  Non zero value implies also maxSynapsesPerSegment > 0.
+                  For non fixed-sized HTM, which grows synapses & segments, use 0.
 
     @param maxSynapsesPerSegment The maximum number of synapses allowed in a segment.
-                  This is used to turn on "fixed size CLA" mode. When in effect,
-                  globalDecay is not applicable and must be set to 0 and maxAge
-                  must be set to 0. When this is used (> 0), maxSegmentsPerCell
-                  must also be > 0.
+                  This is used to turn on "fixed size CLA" mode (value > 0). 
+                  When in effect, globalDecay, maxAge params are ignored (=0).
+                  Non zero value implies also maxSegmentsPerCell > 0.
+                  For non fixed-sized HTM, which grows synapses & segments, use 0.
 
     @param outputType Can be one of the following: 'normal', 'activeState',
                   'activeState1CellPerCol'.
@@ -157,17 +156,6 @@ class TP(ConsolePrinterMixin):
 
     # Check arguments
     assert pamLength > 0, "This implementation must have pamLength > 0"
-
-    # Fixed size CLA mode?
-    if (maxSegmentsPerCell != 0 or maxSynapsesPerSegment != 0):
-      print maxSegmentsPerCell, maxSynapsesPerSegment
-      assert (maxSegmentsPerCell > 0 and maxSynapsesPerSegment > 0)
-      assert (globalDecay == 0.0)
-      assert (maxAge == 0)
-
-      assert maxSynapsesPerSegment >= newSynapseCount, ("TP requires that "
-          "maxSynapsesPerSegment >= newSynapseCount. (Currently %s >= %s)" % (
-          maxSynapsesPerSegment, newSynapseCount))
 
     # Seed random number generator
     if seed >= 0:
@@ -228,6 +216,15 @@ class TP(ConsolePrinterMixin):
     assert outputType in ('normal', 'activeState', 'activeState1CellPerCol')
     ## @todo document
     self.outputType = outputType
+
+    # will set some dependent parameters in fixed-sized CLA
+    if self.isFixedSized():
+      self.globalDecay = 0.0
+      self.maxAge = 0
+      if maxSynapsesPerSegment < newSynapseCount: 
+        raise ValueError("TP requires maxSynapsesPerSegment >= newSynapseCount."
+            " (Currently %s >= %s)" % (maxSynapsesPerSegment, newSynapseCount))
+
 
     # No point having larger expiration if we are not doing pooling
     if not doPooling:
@@ -2839,7 +2836,7 @@ class TP(ConsolePrinterMixin):
     @returns cell index
     """
     # Not fixed size CLA, just choose a cell randomly
-    if self.maxSegmentsPerCell <= 0:
+    if not self.isFixedSized():
       if self.cellsPerColumn > 1:
         # Don't ever choose the start cell (cell # 0) in each column
         i = self._random.getUInt32(self.cellsPerColumn-1) + 1
@@ -3127,10 +3124,8 @@ class TP(ConsolePrinterMixin):
       # syn is now a tuple (src col, src cell)
       synsToAdd = [syn for syn in activeSynapses if type(syn) != int]
       # If we have fixed resources, get rid of some old syns if necessary
-      if self.maxSynapsesPerSegment > 0 \
-          and len(synsToAdd) + len(segment.syns) > self.maxSynapsesPerSegment:
-        numToFree = (len(segment.syns) + len(synsToAdd) -
-                     self.maxSynapsesPerSegment)
+      numToFree = len(segment.syns) + len(synsToAdd) - self.maxSynapsesPerSegment
+      if self.isFixedSized() and numToFree > 0:
         segment.freeNSynapses(numToFree, inactiveSynIndices, self.verbosity)
       for newSyn in synsToAdd:
         segment.addSynapse(newSyn[0], newSyn[1], self.initialPerm)
@@ -3240,6 +3235,25 @@ class TP(ConsolePrinterMixin):
 
     return (nSegments, nSynapses, nActiveSegs, nActiveSynapses,
             distSegSizes, distNSegsPerCell, distPermValues, distAges)
+
+
+  def isFixedSized(self):
+    """
+    check if model should be fixed-sized CLA, or not.
+
+    @return True if fixed-sized CLA, implied by either of maxSegmentsPerCell
+    or maxSynapsesPerSegment params set to > 0. 
+    """
+    # fixed-sized CLA
+    if self.maxSegmentsPerCell > 0 and self.maxSynapsesPerSegment > 0:
+      return True
+    # growing CLA
+    elif self.maxSegmentsPerCell == 0 and self.maxSynapsesPerSegment == 0:
+      return False
+    else:
+      raise ValueError("Either set both 'maxSegmentsPerCell' and "
+                       "'maxSynapsesPerSegment' (>0) for fixed-sized CLA,"
+                       "or set them both 0 for growing CLA")
 
 
 

--- a/nupic/research/TP10X2.py
+++ b/nupic/research/TP10X2.py
@@ -98,8 +98,8 @@ class TP10X2(TP):
                maxSeqLength = 32,
 
                # Fixed size mode params
-               maxSegmentsPerCell = -1,
-               maxSynapsesPerSegment = -1,
+               maxSegmentsPerCell = 0,
+               maxSynapsesPerSegment = 0,
 
                # Output control
                outputType = 'normal',

--- a/nupic/research/TP10X2.py
+++ b/nupic/research/TP10X2.py
@@ -181,7 +181,7 @@ class TP10X2(TP):
       self.cells4.setMaxLrnBacktrack(self.maxLrnBacktrack)
       self.cells4.setMaxSeqLength(self.maxSeqLength)
       self.cells4.setMaxSegmentsPerCell(self.maxSegmentsPerCell)
-      self.cells4.setMaxSynapsesPerCell(self.maxSynapsesPerSegment)
+      self.cells4.setMaxSynapsesPerSegment(self.maxSynapsesPerSegment)
 
     # Reset internal C++ pointers to states
     self._setStatePointers()
@@ -239,7 +239,7 @@ class TP10X2(TP):
       self.cells4.setMaxLrnBacktrack(self.maxLrnBacktrack)
       self.cells4.setMaxSeqLength(self.maxSeqLength)
       self.cells4.setMaxSegmentsPerCell(self.maxSegmentsPerCell)
-      self.cells4.setMaxSynapsesPerCell(self.maxSynapsesPerSegment)
+      self.cells4.setMaxSynapsesPerSegment(self.maxSynapsesPerSegment)
 
       self._setStatePointers()
 

--- a/tests/unit/nupic/research/tp_test.py
+++ b/tests/unit/nupic/research/tp_test.py
@@ -184,6 +184,31 @@ class TPTest(unittest.TestCase):
     self.assertTPsEqual(tp2, tp4)
 
 
+  def testFixedSizedCLA(self):
+    "test TP init and run in fixed-sized mode"
+    # fixed sized CLA
+    fixed = TP(maxSegmentsPerCell = 128, maxSynapsesPerSegment = 28,
+            globalDecay = 0.1, maxAge = 1000)
+    self.assertTrue(fixed.isFixedSized())
+    # these params should be zeroed
+    self.assertEqual(fixed.globalDecay, 0.0)
+    self.assertEqual(fixed.maxAge, 0)
+    # this combination is not acceptable
+    self.assertRaises(ValueError,  TP, maxSegmentsPerCell = 0, maxSynapsesPerSegment = 28)
+
+    # non fixed-sized CLA
+    grow = TP(maxSegmentsPerCell = 0, maxSynapsesPerSegment = 0,
+            globalDecay = 0.1, maxAge = 1000)
+    self.assertFalse(grow.isFixedSized())
+    # these params should be set
+    self.assertAlmostEqual(grow.globalDecay, 0.1) #FIXME assertEqual(grow.globalDecay, 0.1) -> False: 0.1 != 0.1 can this be a problem elsewhere? bcs globalDecay is np.float32()
+    self.assertEqual(grow.maxAge, 1000)
+    # this combination is not acceptable
+    self.assertRaises(ValueError,  TP, maxSegmentsPerCell = 0, maxSynapsesPerSegment = 28)
+
+    
+    
+# Helper methods:
   def assertTPsEqual(self, tp1, tp2):
     """Asserts that two TP instances are the same.
 


### PR DESCRIPTION
Fixes: #1360  

DON'T merge until both Py, C++, TP10X2 are resolved!
c++ sibling: https://github.com/numenta/nupic.core/pull/484

- [ ] revert `.nupic_modules` pointing to my local SHA
- [x] python non fixed-sized TP works
- [ ] fix binding from c++ in TP10X2