### PR TITLE
Split out the Record-dict encoding logic from RecordStreamIface into a separate class.

### DIFF
--- a/nupic/data/fieldmeta.py
+++ b/nupic/data/fieldmeta.py
@@ -28,6 +28,9 @@ from collections import namedtuple
 
 
 
+# :param str name: field name
+# :param str type: one of the values from FieldMetaType
+# :param str special: one of the values from FieldMetaSpecial
 FieldMetaInfoBase = namedtuple('FieldMetaInfoBase', ['name', 'type', 'special'])
 
 class FieldMetaInfo(FieldMetaInfoBase):
@@ -56,6 +59,7 @@ class FieldMetaInfo(FieldMetaInfoBase):
 
   3.
   """
+
 
   @staticmethod
   def createFromFileFieldElement(fieldInfoTuple):
@@ -92,6 +96,7 @@ class FieldMetaType(object):
   list = 'list'
 
 
+
 class FieldMetaSpecial(object):
   """
   Public values for the "special" field attribute
@@ -101,3 +106,6 @@ class FieldMetaSpecial(object):
   sequence = 'S'
   timestamp = 'T'
   category = 'C'
+  learning = 'L'
+
+  ALL = (none, reset, sequence, timestamp, category, learning)

--- a/nupic/data/record_stream.py
+++ b/nupic/data/record_stream.py
@@ -25,6 +25,209 @@ from abc import ABCMeta, abstractmethod
 import datetime
 
 
