### PR TITLE
Replace saving of all historical data points with a sliding window in AnomalyLikelihood class

### DIFF
--- a/nupic/algorithms/anomaly_likelihood.py
+++ b/nupic/algorithms/anomaly_likelihood.py
@@ -152,6 +152,12 @@ class AnomalyLikelihood(object):
   def _calcSkipRecords(numIngested, windowSize, learningPeriod):
     """Return the value of skipRecords for passing to estimateAnomalyLikelihoods
 
+    If `windowSize` is very large (bigger than the amount of data) then this
+    could just return `learningPeriod`. But when some values have fallen out of
+    the historical sliding window of anomaly records, then we have to take those
+    into account as well so we return the `learningPeriod` minus the number
+    shifted out.
+
     :param int numIngested: number of data points that have been added to the
       sliding window of historical data points.
     :param int windowSize: size of sliding window of historical data points.

--- a/nupic/algorithms/anomaly_likelihood.py
+++ b/nupic/algorithms/anomaly_likelihood.py
@@ -84,7 +84,7 @@ class AnomalyLikelihood(object):
     reasonable - we just need sufficient samples to get a decent estimate for
     the Gaussian. It's unlikely you will need to tune this since the Gaussian is
     re-estimated every 100 iterations.
-    
+
     Anomaly likelihood scores are reported at a flat 0.5 for claLearningPeriod +
     estimationSamples iterations.
     """
@@ -93,15 +93,16 @@ class AnomalyLikelihood(object):
     self._distribution = None
     self._probationaryPeriod = claLearningPeriod + estimationSamples
     self._claLearningPeriod = claLearningPeriod
-    
+
     # How often we re-estimate the Gaussian distribution. The ideal is to
     # re-estimate every iteration but this is a performance hit. In general the
     # system is not very sensitive to this number as long as it is small
     # relative to the total number of records processed.
-    self._reestimationPeriod = 100 
+    self._reestimationPeriod = 100
 
 
   def __eq__(self, o):
+    # pylint: disable=W0212
     return (isinstance(o, AnomalyLikelihood) and
             self._iteration == o._iteration and
             self._historicalScores == o._historicalScores and
@@ -109,16 +110,17 @@ class AnomalyLikelihood(object):
             self._probationaryPeriod == o._probationaryPeriod and
             self._claLearningPeriod == o._claLearningPeriod and
             self._reestimationPeriod == o._reestimationPeriod)
+    # pylint: enable=W0212
 
 
   def __str__(self):
     return ("AnomalyLikelihood: %s %s %s %s %s %s" % (
-            self._iteration,
-            self._historicalScores,
-            self._distribution,
-            self._probationaryPeriod,
-            self._claLearningPeriod,
-            self._reestimationPeriod) )
+      self._iteration,
+      self._historicalScores,
+      self._distribution,
+      self._probationaryPeriod,
+      self._claLearningPeriod,
+      self._reestimationPeriod) )
 
 
   @staticmethod
@@ -140,16 +142,16 @@ class AnomalyLikelihood(object):
     an anomaly given the historical distribution of anomaly scores. The closer
     the number is to 1, the higher the chance it is an anomaly.
 
-    @param value - the current metric ("raw") input value, eg. "orange", or 
+    @param value - the current metric ("raw") input value, eg. "orange", or
                    '21.2' (deg. Celsius), ...
     @param anomalyScore - the current anomaly score
