### PR TITLE
Convert nupic.bindings egg to wheel for deployment

### DIFF
--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -49,7 +49,7 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     # Build all NuPIC and all required python packages into dist/wheels as .whl
     # files.
     echo "pip wheel --wheel-dir=dist/wheels ."
-    pip wheel --wheel-dir=dist/wheels .
+    pip wheel --wheel-dir=dist/wheels . --find-links=extensions/core/build/release
 
     # The dist/wheels folder is expected to be deployed to S3.
 

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,8 @@ def findRequirements(nupicCoreReleaseDir):
     filename = os.path.splitext(egg)[0]
     currentDir = os.getcwd()
     os.chdir(nupicCoreReleaseDir)
-    call(["wheel", "convert", egg])
+    print "python -m wheel convert {}".format(egg)
+    call(["python", "-m", "wheel", "convert", egg])
     os.chdir(currentDir)
     dependencies.append(filename + ".whl")
 

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ import tarfile
 import urllib2
 
 from setuptools import setup, find_packages, Extension
+from subprocess import call
 
 """
 This file builds and installs the NuPIC binaries.
@@ -212,7 +213,12 @@ def findRequirements(nupicCoreReleaseDir):
     dependencies.append(wheel)
   eggFiles = glob.glob(os.path.join(nupicCoreReleaseDir, "*.egg"))
   for egg in eggFiles:
-    dependencies.append(egg)
+    filename = os.path.splitext(egg)[0]
+    currentDir = os.getcwd()
+    os.chdir(nupicCoreReleaseDir)
+    call(["wheel", "convert", egg])
+    os.chdir(currentDir)
+    dependencies.append(filename + ".whl")
 
   requirements = parse_file(requirementsPath)
 


### PR DESCRIPTION
To deploy nupic, we need the wheel for nupic.bindings and the path to it.  This converts it to a wheel and gets the path.

Fixes #2413

@rhyolight @scottpurdy 