+from nupic.data.fieldmeta import FieldMetaSpecial
+
+
+
+def _getFieldIndexBySpecial(fields, special):
+  """ Return index of the field matching the field meta special value.
+
+  :param fields: sequence of nupic.data.fieldmeta.FieldMetaInfo objects
+    representing the fields of a stream
+  :param special: one of the special field attribute values from
+    nupic.data.fieldmeta.FieldMetaSpecial
+
+  :returns: first zero-based index of the field tagged with the target field
+    meta special attribute; None if no such field
+  """
+  for i, field in enumerate(fields):
+    if field.special == special:
+      return i
+  return None
+
+
+
+
+class RecordDictEncoder(object):
+  """Encodes metric data input rows as dicts for consumption by OPF models. See
+  the `RecordDictEncoder.encode` method for more details.
+  """
+
+
+  def __init__(self, fields, aggregationPeriod=None):
+    """
+    :param fields: sequence of nupic.data.fieldmeta.FieldMetaInfo objects
+      corresponding to fields in input rows.
+    :param dict aggregationPeriod: aggregation period of the record stream as a
+      dict containing 'months' and 'seconds'. The months is always an integer
+      and seconds is a floating point. Only one is allowed to be non-zero at a
+      time. If there is no aggregation associated with the stream, pass None.
+      Typically, a raw file or hbase stream will NOT have any aggregation info,
+      but subclasses of RecordStreamIface, like StreamReader, will and will
+      provide the aggregation period. This is used by the encode method to
+      assign a record number to a record given its timestamp and the aggregation
+      interval.
+    """
+    self._fields = fields
+    self._aggregationPeriod = aggregationPeriod
+
+    self._sequenceId = -1
+
+    self._fieldNames = tuple(f.name for f in fields)
+
+    self._categoryFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.category)
+
+    self._resetFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.reset)
+
+    self._sequenceFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.sequence)
+
+    self._timestampFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.timestamp)
+
+    self._learningFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.learning)
+
+
+  @property
+  def fields(self):
+    """
+    :returns: sequence of nupic.data.fieldmeta.FieldMetaInfo objects
+      corresponding to fields in input rows.
+    """
+    return self._fields
+
+
+  def rewind(self):
+    """Put us back at the beginning of the file again """
+    self._sequenceId = -1
+
+
+  def encode(self, inputRow):
+    """Encodes the given input row as a dict, with the
+    keys being the field names. This also adds in some meta fields:
+      '_category': The value from the category field (if any)
+      '_reset': True if the reset field was True (if any)
+      '_sequenceId': the value from the sequenceId field (if any)
+
+    :param inputRow: sequence of values corresponding to a single input metric
+      data row
+    :rtype: dict
+    """
+
+    if inputRow is None:
+      return None
+
+    if not inputRow:
+      return dict()
+
+    # Create the return dict
+    result = dict(zip(self._fieldNames, inputRow))
+
+    # Add in the special fields
+    if self._categoryFieldIndex is not None:
+      # category value can be an int or a list
+      if isinstance(inputRow[self._categoryFieldIndex], int):
+        result['_category'] = [inputRow[self._categoryFieldIndex]]
+      else:
+        result['_category'] = (inputRow[self._categoryFieldIndex]
+                               if inputRow[self._categoryFieldIndex]
+                               else [None])
+    else:
+      result['_category'] = [None]
+
+    if self._resetFieldIndex is not None:
+      result['_reset'] = int(bool(inputRow[self._resetFieldIndex]))
+    else:
+      result['_reset'] = 0
+
+    if self._learningFieldIndex is not None:
+      result['_learning'] = int(bool(inputRow[self._learningFieldIndex]))
+
+    result['_timestampRecordIdx'] = None
+    if self._timestampFieldIndex is not None:
+      result['_timestamp'] = inputRow[self._timestampFieldIndex]
+      # Compute the record index based on timestamp
+      result['_timestampRecordIdx'] = self._computeTimestampRecordIdx(
+        inputRow[self._timestampFieldIndex])
+    else:
+      result['_timestamp'] = None
+
+    # -----------------------------------------------------------------------
+    # Figure out the sequence ID
+    hasReset = self._resetFieldIndex is not None
+    hasSequenceId = self._sequenceFieldIndex is not None
+    if hasReset and not hasSequenceId:
+      # Reset only
+      if result['_reset']:
+        try:
+          self._sequenceId += 1
+        except:
+          import pdb; pdb.set_trace()
+      sequenceId = self._sequenceId
+
+    elif not hasReset and hasSequenceId:
+      sequenceId = inputRow[self._sequenceFieldIndex]
+      result['_reset'] = int(sequenceId != self._sequenceId)
+      self._sequenceId = sequenceId
+
+    elif hasReset and hasSequenceId:
+      sequenceId = inputRow[self._sequenceFieldIndex]
+
+    else:
+      sequenceId = 0
+
+    if sequenceId is not None:
+      result['_sequenceId'] = hash(sequenceId)
+    else:
+      result['_sequenceId'] = None
+
+    return result
+
+
+  def _computeTimestampRecordIdx(self, recordTS):
+    """ Give the timestamp of a record (a datetime object), compute the record's
+    timestamp index - this is the timestamp divided by the aggregation period.
+
+
+    Parameters:
+    ------------------------------------------------------------------------
+    recordTS:  datetime instance
+    retval:    record timestamp index, or None if no aggregation period
+    """
+
+    if self._aggregationPeriod is None:
+      return None
+
+    # Base record index on number of elapsed months if aggregation is in
+    #  months
+    if self._aggregationPeriod['months'] > 0:
+      assert self._aggregationPeriod['seconds'] == 0
+      result = int(
+        (recordTS.year * 12 + (recordTS.month-1)) /
+        self._aggregationPeriod['months'])
+
+    # Base record index on elapsed seconds
+    elif self._aggregationPeriod['seconds'] > 0:
+      delta = recordTS - datetime.datetime(year=1, month=1, day=1)
+      deltaSecs = delta.days * 24 * 60 * 60   \
+                + delta.seconds               \
+                + delta.microseconds / 1000000.0
+      result = int(deltaSecs / self._aggregationPeriod['seconds'])
+
+    else:
+      result = None
+
+    return result
+
+
 
 class RecordStreamIface(object):
   """This is the interface for the record input/output storage classes."""
@@ -32,8 +235,25 @@ class RecordStreamIface(object):
   __metaclass__ = ABCMeta
 
 