-    @param timestamp - (optional) timestamp of the ocurrence, 
+    @param timestamp - (optional) timestamp of the ocurrence,
                        default (None) results in using iteration step.
     @return theanomalyLikelihood for this record.
     """
     if timestamp is None:
       timestamp = self._iteration
-      
+
     dataPoint = (timestamp, value, anomalyScore)
     # We ignore the first probationaryPeriod data points
     if len(self._historicalScores) < self._probationaryPeriod:
@@ -166,7 +168,7 @@ class AnomalyLikelihood(object):
 
       likelihoods, _, self._distribution = (
         updateAnomalyLikelihoods([dataPoint],
-          self._distribution)
+                                 self._distribution)
       )
       likelihood = 1.0 - likelihoods[0]
 
@@ -298,9 +300,9 @@ def estimateAnomalyLikelihoods(anomalyScores,
 
   # Compute averaged anomaly scores
   aggRecordList, historicalValues, total =  _anomalyScoreMovingAverage(
-                                              anomalyScores,
-                                              windowSize = averagingWindow,
-                                              verbosity = verbosity)
+    anomalyScores,
+    windowSize = averagingWindow,
+    verbosity = verbosity)
   s = [r[2] for r in aggRecordList]
   dataValues = numpy.array(s)
 
@@ -340,7 +342,7 @@ def estimateAnomalyLikelihoods(anomalyScores,
       "windowSize":       averagingWindow,
     },
     "historicalLikelihoods":
-          list(likelihoods[-min(averagingWindow, len(likelihoods)):]),
+      list(likelihoods[-min(averagingWindow, len(likelihoods)):]),
   }
 
   if verbosity > 1:
@@ -358,7 +360,7 @@ def estimateAnomalyLikelihoods(anomalyScores,
 
 def updateAnomalyLikelihoods(anomalyScores,
                              params,
-                             verbosity=0): # pylint: disable=W0613
+                             verbosity=0):
   """
   Compute updated probabilities for anomalyScores using the given params.
 
@@ -459,7 +461,7 @@ def _filterLikelihoods(likelihoods,
   """
   redThreshold    = 1.0 - redThreshold
   yellowThreshold = 1.0 - yellowThreshold
-  
+
   # The first value is untouched
   filteredLikelihoods = [likelihoods[0]]
 
@@ -521,7 +523,7 @@ def _anomalyScoreMovingAverage(anomalyScores,
 
 
 
-def estimateNormal(sampleData, performLowerBoundCheck=True):  # pylint: disable=W0613
+def estimateNormal(sampleData, performLowerBoundCheck=True):
   """
   :param sampleData:
   :type sampleData: Numpy array.
@@ -531,9 +533,9 @@ def estimateNormal(sampleData, performLowerBoundCheck=True):  # pylint: disable=
       the ``sampleData``.
   """
   params = {
-      "name": "normal",
-      "mean": numpy.mean(sampleData),
-      "variance": numpy.var(sampleData),
+    "name": "normal",
+    "mean": numpy.mean(sampleData),
+    "variance": numpy.var(sampleData),
   }
 
   if performLowerBoundCheck:
@@ -567,10 +569,10 @@ def nullDistribution(verbosity=0):
   if verbosity>0:
     print "Returning nullDistribution"
   return {
-      "name": "normal",
-      "mean": 0.5,
-      "variance": 1e6,
-      "stdev": 1e3,
+    "name": "normal",
+    "mean": 0.5,
+    "variance": 1e6,
+    "stdev": 1e3,
   }
 
 
@@ -603,7 +605,7 @@ def isValidEstimatorParams(p):
     by ``estimateAnomalyLikelihoods()`` or ``updateAnomalyLikelihoods``,
     ``False`` otherwise.  Just does some basic validation.
   """
-  if type(p) != type({}):
+  if not isinstance(p, dict):
     return False
   if not p.has_key("distribution"):
     return False
@@ -611,8 +613,7 @@ def isValidEstimatorParams(p):
     return False
   dist = p["distribution"]
   if not (dist.has_key("mean") and dist.has_key("name")
-          and dist.has_key("variance") and dist.has_key("stdev")
-          ):
+          and dist.has_key("variance") and dist.has_key("stdev")):
     return False
 
   return True

--- a/tests/unit/nupic/algorithms/anomaly_likelihood_test.py
+++ b/tests/unit/nupic/algorithms/anomaly_likelihood_test.py
@@ -22,6 +22,9 @@
 
 """Unit tests for anomaly likelihood module."""
 
+# disable pylint warning: "Access to a protected member xxxxx of a client class"
+# pylint: disable=W0212
+
 import copy
 import datetime
 import math

