### PR TITLE
Coordinate encoder speedup using cache

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -3,6 +3,7 @@
 # any that are there: <nupic.core repo>/external/common/requirements.txt
 asteval==0.9.1
 coverage==3.7.1
+fastcache==1.0.2
 mock==1.0.1
 ordereddict==1.1
 pillow==2.3.0

--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -3,7 +3,6 @@
 # any that are there: <nupic.core repo>/external/common/requirements.txt
 asteval==0.9.1
 coverage==3.7.1
-fastcache==1.0.2
 mock==1.0.1
 ordereddict==1.1
 pillow==2.3.0

--- a/nupic/encoders/coordinate.capnp
+++ b/nupic/encoders/coordinate.capnp
@@ -1,9 +1,10 @@
 @0xdbf38fd0fd055200;
 
-# Next ID: 4
+# Next ID: 5
 struct CoordinateEncoderProto {
   w @0 :UInt32;
   n @1 :UInt32;
   verbosity @2 :UInt8;
   name @3 :Text;
+  cacheSize @4 :UInt32;
 }

--- a/nupic/encoders/coordinate.py
+++ b/nupic/encoders/coordinate.py
@@ -101,10 +101,14 @@ class CoordinateEncoder(Encoder):
 
   
   @cache(maxsize=100, typed=False)
-  def encode(self, coordinate, radius, **kwds):
+  def encode(self, coordinate, radius, cacheSizeName='cacheSize', **kwds):
     """
     @param coordinate - a tuple (is hashable) of each axis, eg (x,y,z)
     @param radius - float
+    @param cacheSizeName - string (opt), points to the attribute of the object
+                         (CoordinateEncoder().cacheSize) which holds value for
+                         the size of the cache. 
+                         See nupic.utils.lru_cache and tests for explanation.
     """
     out = numpy.zeros(self.n)
     coordArr = numpy.array(coordinate)

--- a/nupic/encoders/coordinate.py
+++ b/nupic/encoders/coordinate.py
@@ -165,15 +165,6 @@ class CoordinateEncoder(Encoder):
     return coordinates[indices]
 
 
-  @staticmethod
-  def _hashCoordinate(coordinate):
-    """Hash a coordinate to a 64 bit integer."""
-    coordinateStr = ",".join(str(v) for v in coordinate)
-    # Compute the hash and convert to 64 bit int.
-    hash = int(int(hashlib.md5(coordinateStr).hexdigest(), 16) % (2 ** 64))
-    return hash
-
-
   @classmethod
   def _orderForCoordinate(cls, coordinate):
     """
@@ -183,7 +174,7 @@ class CoordinateEncoder(Encoder):
     @return (float) A value in the interval [0, 1), representing the
                     order of the coordinate
     """
-    seed = cls._hashCoordinate(coordinate)
+    seed = hash(coordinate.data)
     rng = Random(seed)
     return rng.getReal64()
 
@@ -197,7 +188,7 @@ class CoordinateEncoder(Encoder):
     @param n (int) The number of available bits in the SDR
     @return (int) The index to a bit in the SDR
     """
-    seed = cls._hashCoordinate(coordinate)
+    seed = hash(coordinate.data)
     rng = Random(seed)
     return rng.getUInt32(n)
 

--- a/nupic/encoders/coordinate.py
+++ b/nupic/encoders/coordinate.py
@@ -19,7 +19,7 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-from fastcache import clru_cache as cache
+from nupic.utils import lru_cache as cache
 import hashlib
 import itertools
 

--- a/nupic/encoders/coordinate.py
+++ b/nupic/encoders/coordinate.py
@@ -165,6 +165,15 @@ class CoordinateEncoder(Encoder):
     return coordinates[indices]
 
 
+  @staticmethod
+  def _hashCoordinate(coordinate):
+    """Hash a coordinate to a 64 bit integer."""
+    coordinateStr = ",".join(str(v) for v in coordinate)
+    # Compute the hash and convert to 64 bit int.
+    hash = int(int(hashlib.md5(coordinateStr).hexdigest(), 16) % (2 ** 64))
+    return hash
+
+
   @classmethod
   def _orderForCoordinate(cls, coordinate):
     """