-  def __init__(self):
-    self._sequenceId = -1
+  def __init__(self, fields, aggregationPeriod=None):
+    """
+    :param fields: sequence of nupic.data.fieldmeta.FieldMetaInfo objects
+      corresponding to fields in input rows.
+    :param dict aggregationPeriod: aggregation period of the record stream as a
+      dict containing 'months' and 'seconds'. The months is always an integer
+      and seconds is a floating point. Only one is allowed to be non-zero at a
+      time. If there is no aggregation associated with the stream, pass None.
+      Typically, a raw file or hbase stream will NOT have any aggregation info,
+      but subclasses of RecordStreamIface, like StreamReader, will and will
+      provide the aggregation period. This is used by the encode method to
+      assign a record number to a record given its timestamp and the aggregation
+      interval.
+    """
+    self._fieldNames = tuple(f.name for f in fields)
+
+    self._recordDictEncoder = RecordDictEncoder(
+      fields=fields,
+      aggregationPeriod=aggregationPeriod)
 
 
   @abstractmethod
@@ -43,18 +263,18 @@ class RecordStreamIface(object):
 
 
   def rewind(self):
-    """Put us back at the beginning of the file again) """
-    self._sequenceId = -1
+    """Put us back at the beginning of the file again """
+    self._recordDictEncoder.rewind()
 
 
   @abstractmethod
   def getNextRecord(self, useCache=True):
     """Returns next available data record from the storage. If useCache is
     False, then don't read ahead and don't cache any records.
-    
+
     Raises nupic.support.exceptions.StreamDisappearedError if stream
     disappears (e.g., gets garbage-collected).
-    
+
     retval: a data row (a list or tuple) if available; None, if no more records
              in the table (End of Stream - EOS); empty sequence (list or tuple)
              when timing out while waiting for the next record.
@@ -67,140 +287,10 @@ class RecordStreamIface(object):
       '_category': The value from the category field (if any)
       '_reset': True if the reset field was True (if any)
       '_sequenceId': the value from the sequenceId field (if any)
-    
+
     """
-    
-    values = self.getNextRecord()
-    if values is None:
-      return None
-    
-    if not values:
-      return dict()
-    
-    # Create the return dict
-    result = dict(zip(self.getFieldNames(), values))
-    
-    # Add in the special fields
-    catIdx = self.getCategoryFieldIdx()
-    resetIdx = self.getResetFieldIdx()
-    sequenceIdx = self.getSequenceIdFieldIdx()
-    timeIdx = self.getTimestampFieldIdx()
-    learningIdx = self.getLearningFieldIdx()
+    return self._recordDictEncoder.encode(self.getNextRecord())
 
