### PR TITLE
Input Model Record Encoder

### DIFF
--- a/nupic/data/fieldmeta.py
+++ b/nupic/data/fieldmeta.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-15, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -30,6 +30,8 @@ from collections import namedtuple
 
 FieldMetaInfoBase = namedtuple('FieldMetaInfoBase', ['name', 'type', 'special'])
 
+
+
 class FieldMetaInfo(FieldMetaInfoBase):
   """
   This class acts as a container of meta-data for a single field (column) of
@@ -57,6 +59,27 @@ class FieldMetaInfo(FieldMetaInfoBase):
   3.
   """
 
+
+  def __init__(self,
+               name,
+               type,  # pylint: disable=W0622
+               special):
+    """
+    :param str name: field name
+    :param str type: one of the values from FieldMetaType
+    :param str special: one of the values from FieldMetaSpecial
+    :raises ValueError: if type or special arg values are invalid
+    """
+
+    if not FieldMetaType.isValid(type):
+      raise ValueError('Unexpected field type %r' % (type,))
+
+    if not FieldMetaSpecial.isValid(special):
+      raise ValueError('Unexpected field special attribute %r' % (special,))
+
+    super(FieldMetaInfo, self).__init__(name, type, special)
+
+
   @staticmethod
   def createFromFileFieldElement(fieldInfoTuple):
     """ Creates a FieldMetaInfo instance from an element of the File.fields list
@@ -76,7 +99,7 @@ class FieldMetaInfo(FieldMetaInfoBase):
     Returns:  A list of FieldMetaInfo elements corresponding to the given
               'fields' list.
     """
-    return map(lambda x: cls.createFromFileFieldElement(x), fields)
+    return [cls.createFromFileFieldElement(f) for f in fields]
 
 
 
@@ -90,6 +113,22 @@ class FieldMetaType(object):
   float = 'float'
   boolean = 'bool'
   list = 'list'
+  sdr = 'sdr'  # sparse distributed representation
+
+  _ALL = (string, datetime, integer, float, boolean, list, sdr)
+
+
+  @classmethod
+  def isValid(cls, fieldDataType):
+    """Check a candidate value whether it's one of the valid field data types
+
+    :param str fieldDataType: candidate field data type
+    :returns: True if the candidate value is a legitimate field data type value;
+      False if not
+    :rtype: bool
+    """
+    return fieldDataType in cls._ALL
+
 
 
 class FieldMetaSpecial(object):
@@ -101,3 +140,18 @@ class FieldMetaSpecial(object):
   sequence = 'S'
   timestamp = 'T'
   category = 'C'
+  learning = 'L'
+
+  _ALL = (none, reset, sequence, timestamp, category, learning,)
+
+
+  @classmethod
+  def isValid(cls, attr):
+    """Check a candidate value whether it's one of the valid attributes
+
+    :param str attr: candidate value
+    :returns: True if the candidate value is a legitimate "special" field
+      attribute; False if not
+    :rtype: bool
+    """
+    return attr in cls._ALL

--- a/nupic/data/record_stream.py
+++ b/nupic/data/record_stream.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-2015, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -25,6 +25,191 @@ from abc import ABCMeta, abstractmethod
 import datetime
 
 
