### PR TITLE
Fixed fast_temporal_memory cellsForColumn calculation

### DIFF
--- a/nupic/research/fast_temporal_memory.py
+++ b/nupic/research/fast_temporal_memory.py
@@ -182,7 +182,7 @@ class FastTemporalMemory(TemporalMemory):
     """
     self._validateColumn(column)
 
-    start = self.cellsPerColumn * self.getCellIndex(column)
+    start = self.cellsPerColumn * column
     end = start + self.cellsPerColumn
     return set([ConnectionsCell(idx) for idx in xrange(start, end)])
 


### PR DESCRIPTION
@scottpurdy @chetan51 

fixes #2440 

This code is failing for me w/ the `getCellIndex` call. Column is an `numpy.int64` not a nupic `Cell`, so getCellIndex won't actually work on this. The docstring describes column as an int anyway, so the `fast_temporal_memory` implementation shouldn't try to use `getCellIndex` which expects a `Cell`. 