-    if catIdx is not None:
-      # category value can be an int or a list
-      if isinstance(values[catIdx], int):
-        result['_category'] = [values[catIdx]]
-      else:
-        result['_category'] = values[catIdx] if values[catIdx] else [None]
-    else:
-      result['_category'] = [None]
-
-    if resetIdx is not None:
-      result['_reset'] = int(bool(values[resetIdx]))
-    else:
-      result['_reset'] = 0
-      
-    if learningIdx is not None:
-      result['_learning'] = int(bool(values[learningIdx]))
-      
-    result['_timestampRecordIdx'] = None
-    if timeIdx is not None:
-      result['_timestamp'] = values[timeIdx]      
-      # Compute the record index based on timestamp
-      result['_timestampRecordIdx'] = self._computeTimestampRecordIdx(
-                                                        values[timeIdx])
-    else:
-      result['_timestamp'] = None
-    
-    # -----------------------------------------------------------------------
-    # Figure out the sequence ID
-    hasReset = resetIdx is not None
-    hasSequenceId = sequenceIdx is not None
-    if hasReset and not hasSequenceId:
-      # Reset only
-      if result['_reset']:
-        try:
-          self._sequenceId += 1
-        except:
-          import pdb; pdb.set_trace() 
-      sequenceId = self._sequenceId
-      
-    elif not hasReset and hasSequenceId:
-      sequenceId = values[sequenceIdx]
-      result['_reset'] = int(sequenceId != self._sequenceId)
-      self._sequenceId = sequenceId
-      
-    elif hasReset and hasSequenceId:
-      sequenceId = values[sequenceIdx]
-      
-    else:
-      sequenceId = 0
-      
-    if sequenceId is not None:
-      result['_sequenceId'] = hash(sequenceId)
-    else:
-      result['_sequenceId'] = None
-    
-    return result
-
-
-  def _computeTimestampRecordIdx(self, recordTS):
-    """ Give the timestamp of a record (a datetime object), compute the record's
-    timestamp index - this is the timestamp divided by the aggregation period. 
-    
-    
-    Parameters:
-    ------------------------------------------------------------------------
-    recordTS:  datetime instance
-    retval:    record timestamp index, or None if no aggregation period 
-    """
-    
-    aggPeriod = self.getAggregationMonthsAndSeconds()
-    if aggPeriod is None:
-      return None
-    
-    # Base record index on number of elapsed months if aggregation is in 
-    #  months
-    if aggPeriod['months'] > 0:
-      assert aggPeriod['seconds'] == 0
-      result = \
-        int((recordTS.year * 12 + (recordTS.month-1)) / aggPeriod['months'])
-        
-    # Base record index on elapsed seconds
-    elif aggPeriod['seconds'] > 0:
-      delta = recordTS - datetime.datetime(year=1, month=1, day=1)
-      deltaSecs = delta.days * 24 * 60 * 60   \
-                + delta.seconds               \
-                + delta.microseconds / 1000000.0
-      result = int(deltaSecs / aggPeriod['seconds'])
-    
-    else:
-      result = None
-      
-    return result
-
-
-  def getAggregationMonthsAndSeconds(self):
-    """ Returns the aggregation period of the record stream as a dict 
-    containing 'months' and 'seconds'. The months is always an integer and
-    seconds is a floating point. Only one is allowed to be non-zero.  
-    
-    If there is no aggregation associated with the stream, returns None. 
-    
-    Typically, a raw file or hbase stream will NOT have any aggregation info,
-    but subclasses of RecordStreamIFace, like StreamReader, will and will
-    return the aggregation period from this call. This call is used by the
-    getNextRecordDict() method to assign a record number to a record given
-    its timestamp and the aggregation interval
-    
-    Parameters:
-    ------------------------------------------------------------------------
-    retval: aggregationPeriod (as a dict) or None  
-              'months': number of months in aggregation period
-              'seconds': number of seconds in aggregation period (as a float)
-    """
-    return None
 
 
   @abstractmethod
@@ -214,7 +304,8 @@ class RecordStreamIface(object):
 
   @abstractmethod
   def getNextRecordIdx(self):
-    """Returns the index of the record that will be read next from getNextRecord()
+    """Returns the index of the record that will be read next from
+    getNextRecord()
     """
 
 
@@ -329,57 +420,55 @@ class RecordStreamIface(object):
     """Marks the stream completed (True or False)."""
 
 
-  @abstractmethod
   def getFieldNames(self):
-    """Returns an array of field names associated with the data."""
-
-
-  @abstractmethod
-  def getFields(self):
-    """Returns a sequence of nupic.data.fieldmeta.FieldMetaInfo
-    name/type/special tuples for each field in the stream. Might be None, if
-    that information is provided externally (thru stream def, for example).
     """
+    :returns: a sequence of field names corresponding to the stream's data
+      columns.
+    """
+    return self._fieldNames
+
+
+  def getFields(self):
+    """
+    :returns: a sequence of nupic.data.fieldmeta.FieldMetaInfo objects
+    corresponding to the stream's data columns.
+    """
+    return self._recordDictEncoder.fields
 
 
   def getResetFieldIdx(self):
     """ Return index of the 'reset' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'R' or field[2] == 'r':
-        return i
-    return None
+    return _getFieldIndexBySpecial(
+      fields=self.getFields(),
+      special=FieldMetaSpecial.reset)
 
 
   def getTimestampFieldIdx(self):
     """ Return index of the 'timestamp' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'T' or field[2] == 't':