--- a/tests/unit/nupic/algorithms/anomaly_likelihood_test.py
+++ b/tests/unit/nupic/algorithms/anomaly_likelihood_test.py
@@ -498,7 +498,7 @@ class AnomalyLikelihoodTest(TestCaseBase):
 
   def testFilterLikelihodsInputType(self):
     """
-    Calls _filterLikelihoods with both input types -- numpy array of floats and 
+    Calls _filterLikelihoods with both input types -- numpy array of floats and
     list of floats.
     """
     l =[0.0, 0.0, 0.3, 0.3, 0.5]
@@ -533,10 +533,10 @@ class AnomalyLikelihoodTest(TestCaseBase):
     l2[1] = 1 - yellowThreshold
     l2[7] = 1 - yellowThreshold
     l3 = an._filterLikelihoods(l, redThreshold=redThreshold)
-    
+
     [self.assertAlmostEqual(l2[i], l3[i], msg="Failure in case (i)")
       for i in range(len(l2))]
-    
+
     # Case (ii): values at indices 1-10 should be filtered to yellowzone
     l = numpy.array([0.999978229, 0.999978229, 0.999999897, 1, 1, 1, 1,
                      0.999999994, 0.999999966, 0.999999966, 0.999994331,
@@ -545,7 +545,7 @@ class AnomalyLikelihoodTest(TestCaseBase):
     l2 = copy.copy(l)
     l2[1:11] = 1 - yellowThreshold
     l3 = an._filterLikelihoods(l, redThreshold=redThreshold)
-    
+
     [self.assertAlmostEqual(l2[i], l3[i], msg="Failure in case (ii)")
       for i in range(len(l2))]
 
@@ -567,6 +567,44 @@ class AnomalyLikelihoodTest(TestCaseBase):
       for i in range(len(l2b))]
     self.assertFalse(numpy.array_equal(l3a, l3b),
       msg="Failure in case (iii), list 3")
+
+
+  def testForceModelRefresh(self):
+    l = an.AnomalyLikelihood(claLearningPeriod=2, estimationSamples=2)
+
+    self.assertIsNone(l._distribution)
+
+    l.anomalyProbability(5, 0.1, timestamp=1) # burn in
+    l.anomalyProbability(5, 0.1, timestamp=2)
+    l.anomalyProbability(5, 0.1, timestamp=3)
+    l.anomalyProbability(5, 0.1, timestamp=4)
+    l.anomalyProbability(1, 0.3, timestamp=5)
+
+    self.assertIsNotNone(l._distribution)
+
+    l.forceModelRefresh()
+    self.assertIsNone(l._distribution)
+
+    l.anomalyProbability(1, 0.3, timestamp=5)
+    self.assertIsNotNone(l._distribution)
+
+
+  def testEstimationWindowSize(self):
+    l = an.AnomalyLikelihood(claLearningPeriod=2,
+                             estimationSamples=2,
+                             estimationWindowSize=3)
+
+    l.anomalyProbability(5, 0.1, timestamp=1) # burn in
+    self.assertEqual(len(l._historicalScores), 1)
+
+    l.anomalyProbability(5, 0.1, timestamp=2)
+    self.assertEqual(len(l._historicalScores), 2)
+
+    l.anomalyProbability(5, 0.1, timestamp=3)
+    self.assertEqual(len(l._historicalScores), 3)
+
+    l.anomalyProbability(5, 0.1, timestamp=4)
+    self.assertEqual(len(l._historicalScores), 3)
 
 
   def testEquals(self):


### PR DESCRIPTION
Replace saving of all historical data points with a sliding window in AnomalyLikelihood class.

NOTE: This improved memory and performance a ton! `for i in xrange(1000000): a.anomalyProbability(1.0, 0.9)` went from multiple hours to just under 10 minutes on my MacBookPro.

Also, added a new method AnomalyLikelihood.forceModelRefresh: "Force refresh of the anomaly likelihood model's state"


CC @scottpurdy, @subutai, @BoltzmannBrain 

@jcasner, @rhyolight: can we pull this into 0.2.12? https://github.com/numenta/numenta-apps/pull/277 depends on it.