### PR TITLE
Makes nupic a namespace package that other projects can extend.

### DIFF
--- a/nupic/__init__.py
+++ b/nupic/__init__.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -19,4 +19,4 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-__version__ = "0.2.7.dev0"
+__import__('pkg_resources').declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -637,6 +637,7 @@ try:
     name="nupic",
     version=getVersion(),
     install_requires=findRequirements(),
+    namespace_packages=["nupic"],
     packages=find_packages(),
     package_data={
       "nupic.support": ["nupic-default.xml",


### PR DESCRIPTION
fixes #2353

@rhyolight - Does removing the version like this introduce issues? The documentation for namespace packages prohibits anything else from being in the `__init__.py` for a namespace package and [this documentation on version](https://www.python.org/dev/peps/pep-0396/) backs this up.

@oxtopus - please review