### PR TITLE
Removed stripUnlearnedColumns-from-SPRegion

### DIFF
--- a/nupic/regions/SPRegion.py
+++ b/nupic/regions/SPRegion.py
@@ -590,13 +590,7 @@ class SPRegion(PyRegion):
     inputVector = numpy.array(rfInput[0]).astype('uint32')
     outputVector = numpy.zeros(self._sfdr.getNumColumns()).astype('uint32')
 
-    # Don't strip unlearned columns if learning is off and the SP hasn't
-    # learned anything yet. This acts as a random SP.
-    if (not self.learningMode) and (self._sfdr.getIterationLearnNum() == 0):
-      self._sfdr.compute(inputVector, self.learningMode, outputVector)
-    else:
-      self._sfdr.compute(inputVector, self.learningMode, outputVector)
-      self._sfdr.stripUnlearnedColumns(outputVector)
+    self._sfdr.compute(inputVector, self.learningMode, outputVector)
 
     self._spatialPoolerOutput[:] = outputVector[:]
 


### PR DESCRIPTION
Fixes #2279

Removes `stripUnlearnedColumns` from `_doBottomUpCompute` in SP. 

`stripUnlearnedColumns` should only be used in special cases where it is specifically intended to be run on the output of the Spatial Pooler. It should not be running by default (in the current implementation of NuPIC it will only run by default in the case that learning is disabled AND the model has previously learned. This change removes it from ever running by default)