### PR TITLE
Fix: TemporalMemory.getCellIndex doesn't work correctly when running through OPF

### DIFF
--- a/nupic/research/TP_shim.py
+++ b/nupic/research/TP_shim.py
@@ -82,9 +82,9 @@ class TPShim(TemporalMemory):
     numberOfCells = self.numberOfCells()
 
     activeState = numpy.zeros(numberOfCells)
-    activeState[list(self.activeCells)] = 1
+    activeState[self.getCellIndices(self.activeCells)] = 1
     self.infActiveState["t"] = activeState
 
     output = numpy.zeros(numberOfCells)
-    output[list(self.predictiveCells | self.activeCells)] = 1
+    output[self.getCellIndices(self.predictiveCells | self.activeCells)] = 1
     return output

--- a/nupic/research/fast_temporal_memory.py
+++ b/nupic/research/fast_temporal_memory.py
@@ -150,6 +150,11 @@ class FastTemporalMemory(TemporalMemory):
     return activeSegments, predictiveCells, matchingSegments, matchingCells
 
 
+  @staticmethod
+  def getCellIndex(cell):
+    return cell.idx
+
+
   # ==============================
   # Helper functions
   # ==============================

--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -593,7 +593,7 @@ class TemporalMemory(object):
     @param permanenceIncrement  (float)  Amount to increment active synapses
     @param permanenceDecrement  (float)  Amount to decrement inactive synapses
     """
-    for synapse in set(connections.synapsesForSegment(segment)):
+    for synapse in connections.synapsesForSegment(segment):
       synapseData = connections.dataForSynapse(synapse)
       permanence = synapseData.permanence
 

--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -593,7 +593,7 @@ class TemporalMemory(object):
     @param permanenceIncrement  (float)  Amount to increment active synapses
     @param permanenceDecrement  (float)  Amount to decrement inactive synapses
     """
-    for synapse in connections.synapsesForSegment(segment):
+    for synapse in set(connections.synapsesForSegment(segment)):
       synapseData = connections.dataForSynapse(synapse)
       permanence = synapseData.permanence
 
@@ -846,4 +846,4 @@ class TemporalMemory(object):
 
   @staticmethod
   def getCellIndex(cell):
-    return cell.idx
+    return cell


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/2314.