+from nupic.data.fieldmeta import FieldMetaSpecial
+
+
+
+def _getFieldIndexBySpecial(fields, special):
+  """ Return index of the field matching the field meta special value.
+  :param fields: sequence of nupic.data.fieldmeta.FieldMetaInfo objects
+    representing the fields of a stream
+  :param special: one of the special field attribute values from
+    nupic.data.fieldmeta.FieldMetaSpecial
+  :returns: first zero-based index of the field tagged with the target field
+    meta special attribute; None if no such field
+  """
+  for i, field in enumerate(fields):
+    if field.special == special:
+      return i
+  return None
+
+
+
+class ModelRecordEncoder(object):
+  """Encodes metric data input rows  for consumption by OPF models. See
+  the `ModelRecordEncoder.encode` method for more details.
+  """
+
+
+  def __init__(self, fields, aggregationPeriod=None):
+    """
+    :param fields: non-empty sequence of nupic.data.fieldmeta.FieldMetaInfo
+      objects corresponding to fields in input rows.
+    :param dict aggregationPeriod: aggregation period of the record stream as a
+      dict containing 'months' and 'seconds'. The months is always an integer
+      and seconds is a floating point. Only one is allowed to be non-zero at a
+      time. If there is no aggregation associated with the stream, pass None.
+      Typically, a raw file or hbase stream will NOT have any aggregation info,
+      but subclasses of RecordStreamIface, like StreamReader, will and will
+      provide the aggregation period. This is used by the encode method to
+      assign a record number to a record given its timestamp and the aggregation
+      interval.
+    """
+    if not fields:
+      raise ValueError('fields arg must be non-empty, but got %r' % (fields,))
+
+    self._fields = fields
+    self._aggregationPeriod = aggregationPeriod
+
+    self._sequenceId = -1
+
+    self._fieldNames = tuple(f.name for f in fields)
+
+    self._categoryFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.category)
+
+    self._resetFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.reset)
+
+    self._sequenceFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.sequence)
+
+    self._timestampFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.timestamp)
+
+    self._learningFieldIndex = _getFieldIndexBySpecial(
+      fields,
+      FieldMetaSpecial.learning)
+
+
+  def rewind(self):
+    """Put us back at the beginning of the file again """
+    self._sequenceId = -1
+
+
+  def encode(self, inputRow):
+    """Encodes the given input row as a dict, with the
+    keys being the field names. This also adds in some meta fields:
+      '_category': The value from the category field (if any)
+      '_reset': True if the reset field was True (if any)
+      '_sequenceId': the value from the sequenceId field (if any)
+
+    :param inputRow: sequence of values corresponding to a single input metric
+      data row
+    :rtype: dict
+    """
+
+    # Create the return dict
+    result = dict(zip(self._fieldNames, inputRow))
+
+    # Add in the special fields
+    if self._categoryFieldIndex is not None:
+      # category value can be an int or a list
+      if isinstance(inputRow[self._categoryFieldIndex], int):
+        result['_category'] = [inputRow[self._categoryFieldIndex]]
+      else:
+        result['_category'] = (inputRow[self._categoryFieldIndex]
+                               if inputRow[self._categoryFieldIndex]
+                               else [None])
+    else:
+      result['_category'] = [None]
+
+    if self._resetFieldIndex is not None:
+      result['_reset'] = int(bool(inputRow[self._resetFieldIndex]))
+    else:
+      result['_reset'] = 0
+
+    if self._learningFieldIndex is not None:
+      result['_learning'] = int(bool(inputRow[self._learningFieldIndex]))
+
+    result['_timestampRecordIdx'] = None
+    if self._timestampFieldIndex is not None:
+      result['_timestamp'] = inputRow[self._timestampFieldIndex]
+      # Compute the record index based on timestamp
+      result['_timestampRecordIdx'] = self._computeTimestampRecordIdx(
+        inputRow[self._timestampFieldIndex])
+    else:
+      result['_timestamp'] = None
+
+    # -----------------------------------------------------------------------
+    # Figure out the sequence ID
+    hasReset = self._resetFieldIndex is not None
+    hasSequenceId = self._sequenceFieldIndex is not None
+    if hasReset and not hasSequenceId:
+      # Reset only
+      if result['_reset']:
+        self._sequenceId += 1
+      sequenceId = self._sequenceId
+
+    elif not hasReset and hasSequenceId:
+      sequenceId = inputRow[self._sequenceFieldIndex]
+      result['_reset'] = int(sequenceId != self._sequenceId)
+      self._sequenceId = sequenceId
+
+    elif hasReset and hasSequenceId:
+      sequenceId = inputRow[self._sequenceFieldIndex]
+
+    else:
+      sequenceId = 0
+
+    if sequenceId is not None:
+      result['_sequenceId'] = hash(sequenceId)
+    else:
+      result['_sequenceId'] = None
+
+    return result
+
+
+  def _computeTimestampRecordIdx(self, recordTS):
+    """ Give the timestamp of a record (a datetime object), compute the record's
+    timestamp index - this is the timestamp divided by the aggregation period.
+
+
+    Parameters:
+    ------------------------------------------------------------------------
+    recordTS:  datetime instance
+    retval:    record timestamp index, or None if no aggregation period
+    """
+
+    if self._aggregationPeriod is None:
+      return None
+
+    # Base record index on number of elapsed months if aggregation is in
+    #  months
+    if self._aggregationPeriod['months'] > 0:
+      assert self._aggregationPeriod['seconds'] == 0
+      result = int(
+        (recordTS.year * 12 + (recordTS.month-1)) /
+        self._aggregationPeriod['months'])
+
+    # Base record index on elapsed seconds
+    elif self._aggregationPeriod['seconds'] > 0:
+      delta = recordTS - datetime.datetime(year=1, month=1, day=1)
+      deltaSecs = delta.days * 24 * 60 * 60   \
+                + delta.seconds               \
+                + delta.microseconds / 1000000.0
+      result = int(deltaSecs / self._aggregationPeriod['seconds'])
+
+    else:
+      result = None
+
+    return result
+
+
 
 class RecordStreamIface(object):
   """This is the interface for the record input/output storage classes."""
@@ -33,7 +218,9 @@ class RecordStreamIface(object):
 
 
   def __init__(self):
-    self._sequenceId = -1
+    # Will be initialized on-demand in getNextRecordDict with a
+    # ModelRecordEncoder instance, once encoding metadata is available
+    self._modelRecordEncoder = None
 
 
   @abstractmethod
@@ -44,17 +231,18 @@ class RecordStreamIface(object):
 
   def rewind(self):
     """Put us back at the beginning of the file again) """
-    self._sequenceId = -1
+    if self._modelRecordEncoder is not None:
+      self._modelRecordEncoder.rewind()
 
 
   @abstractmethod
   def getNextRecord(self, useCache=True):
     """Returns next available data record from the storage. If useCache is
     False, then don't read ahead and don't cache any records.
-    
+
     Raises nupic.support.exceptions.StreamDisappearedError if stream
     disappears (e.g., gets garbage-collected).
-    
+
     retval: a data row (a list or tuple) if available; None, if no more records
              in the table (End of Stream - EOS); empty sequence (list or tuple)
              when timing out while waiting for the next record.
@@ -67,136 +255,41 @@ class RecordStreamIface(object):
       '_category': The value from the category field (if any)
       '_reset': True if the reset field was True (if any)
       '_sequenceId': the value from the sequenceId field (if any)
-    
+
     """
-    
+
     values = self.getNextRecord()
     if values is None:
       return None
-    
+
     if not values:
       return dict()
-    
-    # Create the return dict
-    result = dict(zip(self.getFieldNames(), values))
-    
-    # Add in the special fields
-    catIdx = self.getCategoryFieldIdx()
-    resetIdx = self.getResetFieldIdx()
-    sequenceIdx = self.getSequenceIdFieldIdx()
-    timeIdx = self.getTimestampFieldIdx()
-    learningIdx = self.getLearningFieldIdx()
 
-    if catIdx is not None:
-      # category value can be an int or a list
-      if isinstance(values[catIdx], int):
-        result['_category'] = [values[catIdx]]
-      else:
-        result['_category'] = values[catIdx] if values[catIdx] else [None]
-    else:
-      result['_category'] = [None]
+    if self._modelRecordEncoder is None:
+      self._modelRecordEncoder = ModelRecordEncoder(
+        fields=self.getFields(),
+        aggregationPeriod=self.getAggregationMonthsAndSeconds())
 
