### PR TITLE
Remove plugin that breaks Pylint.

### DIFF
--- a/pylintrc
+++ b/pylintrc
@@ -47,7 +47,7 @@ persistent=no
 
 # List of plugins (as comma separated values of python modules names) to load,
 # usually to register additional checkers.
-load-plugins=nupic.support.lint.executable
+load-plugins=
 
 
 [MESSAGES CONTROL]


### PR DESCRIPTION
fixes #2442 

This plugin is no longer needed anyway.

@vitaly-krugl - please review