### PR TITLE
Remove unused synapses in Temporal Memory

### DIFF
--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -597,6 +597,8 @@ class TemporalMemory(object):
     @param permanenceIncrement  (float)  Amount to increment active synapses
     @param permanenceDecrement  (float)  Amount to decrement inactive synapses
     """
+    # Need to copy synapses for segment set below because it will be modified
+    # during iteration by `destroySynapse`
     for synapse in set(connections.synapsesForSegment(segment)):
       synapseData = connections.dataForSynapse(synapse)
       permanence = synapseData.permanence

--- a/nupic/research/temporal_memory.py
+++ b/nupic/research/temporal_memory.py
@@ -31,6 +31,10 @@ from nupic.research.connections import Connections
 
 
 
+EPSILON = 0.0000001
+
+
+
 class TemporalMemory(object):
   """
   Class implementing the Temporal Memory algorithm.
@@ -593,7 +597,7 @@ class TemporalMemory(object):
     @param permanenceIncrement  (float)  Amount to increment active synapses
     @param permanenceDecrement  (float)  Amount to decrement inactive synapses
     """
-    for synapse in connections.synapsesForSegment(segment):
+    for synapse in set(connections.synapsesForSegment(segment)):
       synapseData = connections.dataForSynapse(synapse)
       permanence = synapseData.permanence
 
@@ -605,7 +609,10 @@ class TemporalMemory(object):
       # Keep permanence within min/max bounds
       permanence = max(0.0, min(1.0, permanence))
 
-      connections.updateSynapsePermanence(synapse, permanence)
+      if (abs(permanence) < EPSILON):
+        connections.destroySynapse(synapse)
+      else:
+        connections.updateSynapsePermanence(synapse, permanence)
 
 
   def pickCellsToLearnOn(self, n, segment, winnerCells, connections):
@@ -779,22 +786,20 @@ class TemporalMemory(object):
 
     @param other (TemporalMemory) TemporalMemory instance to compare to
     """
-    epsilon = 0.0000001
-
     if self.columnDimensions != other.columnDimensions: return False
     if self.cellsPerColumn != other.cellsPerColumn: return False
     if self.activationThreshold != other.activationThreshold: return False
-    if abs(self.initialPermanence - other.initialPermanence) > epsilon:
+    if abs(self.initialPermanence - other.initialPermanence) > EPSILON:
       return False
-    if abs(self.connectedPermanence - other.connectedPermanence) > epsilon:
+    if abs(self.connectedPermanence - other.connectedPermanence) > EPSILON:
       return False
     if self.minThreshold != other.minThreshold: return False
     if self.maxNewSynapseCount != other.maxNewSynapseCount: return False
-    if abs(self.permanenceIncrement - other.permanenceIncrement) > epsilon:
+    if abs(self.permanenceIncrement - other.permanenceIncrement) > EPSILON:
       return False
-    if abs(self.permanenceDecrement - other.permanenceDecrement) > epsilon:
+    if abs(self.permanenceDecrement - other.permanenceDecrement) > EPSILON:
       return False
-    if abs(self.predictedSegmentDecrement - other.predictedSegmentDecrement) > epsilon:
+    if abs(self.predictedSegmentDecrement - other.predictedSegmentDecrement) > EPSILON:
       return False
 
     if self.connections != other.connections: return False

--- a/tests/unit/nupic/research/temporal_memory_test.py
+++ b/tests/unit/nupic/research/temporal_memory_test.py
@@ -491,15 +491,9 @@ class TemporalMemoryTest(unittest.TestCase):
     tm.adaptSegment(0, set(), connections,
                     tm.permanenceIncrement,
                     tm.permanenceDecrement)
-    synapseData = connections.dataForSynapse(0)
-    self.assertAlmostEqual(synapseData.permanence, 0.0)
 
-    # Now permanence should be at min
-    tm.adaptSegment(0, set(), connections,
-                    tm.permanenceIncrement,
-                    tm.permanenceDecrement)
-    synapseData = connections.dataForSynapse(0)
-    self.assertAlmostEqual(synapseData.permanence, 0.0)
+    synapses = connections.synapsesForSegment(0)
+    self.assertFalse(0 in synapses)
 
 
   def testPickCellsToLearnOn(self):


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/2316.

I verified that it improves accuracy and speed for the Python `TemporalMemory`, improves accuracy and has no impact on speed for the `FastTemporalMemory` (tested by running through a large hotgym dataset).