-    if resetIdx is not None:
-      result['_reset'] = int(bool(values[resetIdx]))
-    else:
-      result['_reset'] = 0
-      
-    if learningIdx is not None:
-      result['_learning'] = int(bool(values[learningIdx]))
-      
-    result['_timestampRecordIdx'] = None
-    if timeIdx is not None:
-      result['_timestamp'] = values[timeIdx]      
-      # Compute the record index based on timestamp
-      result['_timestampRecordIdx'] = self._computeTimestampRecordIdx(
-                                                        values[timeIdx])
-    else:
-      result['_timestamp'] = None
-    
-    # -----------------------------------------------------------------------
-    # Figure out the sequence ID
-    hasReset = resetIdx is not None
-    hasSequenceId = sequenceIdx is not None
-    if hasReset and not hasSequenceId:
-      # Reset only
-      if result['_reset']:
-        try:
-          self._sequenceId += 1
-        except:
-          import pdb; pdb.set_trace() 
-      sequenceId = self._sequenceId
-      
-    elif not hasReset and hasSequenceId:
-      sequenceId = values[sequenceIdx]
-      result['_reset'] = int(sequenceId != self._sequenceId)
-      self._sequenceId = sequenceId
-      
-    elif hasReset and hasSequenceId:
-      sequenceId = values[sequenceIdx]
-      
-    else:
-      sequenceId = 0
-      
-    if sequenceId is not None:
-      result['_sequenceId'] = hash(sequenceId)
-    else:
-      result['_sequenceId'] = None
-    
-    return result
+    return self._modelRecordEncoder.encode(values)
 
-
-  def _computeTimestampRecordIdx(self, recordTS):
-    """ Give the timestamp of a record (a datetime object), compute the record's
-    timestamp index - this is the timestamp divided by the aggregation period. 
-    
-    
-    Parameters:
-    ------------------------------------------------------------------------
-    recordTS:  datetime instance
-    retval:    record timestamp index, or None if no aggregation period 
-    """
-    
-    aggPeriod = self.getAggregationMonthsAndSeconds()
-    if aggPeriod is None:
-      return None
-    
-    # Base record index on number of elapsed months if aggregation is in 
-    #  months
-    if aggPeriod['months'] > 0:
-      assert aggPeriod['seconds'] == 0
-      result = \
-        int((recordTS.year * 12 + (recordTS.month-1)) / aggPeriod['months'])
-        
-    # Base record index on elapsed seconds
-    elif aggPeriod['seconds'] > 0:
-      delta = recordTS - datetime.datetime(year=1, month=1, day=1)
-      deltaSecs = delta.days * 24 * 60 * 60   \
-                + delta.seconds               \
-                + delta.microseconds / 1000000.0
-      result = int(deltaSecs / aggPeriod['seconds'])
-    
-    else:
-      result = None
-      
-    return result
 
 
   def getAggregationMonthsAndSeconds(self):
-    """ Returns the aggregation period of the record stream as a dict 
+    """ Returns the aggregation period of the record stream as a dict
     containing 'months' and 'seconds'. The months is always an integer and
-    seconds is a floating point. Only one is allowed to be non-zero.  
-    
-    If there is no aggregation associated with the stream, returns None. 
-    
+    seconds is a floating point. Only one is allowed to be non-zero.
+
+    If there is no aggregation associated with the stream, returns None.
+
     Typically, a raw file or hbase stream will NOT have any aggregation info,
     but subclasses of RecordStreamIFace, like StreamReader, will and will
     return the aggregation period from this call. This call is used by the
     getNextRecordDict() method to assign a record number to a record given
     its timestamp and the aggregation interval
-    
+
     Parameters:
     ------------------------------------------------------------------------
-    retval: aggregationPeriod (as a dict) or None  
+    retval: aggregationPeriod (as a dict) or None
               'months': number of months in aggregation period
               'seconds': number of seconds in aggregation period (as a float)
     """
@@ -214,7 +307,8 @@ class RecordStreamIface(object):
 
   @abstractmethod
   def getNextRecordIdx(self):
-    """Returns the index of the record that will be read next from getNextRecord()
+    """Returns the index of the record that will be read next from
+    getNextRecord()
     """
 
 
@@ -343,43 +437,29 @@ class RecordStreamIface(object):
 
 
   def getResetFieldIdx(self):
-    """ Return index of the 'reset' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'R' or field[2] == 'r':
-        return i
-    return None
+    """
+    :returns: index of the 'reset' field; None if no such field. """
+    return _getFieldIndexBySpecial(self.getFields(), FieldMetaSpecial.reset)
 
 
   def getTimestampFieldIdx(self):
     """ Return index of the 'timestamp' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'T' or field[2] == 't':
-        return i
-    return None
+    return _getFieldIndexBySpecial(self.getFields(), FieldMetaSpecial.timestamp)
 
 
   def getSequenceIdFieldIdx(self):
     """ Return index of the 'sequenceId' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'S' or field[2] == 's':
-        return i
-    return None
+    return _getFieldIndexBySpecial(self.getFields(), FieldMetaSpecial.sequence)
 
 
   def getCategoryFieldIdx(self):
     """ Return index of the 'category' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'C' or field[2] == 'c':
-        return i
-    return None
+    return _getFieldIndexBySpecial(self.getFields(), FieldMetaSpecial.category)
 
 
   def getLearningFieldIdx(self):
     """ Return index of the 'learning' field. """
-    for i, field in enumerate(self.getFields()):
-      if field[2] == 'L' or field[2] == 'l':
-        return i
-    return None
+    return _getFieldIndexBySpecial(self.getFields(), FieldMetaSpecial.learning)
 
 
   @abstractmethod

--- a/nupic/data/stream_reader.py
+++ b/nupic/data/stream_reader.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-15, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -24,20 +24,15 @@ import os
 import logging
 import tempfile
 
-from pkg_resources import resource_filename
+import pkg_resources
 
 from nupic.data.aggregator import Aggregator