@@ -174,7 +183,7 @@ class CoordinateEncoder(Encoder):
     @return (float) A value in the interval [0, 1), representing the
                     order of the coordinate
     """
-    seed = hash(coordinate.data)
+    seed = cls._hashCoordinate(coordinate)
     rng = Random(seed)
     return rng.getReal64()
 
@@ -188,7 +197,7 @@ class CoordinateEncoder(Encoder):
     @param n (int) The number of available bits in the SDR
     @return (int) The index to a bit in the SDR
     """
-    seed = hash(coordinate.data)
+    seed = cls._hashCoordinate(coordinate)
     rng = Random(seed)
     return rng.getUInt32(n)
 

--- a/nupic/encoders/coordinate.py
+++ b/nupic/encoders/coordinate.py
@@ -101,7 +101,7 @@ class CoordinateEncoder(Encoder):
 
   
   @cache(maxsize=100, typed=False)
-  def encode(self, coordinate, radius):
+  def encode(self, coordinate, radius, **kwds):
     """
     @param coordinate - a tuple (is hashable) of each axis, eg (x,y,z)
     @param radius - float

--- a/nupic/encoders/coordinate.py
+++ b/nupic/encoders/coordinate.py
@@ -100,15 +100,11 @@ class CoordinateEncoder(Encoder):
     return numpy.array([0]*len(inputData))
 
   
-  @cache(maxsize=100, typed=False)
-  def encode(self, coordinate, radius, cacheSizeName='cacheSize', **kwds):
+  @cache(sizeref='cacheSize', typed=False)
+  def encode(self, coordinate, radius, **kwds):
     """
     @param coordinate - a tuple (is hashable) of each axis, eg (x,y,z)
     @param radius - float