-        return i
-    return None
+    return _getFieldIndexBySpecial(
+      fields=self.getFields(),
+      special=FieldMetaSpecial.timestamp)
 
 
   def getSequenceIdFieldIdx(self):
     """ Return index of the 'sequenceId' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'S' or field[2] == 's':
-        return i
-    return None
+    return _getFieldIndexBySpecial(
+      fields=self.getFields(),
+      special=FieldMetaSpecial.sequence)
 
 
   def getCategoryFieldIdx(self):
     """ Return index of the 'category' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'C' or field[2] == 'c':
-        return i
-    return None
+    return _getFieldIndexBySpecial(
+      fields=self.getFields(),
+      special=FieldMetaSpecial.category)
 
 
   def getLearningFieldIdx(self):
     """ Return index of the 'learning' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'L' or field[2] == 'l':
-        return i
-    return None
+    return _getFieldIndexBySpecial(
+      fields=self.getFields(),
+      special=FieldMetaSpecial.learning)
 
 
   @abstractmethod

--- a/tests/unit/nupic/data/file_record_stream_test.py
+++ b/tests/unit/nupic/data/file_record_stream_test.py
@@ -71,7 +71,7 @@ class TestFileRecordStream(unittest.TestCase):
         ['rec_2', datetime(day=2, month=3, year=2010), 8, 7.5, 0, 'seq-1', 11],
         ['rec_3', datetime(day=3, month=3, year=2010), 12, 8.5, 0, 'seq-1', 12])
 
-      self.assertEqual(fields, s.getFields())
+      self.assertSequenceEqual(fields, s.getFields())
       self.assertEqual(0, s.getNextRecordIdx())
 
       print 'Writing records ...'
@@ -96,7 +96,7 @@ class TestFileRecordStream(unittest.TestCase):
 
       # Read the standard file
       self.assertEqual(6, s.getDataRowCount())
-      self.assertEqual(fieldNames, s.getFieldNames())
+      self.assertSequenceEqual(fieldNames, s.getFieldNames())
 
       # Note! this is the number of records read so far
       self.assertEqual(0, s.getNextRecordIdx())
@@ -154,7 +154,7 @@ class TestFileRecordStream(unittest.TestCase):
         ['rec_3', datetime(day=3, month=3, year=2010), 2, 8.5, 0, 'seq-1',
          [6, 7, 8,]])
 
-      self.assertEqual(fields, s.getFields())
+      self.assertSequenceEqual(fields, s.getFields())
       self.assertEqual(0, s.getNextRecordIdx())
 
       print 'Writing records ...'
@@ -182,7 +182,7 @@ class TestFileRecordStream(unittest.TestCase):
 
       # Read the standard file
       self.assertEqual(6, s.getDataRowCount())
-      self.assertEqual(fieldNames, s.getFieldNames())
+      self.assertSequenceEqual(fieldNames, s.getFieldNames())
 
       # Note! this is the number of records read so far
       self.assertEqual(0, s.getNextRecordIdx())
@@ -305,7 +305,7 @@ class TestFileRecordStream(unittest.TestCase):
     s = FileRecordStream(streamID=filename, write=False)
 
     fieldsRead = s.getFields()
-    self.assertEqual(fields, fieldsRead)
+    self.assertSequenceEqual(fields, fieldsRead)
 
     recordsRead = []
     while True:


### PR DESCRIPTION
NOTE: this is a preview PR; it doesn't include tests, yet, and no issue has been filed.

Split out the Record-dict encoding logic from `RecordStreamIface` into a separate class so that it may be used by clamodel apps that don't need the rest of `RecordStreamIface`'s abstract-base-class baggage.

Pass fieldmetainfo list to RecordStreamIface instead of querying the derived class every time these static values are needed.
Remove unnecessary implementations of several methods from derived StreamReader class, since an equivalent implementation already exists in `RecordStreamIface`.

Replace use of hard-coded special attribute values with constants from `FieldMetaSpecial`.

Resolved most pylint issues in affected modules.

Fixed getFields validation tests: assert comparison of sequences instead of expecting the values wrapped in a list type explicitly.