### PR TITLE
Fixes #2478 Bug in temporal memory orphan decay test

### DIFF
--- a/tests/integration/nupic/algorithms/extensive_temporal_memory_test.py
+++ b/tests/integration/nupic/algorithms/extensive_temporal_memory_test.py
@@ -505,41 +505,58 @@ class ExtensiveTemporalMemoryTest(AbstractTemporalMemoryTest):
       self.tm.mmGetTraceUnpredictedActiveColumns())
     self.assertTrue(unpredictedActiveColumnsMetric.mean < 3)
 
+
   def testH10(self):
     """Orphan Decay mechanism reduce predicted inactive cells (extra predictions).
     Test feeds in noisy sequences (X = 0.05) to TM with and without orphan decay.
     TM with orphan decay should has many fewer predicted inactive columns.
     Parameters the same as B11, and sequences like H9."""
+
+    # train TM on noisy sequences with orphan decay turned off
     self.init({"cellsPerColumn": 4,
                "activationThreshold": 8})
 
     numbers = self.sequenceMachine.generateNumbers(2, 20, (10, 15))
     sequence = self.sequenceMachine.generateFromNumbers(numbers)
+
     sequenceNoisy = dict()
     for i in xrange(10):
       sequenceNoisy[i] = self.sequenceMachine.addSpatialNoise(sequence, 0.05)
       self.feedTM(sequenceNoisy[i])
+    self.tm.mmClearHistory()
 
     self._testTM(sequence)
+
     predictedInactiveColumnsMetric = self.tm.mmGetMetricFromTrace(
       self.tm.mmGetTracePredictedInactiveColumns())
-    predictedInactiveColumnsMean1 = predictedInactiveColumnsMetric.mean
+    predictedActiveColumnsMetric = self.tm.mmGetMetricFromTrace(
+      self.tm.mmGetTracePredictedActiveColumns())
 
+    predictedInactiveColumnsMeanNoOrphanDecay = predictedInactiveColumnsMetric.mean
+    predictedActiveColumnsMeanNoOrphanDecay = predictedActiveColumnsMetric.mean
+
+    # train TM on the same set of noisy sequences with orphan decay turned on
     self.init({"cellsPerColumn": 4,
                "activationThreshold": 8,
-               "predictedSegmentDecrement": 0.004})
+               "predictedSegmentDecrement": 0.04})
 
-    for _ in xrange(10):
+    for i in xrange(10):
       self.feedTM(sequenceNoisy[i])
+    self.tm.mmClearHistory()
 
     self._testTM(sequence)
+
     predictedInactiveColumnsMetric = self.tm.mmGetMetricFromTrace(
       self.tm.mmGetTracePredictedInactiveColumns())
-    predictedInactiveColumnsMean2 = predictedInactiveColumnsMetric.mean
+    predictedActiveColumnsMetric = self.tm.mmGetMetricFromTrace(
+      self.tm.mmGetTracePredictedActiveColumns())
 
-    self.assertGreater(predictedInactiveColumnsMean1, 0)
-    self.assertGreater(predictedInactiveColumnsMean1, predictedInactiveColumnsMean2)
+    predictedInactiveColumnsMeanOrphanDecay = predictedInactiveColumnsMetric.mean
+    predictedActiveColumnsMeanOrphanDecay = predictedActiveColumnsMetric.mean
 
+    self.assertGreater(predictedInactiveColumnsMeanNoOrphanDecay, 0)
+    self.assertGreater(predictedInactiveColumnsMeanNoOrphanDecay, predictedInactiveColumnsMeanOrphanDecay)
+    self.assertAlmostEqual(predictedActiveColumnsMeanNoOrphanDecay, predictedActiveColumnsMeanOrphanDecay)
   # ==============================
   # Overrides
   # ==============================


### PR DESCRIPTION
Fixes #2478 

@cogmission @chetan51 @rhyolight   Please review

@cogmission I found that predictedSegmentDecrement=0.004 is too small to have a measurable effect on the number of predicted inactive segment. I increased this parameter to 0.04 in the test. I also added the additional check to make sure there is the same number of predicted active columns with and without orphan decay.

Here is the result I got on this test. You can see that the only difference caused by orphan decay is a smaller number of predicted->inactive columns/cells

![image](https://cloud.githubusercontent.com/assets/5067931/9506513/60ffaca4-4bfd-11e5-944d-6ab3ab7d0d2c.png)


Instead of using a higher value of predictedSegmentDecrement, I could also increase the size of the training data to get a measurable effect. Here is the result with 50 set of random sequences and predictedSegmentDecrement=0.01

![image](https://cloud.githubusercontent.com/assets/5067931/9506596/e77100b2-4bfd-11e5-8f3a-b95cf5d747ee.png)


In practice, I think the default value of predictedSegmentDecrement should be small to allow multiple predictions. It will have an effect on reducing extra predictions with large enough datasets.
\