-    @param cacheSizeName - string (opt), points to the attribute of the object
-                         (CoordinateEncoder().cacheSize) which holds value for
-                         the size of the cache. 
-                         See nupic.utils.lru_cache and tests for explanation.
     """
     out = numpy.zeros(self.n)
     coordArr = numpy.array(coordinate)

--- a/nupic/utils.py
+++ b/nupic/utils.py
@@ -126,3 +126,176 @@ class MovingAverage(object):
     proto.windowSize = self.windowSize
     proto.slidingWindow = self.slidingWindow
     proto.total = self.total
+
+
+
+#######################################################
+# code from functools.lru_cache for Python 3.3, backports from ActiveState:
+# https://code.activestate.com/recipes/578078/
+# my modifications under '#mmm:' for runtime evaluation of cachesize argument
+# which is needed for use in a library
+from collections import namedtuple
+from functools import update_wrapper
+from threading import RLock
+
+_CacheInfo = namedtuple("CacheInfo", ["hits", "misses", "maxsize", "currsize"])
+
+class _HashedSeq(list):
+    __slots__ = 'hashvalue'
+
+    def __init__(self, tup, hash=hash):
+        self[:] = tup
+        self.hashvalue = hash(tup)
+
+    def __hash__(self):
+        return self.hashvalue
+
+def _make_key(args, kwds, typed,
+             kwd_mark = (object(),),
+             fasttypes = {int, str, frozenset, type(None)},
+             sorted=sorted, tuple=tuple, type=type, len=len):
+    'Make a cache key from optionally typed positional and keyword arguments'
+    key = args
+    if kwds:
+        sorted_items = sorted(kwds.items())
+        key += kwd_mark
+        for item in sorted_items:
+            key += item
+    if typed:
+        key += tuple(type(v) for v in args)
+        if kwds:
+            key += tuple(type(v) for k, v in sorted_items)
+    elif len(key) == 1 and type(key[0]) in fasttypes:
+        return key[0]
+    return _HashedSeq(key)
+
+def lru_cache(maxsize=100, typed=False):
+    """Least-recently-used cache decorator.
+
+    If *maxsize* is set to None, the LRU features are disabled and the cache
+    can grow without bound.
+
+    If *typed* is True, arguments of different types will be cached separately.
+    For example, f(3.0) and f(3) will be treated as distinct calls with
+    distinct results.
+
+    Arguments to the cached function must be hashable.
+
+    View the cache statistics named tuple (hits, misses, maxsize, currsize) with
+    f.cache_info().  Clear the cache and statistics with f.cache_clear().
+    Access the underlying function with f.__wrapped__.
+
+    See:  http://en.wikipedia.org/wiki/Cache_algorithms#Least_Recently_Used
+
+    """
+
+    # Users should only access the lru_cache through its public API:
+    #       cache_info, cache_clear, and f.__wrapped__
+    # The internals of the lru_cache are encapsulated for thread safety and
+    # to allow the implementation to change (including a possible C version).
+
+    def decorating_function(user_function):
+
+        cache = dict()
+        stats = [0, 0]                  # make statistics updateable non-locally
+        HITS, MISSES = 0, 1             # names for the stats fields
+        make_key = _make_key
+        cache_get = cache.get           # bound method to lookup key or return None
+        _len = len                      # localize the global len() function
+        lock = RLock()                  # because linkedlist updates aren't threadsafe
+        root = []                       # root of the circular doubly linked list
+        root[:] = [root, root, None, None]      # initialize by pointing to self
+        nonlocal_root = [root]                  # make updateable non-locally
+        PREV, NEXT, KEY, RESULT = 0, 1, 2, 3    # names for the link fields
+
+        if maxsize == 0:
+
+            def wrapper(*args, **kwds):
+                # no caching, just do a statistics update after a successful call
+                result = user_function(*args, **kwds)
+                stats[MISSES] += 1
+                return result
+
+        elif maxsize is None:
+
+            def wrapper(*args, **kwds):
+                # simple caching without ordering or size limit
+                key = make_key(args, kwds, typed)
+                result = cache_get(key, root)   # root used here as a unique not-found sentinel
+                if result is not root:
+                    stats[HITS] += 1
+                    return result
+                result = user_function(*args, **kwds)
+                cache[key] = result
+                stats[MISSES] += 1
+                return result
+
+        else:
+
+            def wrapper(*args, **kwds):
+                # size limited caching that tracks accesses by recency
+                key = make_key(args, kwds, typed) if kwds or typed else args
+                with lock:
+                    link = cache_get(key)
+                    if link is not None:
+                        # record recent use of the key by moving it to the front of the list
+                        root, = nonlocal_root
+                        link_prev, link_next, key, result = link
+                        link_prev[NEXT] = link_next
+                        link_next[PREV] = link_prev
+                        last = root[PREV]
+                        last[NEXT] = root[PREV] = link
+                        link[PREV] = last
+                        link[NEXT] = root
+                        stats[HITS] += 1
+                        return result
+                result = user_function(*args, **kwds)
+                with lock:
+                    root, = nonlocal_root
+                    if key in cache:
+                        # getting here means that this same key was added to the
+                        # cache while the lock was released.  since the link
+                        # update is already done, we need only return the
+                        # computed result and update the count of misses.
+                        pass
+                    elif _len(cache) >= maxsize:
+                        # use the old root to store the new key and result
+                        oldroot = root
+                        oldroot[KEY] = key
+                        oldroot[RESULT] = result
+                        # empty the oldest link and make it the new root
+                        root = nonlocal_root[0] = oldroot[NEXT]
+                        oldkey = root[KEY]
+                        oldvalue = root[RESULT]
+                        root[KEY] = root[RESULT] = None
+                        # now update the cache dictionary for the new links
+                        del cache[oldkey]
+                        cache[key] = oldroot
+                    else:
+                        # put result in a new link at the front of the list
+                        last = root[PREV]
+                        link = [last, root, key, result]
+                        last[NEXT] = root[PREV] = cache[key] = link
+                    stats[MISSES] += 1
+                return result
+
+        def cache_info():
+            """Report cache statistics"""
+            with lock:
+                return _CacheInfo(stats[HITS], stats[MISSES], maxsize, len(cache))
+
+        def cache_clear():
+            """Clear the cache and cache statistics"""
+            with lock:
+                cache.clear()
+                root = nonlocal_root[0]
+                root[:] = [root, root, None, None]
+                stats[:] = [0, 0]
+
+        wrapper.__wrapped__ = user_function
+        wrapper.cache_info = cache_info
+        wrapper.cache_clear = cache_clear
+        return update_wrapper(wrapper, user_function)
+
+    return decorating_function
+

--- a/nupic/utils.py
+++ b/nupic/utils.py
@@ -191,13 +191,17 @@ def _setSize(sizeref, properties, *args, **kwds):
   mxRef = -1
 
   # 1st from the method's arguments:
-  mxArg = int(kwds.pop(sizeref, -1))
+  mxArg = kwds.pop(sizeref, -1) # None, >=0, -1
+  if mxArg is not None:
+    mxArg = int(mxArg)
   # 2nd from caller object's member of name as sizeref's value:
   # try to get attribute of value sizeref from methods parent object, if it is called from an object
   # otherwise just ignore
   try:
     caller = args[0]
-    mxRef = int(caller.__dict__.get(sizeref, -1))
+    mxRef = caller.__dict__.get(sizeref, -1) # None, >=0, -1
+    if mxRef is not None:
+      mxRef = int(mxRef)
   except AttributeError:
     # ignore missing attribute of the object
     pass
@@ -208,6 +212,9 @@ def _setSize(sizeref, properties, *args, **kwds):
   elif mxRef >= 0:
     print "setting maxsize to object's member %s = %i" % (sizeref, mxRef)
     properties['maxsize'] = mxRef
+  elif mxRef is None or mxArg is None:
+    print "setting unlimited cache (None)"
+    properties['maxsize'] = None
   else:
     raise ValueError("lru_cache: No arg or object's member of name %s, as specified in 'sizeref'" % (sizeref))
 

--- a/scripts/profiling/enc_profile.py
+++ b/scripts/profiling/enc_profile.py
@@ -42,6 +42,10 @@ def profileEnc(maxValue, nRuns):
   for d in data:
     encScalar.encode(d)
     encRDSE.encode(d)
+    encCoord.encode((d, d), 2)
+
+  print "Scalar n=",encScalar.n," RDSE n=",encRDSE.n," Coord n=",encCoord.n
+  print encCoord.encode.cache_info()
 
   print "Scalar n=",encScalar.n," RDSE n=",encRDSE.n
 

--- a/scripts/profiling/enc_profile.py
+++ b/scripts/profiling/enc_profile.py
@@ -27,16 +27,18 @@ import numpy
 # chose desired Encoder implementations to compare:
 from nupic.encoders.scalar import ScalarEncoder
 from nupic.encoders.random_distributed_scalar import RandomDistributedScalarEncoder as RDSE
+from nupic.encoders.coordinate import CoordinateEncoder
 
 
 def profileEnc(maxValue, nRuns):
   minV=0
-  maxV=nRuns
+  maxV=maxValue
   # generate input data
   data=numpy.random.randint(minV, maxV+1, nRuns)
   # instantiate measured encoders
   encScalar = ScalarEncoder(w=21, minval=minV, maxval=maxV, resolution=1)
   encRDSE = RDSE(resolution=1)
+  encCoord = CoordinateEncoder(cacheSize = 1)
   
   # profile!  
   for d in data:
@@ -45,17 +47,17 @@ def profileEnc(maxValue, nRuns):
     encCoord.encode((d, d), 2)
 
   print "Scalar n=",encScalar.n," RDSE n=",encRDSE.n," Coord n=",encCoord.n
-  print encCoord.encode.cache_info()
-
-  print "Scalar n=",encScalar.n," RDSE n=",encRDSE.n
+  print encCoord.dump()
 
 
 
 if __name__ == "__main__":
   maxV=500
-  epochs=10000
+  iters=10000
+  epochs = 10
   if len(sys.argv) == 3: # 2 args + name
     columns=int(sys.argv[1])
     epochs=int(sys.argv[2])
 
-  profileEnc(maxV, epochs)
+  for _ in xrange(epochs):
+    profileEnc(maxV, iters)

--- a/scripts/profiling/enc_profile.py
+++ b/scripts/profiling/enc_profile.py
@@ -38,7 +38,7 @@ def profileEnc(maxValue, nRuns):
   # instantiate measured encoders
   encScalar = ScalarEncoder(w=21, minval=minV, maxval=maxV, resolution=1)
   encRDSE = RDSE(resolution=1)
-  encCoord = CoordinateEncoder(cacheSize = 1)
+  encCoord = CoordinateEncoder(cacheSize = maxV)
   
   # profile!  
   for d in data:

--- a/tests/unit/nupic/encoders/coordinate_test.py
+++ b/tests/unit/nupic/encoders/coordinate_test.py
@@ -296,6 +296,20 @@ class CoordinateEncoderTest(unittest.TestCase):
     self.assertTrue(np.array_equal(output1, output2))
 
 
+  def testCachedEncoding(self):
+    eDefault = CoordinateEncoder()
+    eCached  = CoordinateEncoder(cacheSize=10)
+    iters = 10
+    for _ in xrange(iters):
+      (x,y) = np.random.randint(0, 10, 2) 
+
+      res1 = encode(eDefault, np.array([x,y]), 2) # uses encodeIntoArray() directly
+      res2 = eCached.encode((x,y), 2) # calls encode() with cache
+
+      self.assertTrue(np.array_equal(res1, res2), "Cached and non-cached encodings differ! %r %r" % (res1, res2))
+    print eCached.dump()
+
+
 def encode(encoder, coordinate, radius):
   output = np.zeros(encoder.getWidth(), dtype=defaultDtype)
   encoder.encodeIntoArray((coordinate, radius), output)

--- a/tests/unit/nupic/encoders/coordinate_test.py
+++ b/tests/unit/nupic/encoders/coordinate_test.py
@@ -301,7 +301,7 @@ class CoordinateEncoderTest(unittest.TestCase):
     eCached  = CoordinateEncoder(cacheSize=10)
     iters = 10
     for _ in xrange(iters):
-      (x,y) = np.random.randint(0, 10, 2) 
+      (x,y) = np.random.randint(0, 2, 2) 
 
       res1 = encode(eDefault, np.array([x,y]), 2) # uses encodeIntoArray() directly
       res2 = eCached.encode((x,y), 2) # calls encode() with cache

--- a/tests/unit/nupic/encoders/coordinate_test.py
+++ b/tests/unit/nupic/encoders/coordinate_test.py
@@ -311,11 +311,12 @@ class CoordinateEncoderTest(unittest.TestCase):
       (x,y) = np.random.randint(0, 2, 2) 
 
       res1 = encode(eDefault, np.array([x,y]), 2) # uses encodeIntoArray() directly
-      res2 = eCached.encode((x,y), 2, cachesize=10, cacheSizeName='cacheSize') # calls encode() with cache
-      # both methods to set cache size are shown: cachesize=10, and cacheSizeName; the latter takes preference.
+      res2 = eCached.encode((x,y), 2) # calls encode() with cache
 
       self.assertTrue(np.array_equal(res1, res2), "Cached and non-cached encodings differ! %r %r" % (res1, res2))
     print eCached.dump()
+    sz = eCached.encode.cache_info().maxsize
+    self.assertEqual(sz, 9, "cache size was not properly set: 9 != %i" % (sz))
 
 
 def encode(encoder, coordinate, radius):

--- a/tests/unit/nupic/encoders/coordinate_test.py
+++ b/tests/unit/nupic/encoders/coordinate_test.py
@@ -298,13 +298,13 @@ class CoordinateEncoderTest(unittest.TestCase):
 
   def testCachedEncoding(self):
     eDefault = CoordinateEncoder()
-    eCached  = CoordinateEncoder(cacheSize=10)
+    eCached  = CoordinateEncoder(cacheSize=9)
     iters = 10
     for _ in xrange(iters):
       (x,y) = np.random.randint(0, 2, 2) 
 
       res1 = encode(eDefault, np.array([x,y]), 2) # uses encodeIntoArray() directly
-      res2 = eCached.encode((x,y), 2) # calls encode() with cache
+      res2 = eCached.encode((x,y), 2, cachesize=10, cacheSizeName='cacheSize') # calls encode() with cache
 
       self.assertTrue(np.array_equal(res1, res2), "Cached and non-cached encodings differ! %r %r" % (res1, res2))
     print eCached.dump()

--- a/tests/unit/nupic/encoders/coordinate_test.py
+++ b/tests/unit/nupic/encoders/coordinate_test.py
@@ -305,6 +305,7 @@ class CoordinateEncoderTest(unittest.TestCase):
 
       res1 = encode(eDefault, np.array([x,y]), 2) # uses encodeIntoArray() directly
       res2 = eCached.encode((x,y), 2, cachesize=10, cacheSizeName='cacheSize') # calls encode() with cache
+      # both methods to set cache size are shown: cachesize=10, and cacheSizeName; the latter takes preference.
 
       self.assertTrue(np.array_equal(res1, res2), "Cached and non-cached encodings differ! %r %r" % (res1, res2))
     print eCached.dump()

--- a/tests/unit/nupic/utils_test.py
+++ b/tests/unit/nupic/utils_test.py
@@ -214,7 +214,6 @@ class UtilsTest(unittest.TestCase):
       def foo(self, x, **kwds):
         return x**2
 
-    # test itself
     a = A(42)
 
     # method 1: maxsize from method's arg, this is an override
@@ -222,6 +221,7 @@ class UtilsTest(unittest.TestCase):
       a.foo(d, cacheSize="5")
     mx = int(a.foo.cache_info().maxsize)
     self.assertEqual(mx, 5, "Cache size from method's arg 'cacheSize' was set to 5, but is %r" % (mx))
+    print a.foo.cache_info()
     a.foo.cache_clear()
 
     # method 2: maxsize from object's member variable
@@ -229,6 +229,18 @@ class UtilsTest(unittest.TestCase):
       a.foo(d)
     mx = int(a.foo.cache_info().maxsize)
     self.assertEqual(mx, 42, "Cache size from object's member 'encoder.cacheSize' was set to 42, but is %r" % (mx))
+    print a.foo.cache_info()
+    a.foo.cache_clear()
+
+    # test for unstandard options - maxsize = None / 0:
+
+    # no cache
+    a = A(0)
+    for d in xrange(10):
+      a.foo(d)
+    mx = int(a.foo.cache_info().maxsize)
+    self.assertEqual(mx, 0, "Cache size set to 0, but is %r" % (mx))
+    print a.foo.cache_info()
     a.foo.cache_clear()
 
 

--- a/tests/unit/nupic/utils_test.py
+++ b/tests/unit/nupic/utils_test.py
@@ -205,34 +205,31 @@ class UtilsTest(unittest.TestCase):
 
 
   def testCacheSetSize(self):
+    """test setting cache's size at runtime"""
     # just a mock object
     class A(object):
       def __init__(self, cacheSize):