-from nupic.data.fieldmeta import FieldMetaInfo
+from nupic.data.fieldmeta import FieldMetaInfo, FieldMetaType, FieldMetaSpecial
 from nupic.data.file_record_stream import FileRecordStream
 from nupic.data import jsonhelpers
 from nupic.data.record_stream import RecordStreamIface
 from nupic.frameworks.opf import jsonschema
 import nupic.support
-from nupic.support.configuration import Configuration
-
-
-TYPES = ['float', 'int', 'string', 'datetime', 'bool', 'address', 'list',
-         'FLOAT', 'INT', 'STRING', 'DATETIME', 'BOOL', 'ADDRESS', 'LIST']
 
 FILE_PREF = 'file://'
 
@@ -60,9 +55,9 @@ class StreamReader(RecordStreamIface):
   implements the raw reading of records from the record store (which could be a
   file, hbase table or something else).
 
-  In the future, we will support joining of two or more RecordStreamIFace's (which
-  is why the streamDef accepts a list of 'stream' elements), but for now only
-  1 source is supported.
+  In the future, we will support joining of two or more RecordStreamIface's (
+  which is why the streamDef accepts a list of 'stream' elements), but for now
+  only 1 source is supported.
 
   The class also implements aggregation of the (in the future) joined records
   from the sources.
@@ -142,7 +137,7 @@ class StreamReader(RecordStreamIface):
     loggerPrefix = 'com.numenta.nupic.data.StreamReader'
     self._logger = logging.getLogger(loggerPrefix)
     jsonhelpers.validate(streamDef,
-                         schemaPath=resource_filename(
+                         schemaPath=pkg_resources.resource_filename(
                              jsonschema.__name__, "stream_def.json"))
     assert len(streamDef['streams']) == 1, "Only 1 source stream is supported"
 
@@ -185,9 +180,9 @@ class StreamReader(RecordStreamIface):
     streamFieldTypes = sourceDict.get('types', None)
     self._logger.debug('Types from the def: %s', streamFieldTypes)
     # Validate that all types are valid
-    if streamFieldTypes != None:
+    if streamFieldTypes is not None:
       for dataType in streamFieldTypes:
-        assert(dataType in TYPES)
+        assert FieldMetaType.isValid(dataType)
 
     # Reset, sequence and time fields might be provided by streamdef json
     streamResetFieldName = streamDef.get('resetField', None)
@@ -201,15 +196,16 @@ class StreamReader(RecordStreamIface):
     # =======================================================================
     # Open up the underlying record store
     dataUrl = sourceDict.get('source', None)
-    assert(dataUrl is not None)
-    self._openStream(dataUrl, isBlocking, maxTimeout, bookmark, firstRecordIdx)
-    assert(self._recordStore is not None)
+    assert dataUrl is not None
+    self._recordStore = self._openStream(dataUrl, isBlocking, maxTimeout,
+                                         bookmark, firstRecordIdx)
+    assert self._recordStore is not None
 
 
     # =======================================================================
     # Prepare the data structures we need for returning just the fields
     #  the caller wants from each record
-    self._recordStoreFields = self._recordStore.getFields()
+    recordStoreFields = self._recordStore.getFields()
     self._recordStoreFieldNames = self._recordStore.getFieldNames()
 
     if not self._needFieldsFiltering:
@@ -225,8 +221,8 @@ class StreamReader(RecordStreamIface):
           "columns: %s" % (name, self._recordStoreFieldNames))
 
       fieldIdx = self._recordStoreFieldNames.index(name)
-      fieldType = self._recordStoreFields[fieldIdx][1]
-      fieldSpecial = self._recordStoreFields[fieldIdx][2]
+      fieldType = recordStoreFields[fieldIdx].type
+      fieldSpecial = recordStoreFields[fieldIdx].special
 
       # If the types or specials were defined in the stream definition,
       #   then override what was found in the record store
@@ -234,11 +230,12 @@ class StreamReader(RecordStreamIface):
         fieldType = streamFieldTypes[dstIdx]
 
       if streamResetFieldName is not None and streamResetFieldName == name:
-        fieldSpecial = 'R'
+        fieldSpecial = FieldMetaSpecial.reset
       if streamTimeFieldName is not None and streamTimeFieldName == name:
-        fieldSpecial = 'T'
-      if streamSequenceFieldName is not None and streamSequenceFieldName == name:
-        fieldSpecial = 'S'
+        fieldSpecial = FieldMetaSpecial.timestamp
+      if (streamSequenceFieldName is not None and
+          streamSequenceFieldName == name):
+        fieldSpecial = FieldMetaSpecial.sequence
 
       self._streamFields.append(FieldMetaInfo(name, fieldType, fieldSpecial))
 
@@ -248,7 +245,7 @@ class StreamReader(RecordStreamIface):
     #  returning them.
     self._aggregator = Aggregator(
             aggregationInfo=streamDef.get('aggregation', None),
-            inputFields=self._recordStoreFields,
+            inputFields=recordStoreFields,
             timeFieldName=streamDef.get('timeField', None),
             sequenceIdFieldName=streamDef.get('sequenceIdField', None),
             resetFieldName=streamDef.get('resetField', None))
@@ -279,20 +276,25 @@ class StreamReader(RecordStreamIface):
       self._writer = None
 
 
