### PR TITLE
Remove unused synapses in Temporal Memory

### DIFF
--- a/nupic/research/connections.py
+++ b/nupic/research/connections.py
@@ -223,6 +223,9 @@ class Connections(object):
     # Update indexes
     self._synapsesForPresynapticCell[newData.presynapticCell][synapse] = newData
 
+    if permanence == 0:
+      self.destroySynapse(synapse)
+
 
   def numSegments(self):
     """

--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -593,7 +593,7 @@ class TemporalMemory(object):
     @param permanenceIncrement  (float)  Amount to increment active synapses
     @param permanenceDecrement  (float)  Amount to decrement inactive synapses
     """
-    for synapse in connections.synapsesForSegment(segment):
+    for synapse in set(connections.synapsesForSegment(segment)):
       synapseData = connections.dataForSynapse(synapse)
       permanence = synapseData.permanence
 

--- a/tests/unit/nupic/research/temporal_memory_test.py
+++ b/tests/unit/nupic/research/temporal_memory_test.py
@@ -491,15 +491,9 @@ class TemporalMemoryTest(unittest.TestCase):
     tm.adaptSegment(0, set(), connections,
                     tm.permanenceIncrement,
                     tm.permanenceDecrement)
-    synapseData = connections.dataForSynapse(0)
-    self.assertAlmostEqual(synapseData.permanence, 0.0)
 
-    # Now permanence should be at min
-    tm.adaptSegment(0, set(), connections,
-                    tm.permanenceIncrement,
-                    tm.permanenceDecrement)
-    synapseData = connections.dataForSynapse(0)
-    self.assertAlmostEqual(synapseData.permanence, 0.0)
+    synapses = connections.synapsesForSegment(0)
+    self.assertFalse(0 in synapses)
 
 
   def testPickCellsToLearnOn(self):


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/2316.

I confirmed that this improves performance when running through a large hotgym dataset.