-        self._cacheSize = cacheSize
-      @cache(maxsize = 100)
+        self.cacheSize = cacheSize
+      @cache(sizeref='cacheSize')
       def foo(self, x, **kwds):
         return x**2
 
     # test itself
     a = A(42)
 
-    # method 1: maxsize explicitely given in decorator (=100)
+    # method 1: maxsize from method's arg, this is an override
+    for d in xrange(10):
+      a.foo(d, cacheSize="5")
+    mx = int(a.foo.cache_info().maxsize)
+    self.assertEqual(mx, 5, "Cache size from method's arg 'cacheSize' was set to 5, but is %r" % (mx))
+    a.foo.cache_clear()
+
+    # method 2: maxsize from object's member variable
     for d in xrange(10):
       a.foo(d)
     mx = int(a.foo.cache_info().maxsize)
-    self.assertEqual(mx, 100, "Cache maxsize was given by decorator to 100, but is %r" % (mx))
-
-    # method 2: maxsize by 'cahesize' **kwarg passed to method
-    for d in xrange(10):
-      a.foo(d, cachesize="5")
-    mx = int(a.foo.cache_info().maxsize)
-    self.assertEqual(mx, 5, "Cache maxsize was given by method arg 'cachesize' to 5, but is %r" % (mx))
-
-    # method 3: maxsize accessed by 'cacheSizeName' reference to a._cacheSize
-    for d in xrange(10):
-      a.foo(d, cacheSizeName='_cacheSize')
-    mx = int(a.foo.cache_info().maxsize)
-    self.assertEqual(mx, 42, "Cache maxsize was given by method arg 'cacheSizeName' to self._cacheSize (=42), but is %r" % (mx))
+    self.assertEqual(mx, 42, "Cache size from object's member 'encoder.cacheSize' was set to 42, but is %r" % (mx))
+    a.foo.cache_clear()
 
 
 