-  def _openStream(self, dataUrl, isBlocking, maxTimeout, bookmark,
+  @staticmethod
+  def _openStream(dataUrl,
+                  isBlocking,  # pylint: disable=W0613
+                  maxTimeout,  # pylint: disable=W0613
+                  bookmark,
                   firstRecordIdx):
-    """Open the underlying file stream.
-
+    """Open the underlying file stream
     This only supports 'file://' prefixed paths.
+
+    :returns: record stream instance
+    :rtype: FileRecordStream
     """
     filePath = dataUrl[len(FILE_PREF):]
     if not os.path.isabs(filePath):
       filePath = os.path.join(os.getcwd(), filePath)
-    self._recordStoreName = filePath 
-    self._recordStore = FileRecordStream(streamID=self._recordStoreName,
-                                         write=False,
-                                         bookmark=bookmark,
-                                         firstRecord=firstRecordIdx)
+    return FileRecordStream(streamID=filePath,
+                            write=False,
+                            bookmark=bookmark,
+                            firstRecord=firstRecordIdx)
 
 
   def close(self):
@@ -398,7 +400,8 @@ class StreamReader(RecordStreamIface):
 
 
   def getNextRecordIdx(self):
-    """Returns the index of the record that will be read next from getNextRecord()
+    """Returns the index of the record that will be read next from
+    getNextRecord()
     """
     return self._recordCount
 
@@ -456,7 +459,7 @@ class StreamReader(RecordStreamIface):
     """ Returns all fields in all inputs (list of plain names).
     NOTE: currently, only one input is supported
     """
-    return [f[0] for f in self._streamFields]
+    return [f.name for f in self._streamFields]
 
 
   def getFields(self):
@@ -470,38 +473,6 @@ class StreamReader(RecordStreamIface):
     """ Returns a bookmark to the current position
     """
     return self._aggBookmark
-
-
-  def getResetFieldIdx(self):
-    """ Return index of the 'reset' field. """
-    for i, field in enumerate(self._streamFields):
-      if field[2] == 'R' or field[2] == 'r':
-        return i
-    return None
-
-
-  def getTimestampFieldIdx(self):
-    """ Return index of the 'timestamp' field. """
-    for i, field in enumerate(self._streamFields):
-      if field[2] == 'T' or field[2] == 't':
-        return i
-    return None
-
-
-  def getSequenceIdFieldIdx(self):
-    """ Return index of the 'sequenceId' field. """
-    for i, field in enumerate(self._streamFields):
-      if field[2] == 'S' or field[2] == 's':
-        return i
-    return None
-
-
-  def getCategoryFieldIdx(self):
-    """ Return index of the 'category' field. """
-    for i, field in enumerate(self._streamFields):
-      if field[2] == 'C' or field[2] == 'c':
-        return i
-    return None
 
 
   def clearStats(self):

--- a/nupic/regions/RecordSensor.py
+++ b/nupic/regions/RecordSensor.py
@@ -417,7 +417,7 @@ class RecordSensor(PyRegion):
       outputs['temporalTopDownOut'][:] = numpy.array(scalars)
       self._outputValues['temporalTopDownEncodings'] = encodings
 
-      assert(len(spatialTopDownOut) == len(temporalTopDownOut), "Error: "
+      assert len(spatialTopDownOut) == len(temporalTopDownOut), ("Error: "
              "spatialTopDownOut and temporalTopDownOut should be the same size")
 
 

--- a/tests/unit/nupic/data/fieldmeta_test.py
+++ b/tests/unit/nupic/data/fieldmeta_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-15, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -49,6 +49,39 @@ class FieldMetaTest(unittest.TestCase):
     ml = FieldMetaInfo.createListFromFileFieldList(el)
 
     self.assertEqual(el, ml)
+
+
+  def testFieldMetaInfoRaisesValueErrorOnInvalidFieldType(self):
+    with self.assertRaises(ValueError):
+      FieldMetaInfo("fieldName", "bogus-type", FieldMetaSpecial.none)
+
+
+  def testFieldMetaInfoRaisesValueErrorOnInvalidFieldSpecial(self):
+    with self.assertRaises(ValueError):
+      FieldMetaInfo("fieldName", FieldMetaType.integer, "bogus-special")
+
+
+  def testFieldMetaSpecialIsValid(self):
+    self.assertEqual(FieldMetaSpecial.isValid(FieldMetaSpecial.none), True)
+    self.assertEqual(FieldMetaSpecial.isValid(FieldMetaSpecial.reset), True)
+    self.assertEqual(FieldMetaSpecial.isValid(FieldMetaSpecial.sequence), True)
+    self.assertEqual(FieldMetaSpecial.isValid(FieldMetaSpecial.timestamp), True)
+    self.assertEqual(FieldMetaSpecial.isValid(FieldMetaSpecial.category), True)
+    self.assertEqual(FieldMetaSpecial.isValid(FieldMetaSpecial.learning), True)
+
+    self.assertEqual(FieldMetaSpecial.isValid("bogus-special"), False)
+
+
+  def testFieldMetaTypeIsValid(self):
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.string), True)
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.datetime), True)
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.integer), True)
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.float), True)
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.boolean), True)
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.list), True)
+    self.assertEqual(FieldMetaType.isValid(FieldMetaType.sdr), True)
+
+    self.assertEqual(FieldMetaType.isValid("bogus-type"), False)
 
 
 

--- a/tests/unit/nupic/data/file_record_stream_test.py
+++ b/tests/unit/nupic/data/file_record_stream_test.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-15, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -25,6 +25,7 @@ import unittest
 
 from datetime import datetime
 from nupic.data import SENTINEL_VALUE_FOR_MISSING_DATA
+from nupic.data.fieldmeta import FieldMetaInfo, FieldMetaType, FieldMetaSpecial
 from nupic.data.file_record_stream import FileRecordStream
 from nupic.data.utils import (
     parseTimestamp, serializeTimestamp, escape, unescape)
@@ -49,13 +50,20 @@ class TestFileRecordStream(unittest.TestCase):
     filename = _getTempFileName()
 
     # Write a standard file
