### PR TITLE
allows us to specify a nupic core branch

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,4 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
 NUPIC_CORE_COMMITISH = 'eb0b420973f54536debd9d13334a88cdc05bf5c1'
+NUPIC_CORE_BRANCH = 'master'


### PR DESCRIPTION
This addresses:
File "/opt/numenta/products/infrastructure/infrastructure/utilities/nupic/build_commands.py", line 142, in getNuPICCoreDetails
    branch = core["NUPIC_CORE_BRANCH"] if not nupicCoreBranch else nupicCoreBranch
KeyError: 'NUPIC_CORE_BRANCH'

It is trying to get "NUPIC_CORE_BRANCH" from .nupic_modules

@jcasner 