--- a/tests/unit/nupic/utils_test.py
+++ b/tests/unit/nupic/utils_test.py
@@ -27,6 +27,7 @@ import tempfile
 import unittest
 
 from nupic.utils import MovingAverage
+from nupic.utils import lru_cache as cache
 
 # Import capnp to force import hook
 import capnp
@@ -178,6 +179,23 @@ class UtilsTest(unittest.TestCase):
     self.assertNotEqual(ma, maP)
     ma.next(6)
     self.assertEqual(ma, maP)
+
+
+  def testCache(self):
+    data = numpy.random.randint(0, 10, 100) 
+    resRef = []
+    resCached = []
+
+    @cache(maxsize=8)
+    def foo(x):
+      return x**2
+
+    for d in data:
+      resRef.append(d**2)
+      resCached.append(foo(d))
+    
+    self.assertListEqual(resRef, resCached, ("Values retrieved from cache differ!: %r vs. %r" % (resRef, resCached))
+
     
 
 

--- a/tests/unit/nupic/utils_test.py
+++ b/tests/unit/nupic/utils_test.py
@@ -22,6 +22,7 @@
 
 """Unit tests for utils module."""
 
+import numpy
 import pickle
 import tempfile
 import unittest
@@ -194,9 +195,39 @@ class UtilsTest(unittest.TestCase):
       resRef.append(d**2)
       resCached.append(foo(d))
     
-    self.assertListEqual(resRef, resCached, ("Values retrieved from cache differ!: %r vs. %r" % (resRef, resCached))
+    self.assertListEqual(resRef, resCached, "Values retrieved from cache differ!: %r vs. %r" % (resRef, resCached))
+    print foo.cache_info()
 
-    
+
+  def testCacheSetSize(self):
+    # just a mock object
+    class A(object):
+      def __init__(self, cacheSize):
+        self._cacheSize = cacheSize
+      @cache(maxsize = 100)
+      def foo(self, x, **kwds):
+        return x**2
+
+    # test itself
+    a = A(42)
+
+    # method 1: maxsize explicitely given in decorator (=100)
+    for d in xrange(10):
+      a.foo(d)
+    mx = int(a.foo.cache_info().maxsize)
+    self.assertEqual(mx, 100, "Cache maxsize was given by decorator to 100, but is %r" % (mx))
+
+    # method 2: maxsize by 'cahesize' **kwarg passed to method
+    for d in xrange(10):
+      a.foo(d, cachesize="5")
+    mx = int(a.foo.cache_info().maxsize)
+    self.assertEqual(mx, 5, "Cache maxsize was given by method arg 'cachesize' to 5, but is %r" % (mx))
+
+    # method 3: maxsize accessed by 'cacheSizeName' reference to a._cacheSize
+    for d in xrange(10):
+      a.foo(d, cacheSizeName='_cacheSize')
+    mx = int(a.foo.cache_info().maxsize)
+    self.assertEqual(mx, 42, "Cache maxsize was given by method arg 'cacheSizeName' to self._cacheSize (=42), but is %r" % (mx))
 
 
 

--- a/tests/unit/nupic/utils_test.py
+++ b/tests/unit/nupic/utils_test.py
@@ -243,6 +243,16 @@ class UtilsTest(unittest.TestCase):
     print a.foo.cache_info()
     a.foo.cache_clear()
 
+    # unlimited cache
+    a = A(None)
+    for d in xrange(10):
+      a.foo(d)
+    mx = a.foo.cache_info().maxsize
+    self.assertEqual(mx, None, "Cache size set to unlimited (None), but is %r" % (mx))
+    print a.foo.cache_info()
+    a.foo.cache_clear()
+
+
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
caches encodings for Coord encoder to make it usable for streaming data (high throughput). 
I've decided not to cache only the hashes but went further and cache whole encodings for a given input. 
This is handeled through `cacheSize` param which defaults to 0 = off. 

I;ve tried `OrderedDict` or even better `cachetools` (LeastFrequentlyUsed, LeastRecentlyUsed caches) to better handle full cache (removal), but they don't cut it. (well, still faster than current, but cca 2x slower then this suggested dict-only approach), on the other hand, I have to remove "random" elements when purging cache. 

Results: 
`   ncalls  tottime  percall  cumtime  percall filename:lineno(function)`
new:  ` 63314    0.444    0.000    0.490    0.000 coordinate.py:114(encodeIntoArray)` ~63000x
old:  `14702    0.809    0.000   31.369    0.002 coordinate.py:114(encodeIntoArray)`   ~14000x

For serialization, I did not bother with storing a dict (maybe possible?), but just drop it, as it's only an optimization.  

Fixes #2150