-    fields = [('name', 'string', ''),
-              ('timestamp', 'datetime', 'T'),
-              ('integer', 'int', ''),
-              ('real', 'float', ''),
-              ('reset', 'int', 'R'),
-              ('sid', 'string', 'S'),
-              ('categoryField', 'int', 'C'),]
+    fields = [FieldMetaInfo('name', FieldMetaType.string,
+                            FieldMetaSpecial.none),
+              FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                            FieldMetaSpecial.timestamp),
+              FieldMetaInfo('integer', FieldMetaType.integer,
+                            FieldMetaSpecial.none),
+              FieldMetaInfo('real', FieldMetaType.float,
+                            FieldMetaSpecial.none),
+              FieldMetaInfo('reset', FieldMetaType.integer,
+                            FieldMetaSpecial.reset),
+              FieldMetaInfo('sid', FieldMetaType.string,
+                            FieldMetaSpecial.sequence),
+              FieldMetaInfo('categoryField', FieldMetaType.integer,
+                            FieldMetaSpecial.category),]
     fieldNames = ['name', 'timestamp', 'integer', 'real', 'reset', 'sid',
                   'categoryField']
 
@@ -84,7 +92,8 @@ class TestFileRecordStream(unittest.TestCase):
       recordsBatch = (
         ['rec_4', datetime(day=4, month=3, year=2010), 2, 9.5, 1, 'seq-1', 13],
         ['rec_5', datetime(day=5, month=3, year=2010), 6, 10.5, 0, 'seq-1', 14],
-        ['rec_6', datetime(day=6, month=3, year=2010), 11, 11.5, 0, 'seq-1', 15])
+        ['rec_6', datetime(day=6, month=3, year=2010), 11, 11.5, 0, 'seq-1', 15]
+      )
 
       print 'Adding batch of records...'
       for rec in recordsBatch:
@@ -129,13 +138,21 @@ class TestFileRecordStream(unittest.TestCase):
     filename = _getTempFileName()
 
     # Write a standard file
-    fields = [('name', 'string', ''),
-              ('timestamp', 'datetime', 'T'),
-              ('integer', 'int', ''),
-              ('real', 'float', ''),
-              ('reset', 'int', 'R'),
-              ('sid', 'string', 'S'),
-              ('categories', 'list', 'C')]
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                    FieldMetaSpecial.timestamp),
+      FieldMetaInfo('integer', FieldMetaType.integer,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('real', FieldMetaType.float,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('reset', FieldMetaType.integer,
+                    FieldMetaSpecial.reset),
+      FieldMetaInfo('sid', FieldMetaType.string,
+                    FieldMetaSpecial.sequence),
+      FieldMetaInfo('categories', FieldMetaType.list,
+                    FieldMetaSpecial.category)]
     fieldNames = ['name', 'timestamp', 'integer', 'real', 'reset', 'sid',
                   'categories']
 
@@ -245,7 +262,8 @@ class TestFileRecordStream(unittest.TestCase):
     print 'Creating tempfile:', filename
 
     # Write bad dataset with records going backwards in time
-    fields = [('timestamp', 'datetime', 'T')]
+    fields = [FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                            FieldMetaSpecial.timestamp)]
     o = FileRecordStream(streamID=filename, write=True, fields=fields)
     # Records
     records = (
@@ -257,7 +275,8 @@ class TestFileRecordStream(unittest.TestCase):
     o.close()
 
     # Write bad dataset with broken sequences
-    fields = [('sid', 'int', 'S')]
+    fields = [FieldMetaInfo('sid', FieldMetaType.integer,
+                            FieldMetaSpecial.sequence)]
     o = FileRecordStream(streamID=filename, write=True, fields=fields)
     # Records
     records = ([1], [2], [1])
@@ -280,10 +299,14 @@ class TestFileRecordStream(unittest.TestCase):
     print 'Creating tempfile:', filename
 
     # write dataset to disk with float, int, and string fields
-    fields = [('timestamp', 'datetime', 'T'),
-              ('name', 'string', ''),
-              ('integer', 'int', ''),
-              ('real', 'float', '')]
+    fields = [FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                            FieldMetaSpecial.timestamp),
+              FieldMetaInfo('name', FieldMetaType.string,
+                            FieldMetaSpecial.none),
+              FieldMetaInfo('integer', FieldMetaType.integer,
+                            FieldMetaSpecial.none),
+              FieldMetaInfo('real', FieldMetaType.float,
+                            FieldMetaSpecial.none)]
     s = FileRecordStream(streamID=filename, write=True, fields=fields)
 
     # Records

