### PR TITLE
Use logging.debug for emitting the message about not being able to import matplotlib

### DIFF
--- a/nupic/research/monitor_mixin/plot.py
+++ b/nupic/research/monitor_mixin/plot.py
@@ -23,17 +23,19 @@
 Plot class used in monitor mixin framework.
 """
 
+import logging
 import os
-import traceback
-import sys
 
 try:
   # We import in here to avoid creating a matplotlib dependency in nupic.
   import matplotlib.pyplot as plt
   import matplotlib.cm as cm
 except ImportError:
-  print >> sys.stderr, "Cannot import matplotlib. Plot class will not work."
-  print >> sys.stderr, traceback.format_exc() + "\n"
+  # Suppress; we log it at debug level to avoid polluting the logs of apps
+  # and services that don't care about plotting
+  logging.debug("Cannot import matplotlib. Plot class will not work.",
+                exc_info=True)
+
 
 
 class Plot(object):


### PR DESCRIPTION
Use logging.debug for emitting the message about not being able to import matplotlib; we log it at debug level to avoid polluting the logs of apps and services that don't care about plotting.

The traceback was ending up in logs (e.g., htmengine's model_scheduler.log), waisting time to investigate the traceback.