### PR TITLE
Sets zip_safe=False option to get pycapnp imports working

### DIFF
--- a/nupic/encoders/multi.py
+++ b/nupic/encoders/multi.py
@@ -19,6 +19,8 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+import capnp
+
 from nupic.encoders.base import Encoder
 from nupic.encoders.scalar import ScalarEncoder
 from nupic.encoders.adaptivescalar import AdaptiveScalarEncoder
@@ -38,7 +40,6 @@ from nupic.encoders.random_distributed_scalar import RandomDistributedScalarEnco
 
 from nupic.encoders.base import Encoder
 from nupic.encoders.scalar_capnp import ScalarEncoderProto
-# multiencoder must be imported last because it imports * from this module!
 
 
 

--- a/nupic/encoders/random_distributed_scalar.py
+++ b/nupic/encoders/random_distributed_scalar.py
@@ -24,6 +24,7 @@ import numbers
 import pprint
 import sys
 
+import capnp
 import numpy
 
 from nupic.data import SENTINEL_VALUE_FOR_MISSING_DATA

--- a/setup.py
+++ b/setup.py
@@ -673,6 +673,7 @@ try:
       "nupic.bindings.proto": ["*.capnp"],
     },
     include_package_data=True,
+    zip_safe=False,
     ext_modules=extensions,
     description="Numenta Platform for Intelligent Computing",
     author="Numenta",

--- a/tests/unit/nupic/algorithms/cla_classifier_test.py
+++ b/tests/unit/nupic/algorithms/cla_classifier_test.py
@@ -28,9 +28,9 @@ import cPickle as pickle
 import types
 import unittest2 as unittest
 
+import capnp
 import numpy
 import tempfile
-import capnp
 
 from nupic.algorithms.CLAClassifier import CLAClassifier
 from nupic.bindings.proto import ClaClassifier_capnp

--- a/tests/unit/nupic/encoders/category_test.py
+++ b/tests/unit/nupic/encoders/category_test.py
@@ -23,12 +23,13 @@
 """Unit tests for category encoder"""
 
 import tempfile
+import unittest
 
-from nupic.encoders.base import defaultDtype
-from nupic.data import SENTINEL_VALUE_FOR_MISSING_DATA
+import capnp
 import numpy
-import unittest2 as unittest
 
+from nupic.data import SENTINEL_VALUE_FOR_MISSING_DATA
+from nupic.encoders.base import defaultDtype
 from nupic.encoders.category import CategoryEncoder, UNKNOWN
 from nupic.encoders.category_capnp import CategoryEncoderProto
 

--- a/tests/unit/nupic/encoders/coordinate_test.py
+++ b/tests/unit/nupic/encoders/coordinate_test.py
@@ -20,6 +20,7 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+import capnp  # For import hook
 import numpy as np
 import tempfile
 import unittest


### PR DESCRIPTION
fixes #2259 

Since the capnp schema require the ability to load files with relative paths, the zip-import functionality won't work. The `setup()` function has a `zip_safe` option that let's us specify that the archive must be unpacked when installed.

@jcasner fyi
@rhyolight please review