--- a/tests/unit/nupic/data/record_stream_test.py
+++ b/tests/unit/nupic/data/record_stream_test.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Unit tests for nupic.data.record_stream."""
+
+from datetime import datetime
+import unittest
+
+import mock
+
+
+from nupic.data.fieldmeta import FieldMetaInfo, FieldMetaType, FieldMetaSpecial
+from nupic.data.record_stream import ModelRecordEncoder, RecordStreamIface
+
+
+
+class ModelRecordEncoderTest(unittest.TestCase):
+
+
+  def testEmptyFieldsArgRaisesValueErrorInConstructor(self):
+    with self.assertRaises(ValueError):
+      ModelRecordEncoder(fields=[])
+
+
+  def testEncoderWithSequenceAndResetFields(self):
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                    FieldMetaSpecial.timestamp),
+      FieldMetaInfo('integer', FieldMetaType.integer,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('real', FieldMetaType.float,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('reset', FieldMetaType.integer,
+                    FieldMetaSpecial.reset),
+      FieldMetaInfo('sid', FieldMetaType.string,
+                    FieldMetaSpecial.sequence),
+      FieldMetaInfo('categories', FieldMetaType.list,
+                    FieldMetaSpecial.category)
+    ]
+
+
+    encoder = ModelRecordEncoder(fields=fields)
+
+    result = encoder.encode(
+      ['rec_1', datetime(day=1, month=3, year=2010), 5, 6.5, 1, 99,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_1',
+        'timestamp': datetime(2010, 3, 1, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'reset': 1,
+        'sid': 99,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 1,
+        '_sequenceId': 99,
+        '_timestamp': datetime(2010, 3, 1, 0, 0),
+        '_timestampRecordIdx': None })
+
+
+  def testEncoderWithResetFieldWithoutSequenceField(self):
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                    FieldMetaSpecial.timestamp),
+      FieldMetaInfo('integer', FieldMetaType.integer,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('real', FieldMetaType.float,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('reset', FieldMetaType.integer,
+                    FieldMetaSpecial.reset),
+      FieldMetaInfo('categories', FieldMetaType.list,
+                    FieldMetaSpecial.category)
+    ]
+
+
+    encoder = ModelRecordEncoder(fields=fields)
+
+    result = encoder.encode(
+      ['rec_1', datetime(day=1, month=3, year=2010), 5, 6.5, 1,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_1',
+        'timestamp': datetime(2010, 3, 1, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'reset': 1,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 1,
+        '_sequenceId': 0,
+        '_timestamp': datetime(2010, 3, 1, 0, 0),
+        '_timestampRecordIdx': None })
+
+    # One more time to verify incremeting sequence id
+    result = encoder.encode(
+      ['rec_2', datetime(day=2, month=3, year=2010), 5, 6.5, 1,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_2',
+        'timestamp': datetime(2010, 3, 2, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'reset': 1,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 1,
+        '_sequenceId': 1,
+        '_timestamp': datetime(2010, 3, 2, 0, 0),
+        '_timestampRecordIdx': None })
+
+    # Now with reset turned off, expecting no change to sequence id
+    result = encoder.encode(
+      ['rec_3', datetime(day=3, month=3, year=2010), 5, 6.5, 0,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_3',
+        'timestamp': datetime(2010, 3, 3, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'reset': 0,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 0,
+        '_sequenceId': 1,
+        '_timestamp': datetime(2010, 3, 3, 0, 0),
+        '_timestampRecordIdx': None })
+
+    # Now check that rewind resets sequence id
+    encoder.rewind()
+    result = encoder.encode(
+      ['rec_4', datetime(day=4, month=3, year=2010), 5, 6.5, 1,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_4',
+        'timestamp': datetime(2010, 3, 4, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'reset': 1,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 1,
+        '_sequenceId': 0,
+        '_timestamp': datetime(2010, 3, 4, 0, 0),
+        '_timestampRecordIdx': None })
+
+
+  def testEncoderWithSequenceFieldWithoutResetField(self):
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                    FieldMetaSpecial.timestamp),
+      FieldMetaInfo('integer', FieldMetaType.integer,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('real', FieldMetaType.float,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('sid', FieldMetaType.string,
+                    FieldMetaSpecial.sequence),
+      FieldMetaInfo('categories', FieldMetaType.list,
+                    FieldMetaSpecial.category)
+    ]
+
+
+    encoder = ModelRecordEncoder(fields=fields)
+
+    # _reset should be 1 the first time
+    result = encoder.encode(
+      ['rec_1', datetime(day=1, month=3, year=2010), 5, 6.5, 99,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_1',
+        'timestamp': datetime(2010, 3, 1, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'sid': 99,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 1,
+        '_sequenceId': 99,
+        '_timestamp': datetime(2010, 3, 1, 0, 0),
+        '_timestampRecordIdx': None })
+
+    # _reset should be 0 when same sequence id is repeated
+    result = encoder.encode(
+      ['rec_2', datetime(day=2, month=3, year=2010), 5, 6.5, 99,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_2',
+        'timestamp': datetime(2010, 3, 2, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'sid': 99,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 0,
+        '_sequenceId': 99,
+        '_timestamp': datetime(2010, 3, 2, 0, 0),
+        '_timestampRecordIdx': None })
+
+    # _reset should be 1 when sequence id changes
+    result = encoder.encode(
+      ['rec_3', datetime(day=2, month=3, year=2010), 5, 6.5, 100,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_3',
+        'timestamp': datetime(2010, 3, 2, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'sid': 100,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 1,
+        '_sequenceId': 100,
+        '_timestamp': datetime(2010, 3, 2, 0, 0),
+        '_timestampRecordIdx': None })
+
+
+
+  def testEncoderWithoutResetAndSequenceFields(self):
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                    FieldMetaSpecial.timestamp),
+      FieldMetaInfo('integer', FieldMetaType.integer,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('real', FieldMetaType.float,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('categories', FieldMetaType.list,
+                    FieldMetaSpecial.category)
+    ]
+
+
+    encoder = ModelRecordEncoder(fields=fields)
+
+    result = encoder.encode(
+      ['rec_1', datetime(day=1, month=3, year=2010), 5, 6.5,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_1',
+        'timestamp': datetime(2010, 3, 1, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 0,
+        '_sequenceId': 0,
+        '_timestamp': datetime(2010, 3, 1, 0, 0),
+        '_timestampRecordIdx': None })
+
+    # One more time to verify that sequence id is still 0
+    result = encoder.encode(
+      ['rec_2', datetime(day=2, month=3, year=2010), 5, 6.5,
+       [0, 1, 2]])
+
+    self.assertEqual(
+      result,
+      {
+        'name': 'rec_2',
+        'timestamp': datetime(2010, 3, 2, 0, 0),
+        'integer': 5,
+        'real': 6.5,
+        'categories': [0, 1, 2],
+        '_category': [0, 1, 2],
+        '_reset': 0,
+        '_sequenceId': 0,
+        '_timestamp': datetime(2010, 3, 2, 0, 0),
+        '_timestampRecordIdx': None })
+
+
+
+class RecordStreamIfaceTest(unittest.TestCase):
+
+
+  class MyRecordStream(RecordStreamIface):
+    """Record stream class for testing functionality of the RecordStreamIface
+    abstract base class
+    """
+
+    def __init__(self, fieldsMeta):
+      super(RecordStreamIfaceTest.MyRecordStream, self).__init__()
+      self._fieldsMeta = fieldsMeta
+      self._fieldNames = tuple(f.name for f in fieldsMeta)
+
+
+    def getNextRecord(self, useCache=True):
+      """[ABC method implementation]
+
+      retval: a data row (a list or tuple) if available; None, if no more records
+               in the table (End of Stream - EOS); empty sequence (list or tuple)
+               when timing out while waiting for the next record.
+      """
+      # The tests will patch this method to feed data
+      pass
+
+
+    def getFieldNames(self):
+      """[ABC method implementation]"""
+      return self._fieldNames
+
+
+    def getFields(self):
+      """[ABC method implementation]"""
+      return self._fieldsMeta
+
+
+    # Satisfy Abstract Base Class requirements for the ABC RecordStreamIface
+    # methods that are no-ops for the currently-implemented tests.
+    close = None
+    getRecordsRange = None
+    getNextRecordIdx = None
+    getLastRecords = None
+    removeOldData = None
+    appendRecord=None
+    appendRecords = None
+    getBookmark = None
+    recordsExistAfter = None
+    seekFromEnd = None
+    getStats = None
+    clearStats = None
+    getError = None
+    setError = None
+    isCompleted = None
+    setCompleted = None
+    setTimeout = None
+    flush = None
+
+
+  def testRewindBeforeModelRecordEncoderIsCreated(self):
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+    ]
+
+    stream = self.MyRecordStream(fields)
+
+    # Check that it doesn't crash by trying to operate on an absent encoder
+    self.assertIsNone(stream._modelRecordEncoder)
+    stream.rewind()
+
+
+  def testGetNextRecordDictWithResetFieldWithoutSequenceField(self):
+    fields = [
+      FieldMetaInfo('name', FieldMetaType.string,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('timestamp', FieldMetaType.datetime,
+                    FieldMetaSpecial.timestamp),
+      FieldMetaInfo('integer', FieldMetaType.integer,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('real', FieldMetaType.float,
+                    FieldMetaSpecial.none),
+      FieldMetaInfo('reset', FieldMetaType.integer,
+                    FieldMetaSpecial.reset),
+      FieldMetaInfo('categories', FieldMetaType.list,
+                    FieldMetaSpecial.category)
+    ]
+
+
+    stream = self.MyRecordStream(fields)
+
+
+    with mock.patch.object(
+        stream, 'getNextRecord', autospec=True,
+        return_value=['rec_1', datetime(day=1, month=3, year=2010), 5, 6.5, 1,
+                      [0, 1, 2]]):
+
+      result = stream.getNextRecordDict()
+
+      self.assertEqual(
+        result,
+        {
+          'name': 'rec_1',
+          'timestamp': datetime(2010, 3, 1, 0, 0),
+          'integer': 5,
+          'real': 6.5,
+          'reset': 1,
+          'categories': [0, 1, 2],
+          '_category': [0, 1, 2],
+          '_reset': 1,
+          '_sequenceId': 0,
+          '_timestamp': datetime(2010, 3, 1, 0, 0),
+          '_timestampRecordIdx': None })
+
+    # One more time to verify incremeting sequence id
+    with mock.patch.object(
+        stream, 'getNextRecord', autospec=True,
+        return_value=['rec_2', datetime(day=2, month=3, year=2010), 5, 6.5, 1,
+                      [0, 1, 2]]):
+
+      result = stream.getNextRecordDict()
+
+      self.assertEqual(
+        result,
+        {
+          'name': 'rec_2',
+          'timestamp': datetime(2010, 3, 2, 0, 0),
+          'integer': 5,
+          'real': 6.5,
+          'reset': 1,
+          'categories': [0, 1, 2],
+          '_category': [0, 1, 2],
+          '_reset': 1,
+          '_sequenceId': 1,
+          '_timestamp': datetime(2010, 3, 2, 0, 0),
+          '_timestampRecordIdx': None })
+
+    # Now with reset turned off, expecting no change to sequence id
+    with mock.patch.object(
+        stream, 'getNextRecord', autospec=True,
+        return_value=['rec_3', datetime(day=3, month=3, year=2010), 5, 6.5, 0,
+                      [0, 1, 2]]):
+
+      result = stream.getNextRecordDict()
+
+      self.assertEqual(
+        result,
+        {
+          'name': 'rec_3',
+          'timestamp': datetime(2010, 3, 3, 0, 0),
+          'integer': 5,
+          'real': 6.5,
+          'reset': 0,
+          'categories': [0, 1, 2],
+          '_category': [0, 1, 2],
+          '_reset': 0,
+          '_sequenceId': 1,
+          '_timestamp': datetime(2010, 3, 3, 0, 0),
+          '_timestampRecordIdx': None })
+
+    # Now check that rewind resets sequence id
+    with mock.patch.object(
+        stream, 'getNextRecord', autospec=True,
+        return_value=['rec_4', datetime(day=4, month=3, year=2010), 5, 6.5, 1,
+                      [0, 1, 2]]):
+      stream.rewind()
+      result = stream.getNextRecordDict()
+
+      self.assertEqual(
+        result,
+        {
+          'name': 'rec_4',
+          'timestamp': datetime(2010, 3, 4, 0, 0),
+          'integer': 5,
+          'real': 6.5,
+          'reset': 1,
+          'categories': [0, 1, 2],
+          '_category': [0, 1, 2],
+          '_reset': 1,
+          '_sequenceId': 0,
+          '_timestamp': datetime(2010, 3, 4, 0, 0),
+          '_timestampRecordIdx': None })
+
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
1. Broke out model record encoding logic from RecordStreamIface into ModelRecordEncoder class.
2. Removed the 'address' field type hack that was left over as the legacy from Precog prep.
3. Added missing attributes and validation checkers in nupic.data.fieldmeta.
4. Converted stream modules to use nupic.data.fieldmeta types/constants instead of hard-coding those values.
5. Implemented unit tests for ModelRecordEncoder.
6. Implemented unit tests for RecordStreamIface.getNextRecordDict and RecordStreamIface.rewind
7. Implemented unit tests for ValueError exception from FieldMetaInfo.
8. Implemented unit tests for FieldMetaSpecial.isValid and FieldMetaType.isValid
9. Fixed a bunch of pylint findings in the affected modules.
