### PR TITLE
Include additional file types in MANIFEST.in, consistent with setup.py

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,4 @@ recursive-include external/darwin64 swig *.a
 recursive-include external/linux64 swig *.a
 
 recursive-include src/nupic/datafiles *.csv *.txt
-recursive-include src/nupic *.capnp
+recursive-include src/nupic *.capnp *.json *.tpl *.txt *.xml


### PR DESCRIPTION
Fixes #2590

In my case, in which the expected xml files are now included:

```
running sdist
running egg_info
writing requirements to src/nupic.egg-info/requires.txt
writing src/nupic.egg-info/PKG-INFO
writing namespace_packages to src/nupic.egg-info/namespace_packages.txt
writing top-level names to src/nupic.egg-info/top_level.txt
writing dependency_links to src/nupic.egg-info/dependency_links.txt
reading manifest file 'src/nupic.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'src/nupic.egg-info/SOURCES.txt'
running check
creating nupic-0.3.3.dev0
creating nupic-0.3.3.dev0/external
creating nupic-0.3.3.dev0/external/common
creating nupic-0.3.3.dev0/external/common/share
creating nupic-0.3.3.dev0/external/common/share/swig
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/cffi
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/clisp
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/gcj
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/modula3
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/pike
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
creating nupic-0.3.3.dev0/external/common/share/swig/3.0.2/uffi
creating nupic-0.3.3.dev0/external/darwin64
creating nupic-0.3.3.dev0/external/darwin64/bin
creating nupic-0.3.3.dev0/external/darwin64/lib
creating nupic-0.3.3.dev0/external/linux64
creating nupic-0.3.3.dev0/external/linux64/bin
creating nupic-0.3.3.dev0/external/linux64/lib
creating nupic-0.3.3.dev0/src
creating nupic-0.3.3.dev0/src/nupic
creating nupic-0.3.3.dev0/src/nupic.egg-info
creating nupic-0.3.3.dev0/src/nupic/algorithms
creating nupic-0.3.3.dev0/src/nupic/bindings
creating nupic-0.3.3.dev0/src/nupic/bindings/proto
creating nupic-0.3.3.dev0/src/nupic/data
creating nupic-0.3.3.dev0/src/nupic/data/generators
creating nupic-0.3.3.dev0/src/nupic/database
creating nupic-0.3.3.dev0/src/nupic/datafiles
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/firstOrder
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/categories
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/linear_two_fields
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/linear_two_plus_one_fields
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/sum_two_fields_plus_extra_field
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/temporal
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/temporal/categories
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym/raw
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/1
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/2
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/3
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/4
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/5
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/6
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/7
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/8
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/9
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/raw
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/qa
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/sawtooth
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/sine
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/waveforms
creating nupic-0.3.3.dev0/src/nupic/datafiles/extra/waveforms/raw
creating nupic-0.3.3.dev0/src/nupic/datafiles/swarming
creating nupic-0.3.3.dev0/src/nupic/datafiles/waveforms
creating nupic-0.3.3.dev0/src/nupic/encoders
creating nupic-0.3.3.dev0/src/nupic/engine
creating nupic-0.3.3.dev0/src/nupic/engine/common_networks
creating nupic-0.3.3.dev0/src/nupic/frameworks
creating nupic-0.3.3.dev0/src/nupic/frameworks/opf
creating nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
creating nupic-0.3.3.dev0/src/nupic/image
creating nupic-0.3.3.dev0/src/nupic/math
creating nupic-0.3.3.dev0/src/nupic/regions
creating nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
creating nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
creating nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
creating nupic-0.3.3.dev0/src/nupic/regions/RecordSensorFilters
creating nupic-0.3.3.dev0/src/nupic/regions/extra
creating nupic-0.3.3.dev0/src/nupic/research
creating nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
creating nupic-0.3.3.dev0/src/nupic/support
creating nupic-0.3.3.dev0/src/nupic/support/unittesthelpers
creating nupic-0.3.3.dev0/src/nupic/swarming
creating nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
creating nupic-0.3.3.dev0/src/nupic/swarming/hypersearch
creating nupic-0.3.3.dev0/src/nupic/swarming/jsonschema
creating nupic-0.3.3.dev0/src/nupic/test
making hard links in nupic-0.3.3.dev0...
hard linking .nupic_modules -> nupic-0.3.3.dev0
hard linking CHANGELOG.md -> nupic-0.3.3.dev0
hard linking CONTRIBUTING.md -> nupic-0.3.3.dev0
hard linking DEPENDENCIES.md -> nupic-0.3.3.dev0
hard linking LICENSE.txt -> nupic-0.3.3.dev0
hard linking MANIFEST.in -> nupic-0.3.3.dev0
hard linking README.md -> nupic-0.3.3.dev0
hard linking VERSION -> nupic-0.3.3.dev0
hard linking bdist_egg.txt -> nupic-0.3.3.dev0
hard linking setup.cfg -> nupic-0.3.3.dev0
hard linking setup.py -> nupic-0.3.3.dev0
hard linking testFl316r.txt -> nupic-0.3.3.dev0
hard linking testGkcLfy.txt -> nupic-0.3.3.dev0
hard linking testcq1iZU.txt -> nupic-0.3.3.dev0
hard linking testsKglq0.txt -> nupic-0.3.3.dev0
hard linking external/common/requirements.txt -> nupic-0.3.3.dev0/external/common
hard linking external/common/share/swig/3.0.2/allkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/attribute.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/cmalloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/constraints.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/cpointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/cstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/cwstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/intrusive_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/inttypes.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/math.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/pointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/runtime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/stdint.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swig.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swigarch.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swigerrors.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swiginit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swiglabels.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swigrun.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swigrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swigwarn.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/swigwarnings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/wchar.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/windows.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2
hard linking external/common/share/swig/3.0.2/allegrocl/allegrocl.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
hard linking external/common/share/swig/3.0.2/allegrocl/inout_typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
hard linking external/common/share/swig/3.0.2/allegrocl/longlongs.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
hard linking external/common/share/swig/3.0.2/allegrocl/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
hard linking external/common/share/swig/3.0.2/allegrocl/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
hard linking external/common/share/swig/3.0.2/allegrocl/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/allegrocl
hard linking external/common/share/swig/3.0.2/cffi/cffi.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/cffi
hard linking external/common/share/swig/3.0.2/chicken/chicken.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/chickenkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/chickenrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/multi-generic.scm -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/swigclosprefix.scm -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/tinyclos-multi-generic.patch -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/chicken/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/chicken
hard linking external/common/share/swig/3.0.2/clisp/clisp.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/clisp
hard linking external/common/share/swig/3.0.2/csharp/arrays_csharp.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/boost_intrusive_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/boost_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/csharp.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/csharphead.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/csharpkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/enums.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/enumsimple.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/enumtypesafe.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_auto_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/std_wstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/swigtype_inout.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/csharp/wchar.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/csharp
hard linking external/common/share/swig/3.0.2/d/boost_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/cpointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/d.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dclassgen.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/ddirectives.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/denums.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dexception.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dhead.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dmemberfunctionpointers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/doperators.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dprimitives.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dswigtype.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/dvoid.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/d/wrapperloader.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/d
hard linking external/common/share/swig/3.0.2/gcj/cni.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/gcj
hard linking external/common/share/swig/3.0.2/gcj/cni.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/gcj
hard linking external/common/share/swig/3.0.2/gcj/javaprims.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/gcj
hard linking external/common/share/swig/3.0.2/go/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/go.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/gokw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/goruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/go/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/go
hard linking external/common/share/swig/3.0.2/guile/common.scm -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/cplusplus.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/guile.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/guile_scm.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/guile_scm_run.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/guilemain.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/interpreter.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/list-vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/pointer-in-out.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/ports.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/swigrun.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/guile/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/guile
hard linking external/common/share/swig/3.0.2/java/arrays_java.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/boost_intrusive_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/boost_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/enums.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/enumsimple.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/enumtypesafe.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/enumtypeunsafe.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/java.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/javahead.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/javakw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_auto_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/std_wstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/java/various.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/java
hard linking external/common/share/swig/3.0.2/javascript/jsc/arrays_javascript.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/ccomplex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascript.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptcode.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptcomplex.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascripthelpers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascriptstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/javascripttypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/jsc/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/jsc
hard linking external/common/share/swig/3.0.2/javascript/v8/arrays_javascript.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/ccomplex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascript.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptcode.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptcomplex.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascripthelpers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascriptstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/javascripttypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/javascript/v8/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/javascript/v8
hard linking external/common/share/swig/3.0.2/lua/_std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/lua.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/lua_fnptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/luakw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/luarun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/luaruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/luatypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/lua/wchar.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/lua
hard linking external/common/share/swig/3.0.2/modula3/modula3.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/modula3
hard linking external/common/share/swig/3.0.2/modula3/modula3head.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/modula3
hard linking external/common/share/swig/3.0.2/modula3/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/modula3
hard linking external/common/share/swig/3.0.2/mzscheme/mzrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/mzscheme.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/mzscheme/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/mzscheme
hard linking external/common/share/swig/3.0.2/ocaml/carray.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/class.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/cstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/ocaml.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/ocaml.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/ocamldec.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/ocamlkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/preamble.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/swig.ml -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/swig.mli -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/swigp4.ml -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/typecheck.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/ocaml/typeregister.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ocaml
hard linking external/common/share/swig/3.0.2/octave/attribute.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/boost_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/cmalloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/implicit.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octave.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octcomplex.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octcontainer.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octiterators.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octopers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octstdcommon.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octtypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/octuserdir.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_alloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_basic_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_carray.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_char_traits.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_container.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/octave/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/octave
hard linking external/common/share/swig/3.0.2/perl5/Makefile.pl -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/attribute.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/cmalloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/cni.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/cpointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/cstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/jstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/noembed.h -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perl5.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlerrors.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlhead.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlmacros.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlmain.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlopers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perlstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perltypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/perluserdir.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/reference.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/perl5/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/perl5
hard linking external/common/share/swig/3.0.2/php/const.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/globalvar.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/php.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/phpinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/phpkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/phppointers.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/phprun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/php/utils.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/php
hard linking external/common/share/swig/3.0.2/pike/pike.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/pike
hard linking external/common/share/swig/3.0.2/pike/pikekw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/pike
hard linking external/common/share/swig/3.0.2/pike/pikerun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/pike
hard linking external/common/share/swig/3.0.2/pike/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/pike
hard linking external/common/share/swig/3.0.2/python/argcargv.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/attribute.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/boost_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/builtin.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/ccomplex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/cmalloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/cni.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/cpointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/cstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/cwstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/defarg.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/embed.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/embed15.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/file.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/implicit.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/jstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyabc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyapi.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pybackward.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pybuffer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyclasses.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pycomplex.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pycontainer.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pydocs.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyerrors.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyhead.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyiterators.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pymacros.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyname_compat.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyopers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pystdcommon.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pystrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/python.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pythonkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pythreads.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pytuplehlp.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pytypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pyuserdir.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/pywstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_alloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_auto_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_basic_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_carray.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_char_traits.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_container.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_ios.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_iostream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_multimap.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_multiset.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_set.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_sstream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_streambuf.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_unordered_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_unordered_multimap.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_unordered_multiset.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_unordered_set.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_vectora.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_wios.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_wiostream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_wsstream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_wstreambuf.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/std_wstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/python/wchar.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/python
hard linking external/common/share/swig/3.0.2/r/boost_shared_ptr.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/r.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/rcontainer.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/rfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/rkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/ropers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/rrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/rstdcommon.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/rtype.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/srun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_alloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_container.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/r/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/r
hard linking external/common/share/swig/3.0.2/ruby/Makefile.swig -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/argcargv.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/attribute.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/cmalloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/cni.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/cpointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/cstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/director.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/embed.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/extconf.rb -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/file.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/jstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/progargcargv.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/ruby.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyapi.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyautodoc.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyclasses.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubycomplex.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubycontainer.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubycontainer_extended.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubydef.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyerrors.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyhead.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyiterators.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubykw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubymacros.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyopers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubystdautodoc.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubystdcommon.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubystdfunctors.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubystrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubytracking.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubytypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubyuserdir.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/rubywstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_alloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_basic_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_char_traits.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_complex.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_container.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_functors.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_ios.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_iostream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_multimap.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_multiset.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_queue.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_set.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_sstream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_stack.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_streambuf.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_vectora.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/std_wstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/timeval.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/ruby/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/ruby
hard linking external/common/share/swig/3.0.2/std/_std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_alloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_basic_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_carray.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_char_traits.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_container.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_ios.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_iostream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_list.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_multimap.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_multiset.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_queue.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_set.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_sstream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_stack.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_streambuf.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_unordered_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_unordered_multimap.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_unordered_multiset.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_unordered_set.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_vectora.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_wios.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_wiostream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_wsstream.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_wstreambuf.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/std/std_wstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/std
hard linking external/common/share/swig/3.0.2/tcl/attribute.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/carrays.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/cdata.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/cmalloc.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/cni.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/cpointer.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/cstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/cwstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/exception.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/factory.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/jstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_common.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_deque.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_except.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_map.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_pair.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_string.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_vector.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/std_wstring.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/stl.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tcl8.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclapi.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclerrors.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclfragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclinit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclinterp.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclkw.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclmacros.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclopers.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclprimtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclresult.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclrun.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclruntime.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclsh.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tcltypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tcluserdir.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/tclwstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/typemaps.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/tcl/wish.i -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/tcl
hard linking external/common/share/swig/3.0.2/typemaps/attribute.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/carrays.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/cdata.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/cmalloc.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/cpointer.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/cstring.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/cstrings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/cwstring.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/enumint.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/exception.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/factory.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/fragments.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/implicit.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/inoutlist.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/misctypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/primtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/ptrtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/std_except.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/std_string.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/std_strings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/std_wstring.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/string.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/strings.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/swigmacros.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/swigobject.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/swigtype.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/swigtypemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/traits.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/typemaps.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/valtypes.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/void.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/typemaps/wstring.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/typemaps
hard linking external/common/share/swig/3.0.2/uffi/uffi.swg -> nupic-0.3.3.dev0/external/common/share/swig/3.0.2/uffi
hard linking external/darwin64/bin/swig -> nupic-0.3.3.dev0/external/darwin64/bin
hard linking external/darwin64/lib/libjpeg.a -> nupic-0.3.3.dev0/external/darwin64/lib
hard linking external/linux64/bin/swig -> nupic-0.3.3.dev0/external/linux64/bin
hard linking external/linux64/lib/libjpeg.a -> nupic-0.3.3.dev0/external/linux64/lib
hard linking src/nupic/__init__.py -> nupic-0.3.3.dev0/src/nupic
hard linking src/nupic/movingaverage.capnp -> nupic-0.3.3.dev0/src/nupic
hard linking src/nupic/simple_server.py -> nupic-0.3.3.dev0/src/nupic
hard linking src/nupic/utils.py -> nupic-0.3.3.dev0/src/nupic
hard linking src/nupic.egg-info/PKG-INFO -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic.egg-info/SOURCES.txt -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic.egg-info/dependency_links.txt -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic.egg-info/namespace_packages.txt -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic.egg-info/not-zip-safe -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic.egg-info/requires.txt -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic.egg-info/top_level.txt -> nupic-0.3.3.dev0/src/nupic.egg-info
hard linking src/nupic/algorithms/CLAClassifier.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/algorithms/KNNClassifier.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/algorithms/__init__.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/algorithms/anomaly.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/algorithms/anomaly_likelihood.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/algorithms/cla_classifier_diff.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/algorithms/cla_classifier_factory.py -> nupic-0.3.3.dev0/src/nupic/algorithms
hard linking src/nupic/bindings/__init__.py -> nupic-0.3.3.dev0/src/nupic/bindings
hard linking src/nupic/bindings/proto/__init__.py -> nupic-0.3.3.dev0/src/nupic/bindings/proto
hard linking src/nupic/data/CategoryFilter.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/__init__.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/aggregator.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/dictutils.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/fieldmeta.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/file_record_stream.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/filters.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/functionsource.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/inference_shifter.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/joiner.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/jsonhelpers.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/record_stream.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/sorter.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/stats.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/stats_v2.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/stream_reader.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/testSchema.json -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/utils.py -> nupic-0.3.3.dev0/src/nupic/data
hard linking src/nupic/data/generators/__init__.py -> nupic-0.3.3.dev0/src/nupic/data/generators
hard linking src/nupic/data/generators/anomalyzer.py -> nupic-0.3.3.dev0/src/nupic/data/generators
hard linking src/nupic/data/generators/data_generator.py -> nupic-0.3.3.dev0/src/nupic/data/generators
hard linking src/nupic/data/generators/distributions.py -> nupic-0.3.3.dev0/src/nupic/data/generators
hard linking src/nupic/data/generators/pattern_machine.py -> nupic-0.3.3.dev0/src/nupic/data/generators
hard linking src/nupic/data/generators/sequence_machine.py -> nupic-0.3.3.dev0/src/nupic/data/generators
hard linking src/nupic/database/ClientJobsDAO.py -> nupic-0.3.3.dev0/src/nupic/database
hard linking src/nupic/database/Connection.py -> nupic-0.3.3.dev0/src/nupic/database
hard linking src/nupic/database/__init__.py -> nupic-0.3.3.dev0/src/nupic/database
hard linking src/nupic/datafiles/__init__.py -> nupic-0.3.3.dev0/src/nupic/datafiles
hard linking src/nupic/datafiles/extra/firstOrder/categories.txt -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/firstOrder
hard linking src/nupic/datafiles/extra/firstOrder/fo_100000_10_train_resets.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/firstOrder
hard linking src/nupic/datafiles/extra/firstOrder/fo_10000_10_test_resets.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/firstOrder
hard linking src/nupic/datafiles/extra/firstOrder/fo_10000_10_train_resets.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/firstOrder
hard linking src/nupic/datafiles/extra/firstOrder/fo_1000_10_train_resets.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/firstOrder
hard linking src/nupic/datafiles/extra/generated/spatial/categories/sample3.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/categories
hard linking src/nupic/datafiles/extra/generated/spatial/categories/sample4.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/categories
hard linking src/nupic/datafiles/extra/generated/spatial/categories/sample5.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/categories
hard linking src/nupic/datafiles/extra/generated/spatial/linear_two_fields/sample1.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/linear_two_fields
hard linking src/nupic/datafiles/extra/generated/spatial/linear_two_fields/sample2.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/linear_two_fields
hard linking src/nupic/datafiles/extra/generated/spatial/linear_two_fields/sample3.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/linear_two_fields
hard linking src/nupic/datafiles/extra/generated/spatial/linear_two_plus_one_fields/sample1.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/linear_two_plus_one_fields
hard linking src/nupic/datafiles/extra/generated/spatial/sum_two_fields_plus_extra_field/sample1.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/spatial/sum_two_fields_plus_extra_field
hard linking src/nupic/datafiles/extra/generated/temporal/categories/sample1.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/temporal/categories
hard linking src/nupic/datafiles/extra/generated/temporal/categories/sample2.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/generated/temporal/categories
hard linking src/nupic/datafiles/extra/gym/agg_gym_hours_5f8N_pp.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_clean_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_clean_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_fri_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_fri_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_mon_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_mon_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_sat_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_sat_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_sun_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_sun_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_test_ext.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_thu_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_thu_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_tue_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_tue_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_wed_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_melbourne_wed_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/gym_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym
hard linking src/nupic/datafiles/extra/gym/raw/Attendance_Clubs_Oct.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym/raw
hard linking src/nupic/datafiles/extra/gym/raw/Attendance_Clubs_Sept.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym/raw
hard linking src/nupic/datafiles/extra/gym/raw/README.txt -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym/raw
hard linking src/nupic/datafiles/extra/gym/raw/all_group1_clubs_detail.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym/raw
hard linking src/nupic/datafiles/extra/gym/raw/all_group1_clubs_summaries.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/gym/raw
hard linking src/nupic/datafiles/extra/hotgym/hotgym.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/joined_mosman_2011.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/joined_mosman_crossvalidation.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/rec-center-hourly.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/rec-center.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/test_hotgym.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/train_hotgym.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/train_hotgym_2011.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym
hard linking src/nupic/datafiles/extra/hotgym/missingdata/1/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/1
hard linking src/nupic/datafiles/extra/hotgym/missingdata/1/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/1
hard linking src/nupic/datafiles/extra/hotgym/missingdata/1/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/1
hard linking src/nupic/datafiles/extra/hotgym/missingdata/1/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/1
hard linking src/nupic/datafiles/extra/hotgym/missingdata/2/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/2
hard linking src/nupic/datafiles/extra/hotgym/missingdata/2/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/2
hard linking src/nupic/datafiles/extra/hotgym/missingdata/2/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/2
hard linking src/nupic/datafiles/extra/hotgym/missingdata/2/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/2
hard linking src/nupic/datafiles/extra/hotgym/missingdata/3/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/3
hard linking src/nupic/datafiles/extra/hotgym/missingdata/3/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/3
hard linking src/nupic/datafiles/extra/hotgym/missingdata/3/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/3
hard linking src/nupic/datafiles/extra/hotgym/missingdata/3/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/3
hard linking src/nupic/datafiles/extra/hotgym/missingdata/4/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/4
hard linking src/nupic/datafiles/extra/hotgym/missingdata/4/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/4
hard linking src/nupic/datafiles/extra/hotgym/missingdata/4/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/4
hard linking src/nupic/datafiles/extra/hotgym/missingdata/4/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/4
hard linking src/nupic/datafiles/extra/hotgym/missingdata/5/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/5
hard linking src/nupic/datafiles/extra/hotgym/missingdata/5/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/5
hard linking src/nupic/datafiles/extra/hotgym/missingdata/5/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/5
hard linking src/nupic/datafiles/extra/hotgym/missingdata/5/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/5
hard linking src/nupic/datafiles/extra/hotgym/missingdata/6/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/6
hard linking src/nupic/datafiles/extra/hotgym/missingdata/6/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/6
hard linking src/nupic/datafiles/extra/hotgym/missingdata/6/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/6
hard linking src/nupic/datafiles/extra/hotgym/missingdata/6/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/6
hard linking src/nupic/datafiles/extra/hotgym/missingdata/7/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/7
hard linking src/nupic/datafiles/extra/hotgym/missingdata/7/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/7
hard linking src/nupic/datafiles/extra/hotgym/missingdata/7/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/7
hard linking src/nupic/datafiles/extra/hotgym/missingdata/7/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/7
hard linking src/nupic/datafiles/extra/hotgym/missingdata/8/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/8
hard linking src/nupic/datafiles/extra/hotgym/missingdata/8/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/8
hard linking src/nupic/datafiles/extra/hotgym/missingdata/8/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/8
hard linking src/nupic/datafiles/extra/hotgym/missingdata/8/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/8
hard linking src/nupic/datafiles/extra/hotgym/missingdata/9/agg_joined_mosman_test_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/9
hard linking src/nupic/datafiles/extra/hotgym/missingdata/9/agg_joined_mosman_train_hours_24.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/9
hard linking src/nupic/datafiles/extra/hotgym/missingdata/9/joined_mosman_test.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/9
hard linking src/nupic/datafiles/extra/hotgym/missingdata/9/joined_mosman_train.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/missingdata/9
hard linking src/nupic/datafiles/extra/hotgym/raw/README.txt -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/raw
hard linking src/nupic/datafiles/extra/hotgym/raw/club_hours.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/raw
hard linking src/nupic/datafiles/extra/hotgym/raw/gym_input.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/raw
hard linking src/nupic/datafiles/extra/hotgym/raw/max_temps.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/raw
hard linking src/nupic/datafiles/extra/hotgym/raw/min_temps.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/hotgym/raw
hard linking src/nupic/datafiles/extra/qa/delta.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/qa
hard linking src/nupic/datafiles/extra/sawtooth/sawtooth.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/sawtooth
hard linking src/nupic/datafiles/extra/sine/sine.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/sine
hard linking src/nupic/datafiles/extra/waveforms/raw/sine.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/waveforms/raw
hard linking src/nupic/datafiles/extra/waveforms/raw/squareABLong.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/waveforms/raw
hard linking src/nupic/datafiles/extra/waveforms/raw/squareABSuperExtraLong.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/extra/waveforms/raw
hard linking src/nupic/datafiles/swarming/test_data.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/swarming
hard linking src/nupic/datafiles/waveforms/higherOrder.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/waveforms
hard linking src/nupic/datafiles/waveforms/multiStepBranch.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/waveforms
hard linking src/nupic/datafiles/waveforms/rising.csv -> nupic-0.3.3.dev0/src/nupic/datafiles/waveforms
hard linking src/nupic/encoders/__init__.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/adaptivescalar.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/adaptivescalar.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/base.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/category.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/category.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/coordinate.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/coordinate.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/date.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/date.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/delta.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/delta.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/geospatial_coordinate.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/geospatial_coordinate.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/log.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/logenc.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/multi.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/multi.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/pass_through.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/pass_through_encoder.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/random_distributed_scalar.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/random_distributed_scalar.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/scalar.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/scalar.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/scalarspace.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/sdrcategory.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/sdrcategory.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/sparse_pass_through_encoder.capnp -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/sparse_pass_through_encoder.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/encoders/utils.py -> nupic-0.3.3.dev0/src/nupic/encoders
hard linking src/nupic/engine/__init__.py -> nupic-0.3.3.dev0/src/nupic/engine
hard linking src/nupic/engine/common_networks/__init__.py -> nupic-0.3.3.dev0/src/nupic/engine/common_networks
hard linking src/nupic/frameworks/__init__.py -> nupic-0.3.3.dev0/src/nupic/frameworks
hard linking src/nupic/frameworks/opf/__init__.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/clamodel.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/clamodel_classifier_helper.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/clamodelcallbacks.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/client.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/exceptions.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/expdescriptionapi.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/expdescriptionhelpers.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/experiment_runner.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/metrics.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/model.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/modelcallbacks.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/modelfactory.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/opfbasicenvironment.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/opfenvironment.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/opfhelpers.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/opftaskdriver.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/opfutils.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/periodic.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/predictionmetricsmanager.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/previousvaluemodel.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/safe_interpreter.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/two_gram_model.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf
hard linking src/nupic/frameworks/opf/jsonschema/__init__.py -> nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
hard linking src/nupic/frameworks/opf/jsonschema/nupicControlSchema.json -> nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
hard linking src/nupic/frameworks/opf/jsonschema/opfLoggingPreferencesSchema.json -> nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
hard linking src/nupic/frameworks/opf/jsonschema/opfTaskControlSchema.json -> nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
hard linking src/nupic/frameworks/opf/jsonschema/opfTaskSchema.json -> nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
hard linking src/nupic/frameworks/opf/jsonschema/stream_def.json -> nupic-0.3.3.dev0/src/nupic/frameworks/opf/jsonschema
hard linking src/nupic/image/__init__.py -> nupic-0.3.3.dev0/src/nupic/image
hard linking src/nupic/math/__init__.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/cross.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/dist.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/logarithms.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/mvn.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/proposal.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/roc_utils.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/math/stats.py -> nupic-0.3.3.dev0/src/nupic/math
hard linking src/nupic/regions/AnomalyRegion.capnp -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/AnomalyRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/CLAClassifierRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/ImageSensor.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/KNNAnomalyClassifierRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/KNNClassifierRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/PyRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/RecordSensor.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/SPRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/SVMClassifierNode.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/Spec.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/TPRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/TestNode.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/TestRegion.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/UnimportableNode.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/__init__.py -> nupic-0.3.3.dev0/src/nupic/regions
hard linking src/nupic/regions/ImageSensorExplorers/BaseExplorer.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/BlockSpread.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/CrossSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/ExhaustiveSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/EyeMovements.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/Flash.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/ImageSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/InwardSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/Jiggle.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/ManualSaliency.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/MultiSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/OnionBlock.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/OnionSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/PatrolSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/RandomEyeMovements.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/RandomFlash.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/RandomJump.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/RandomSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/RepetitiveSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/SpiralSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/ToCenterSweep.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorExplorers/__init__.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorExplorers
hard linking src/nupic/regions/ImageSensorFilters/AddBackgroundImage.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/AddNoise.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/AffineTransform.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/BaseFilter.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/BoxFixer.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Brightness.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/CenterSurroundConvolution.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/CenteredMultipleScales.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Contrast.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Convolution.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Crop.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/EqualizeHistogram.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/FillBackground.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Flip.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/GaborConvolution.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/GaborFilter.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/GaussianBlur.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Gradient.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/HistogramShift.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Lines.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/LogPolar.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Mirror.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/MultipleScales.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/NormalizeContrast.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Occlusion.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/PadToFit.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Resize.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Rotation2D.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/ScaleToFit.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Thicken.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/Tracking.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/ImageSensorFilters/__init__.py -> nupic-0.3.3.dev0/src/nupic/regions/ImageSensorFilters
hard linking src/nupic/regions/PictureSensorExplorers/HorizontalBlock.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/__init__.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/block.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/block1DOF.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/blockSpread.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/center.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/horizontal.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/inward.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/random.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/random1DOF.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/rotate.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/rotate_block.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/PictureSensorExplorers/vertical.py -> nupic-0.3.3.dev0/src/nupic/regions/PictureSensorExplorers
hard linking src/nupic/regions/RecordSensorFilters/AddNoise.py -> nupic-0.3.3.dev0/src/nupic/regions/RecordSensorFilters
hard linking src/nupic/regions/RecordSensorFilters/ModifyFields.py -> nupic-0.3.3.dev0/src/nupic/regions/RecordSensorFilters
hard linking src/nupic/regions/RecordSensorFilters/__init__.py -> nupic-0.3.3.dev0/src/nupic/regions/RecordSensorFilters
hard linking src/nupic/regions/extra/GaborNode2.py -> nupic-0.3.3.dev0/src/nupic/regions/extra
hard linking src/nupic/regions/extra/__init__.py -> nupic-0.3.3.dev0/src/nupic/regions/extra
hard linking src/nupic/research/TP.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/TP10X2.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/TP_shim.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/__init__.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/connections.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/fast_temporal_memory.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/fdrutilities.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/spatial_pooler.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/temporal_memory.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/temporal_memory_shim.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/utils.py -> nupic-0.3.3.dev0/src/nupic/research
hard linking src/nupic/research/monitor_mixin/__init__.py -> nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
hard linking src/nupic/research/monitor_mixin/metric.py -> nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
hard linking src/nupic/research/monitor_mixin/monitor_mixin_base.py -> nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
hard linking src/nupic/research/monitor_mixin/plot.py -> nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
hard linking src/nupic/research/monitor_mixin/temporal_memory_monitor_mixin.py -> nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
hard linking src/nupic/research/monitor_mixin/trace.py -> nupic-0.3.3.dev0/src/nupic/research/monitor_mixin
hard linking src/nupic/support/__init__.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/configuration.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/configuration_base.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/configuration_custom.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/consoleprinter.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/datafiles.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/decorators.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/enum.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/exceptions.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/feature_groups.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/features.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/features_list.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/fshelpers.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/lockattributes.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/log_utils.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/loophelpers.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/nupic-default.xml -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/pymysqlhelpers.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/serializationutils.py -> nupic-0.3.3.dev0/src/nupic/support
hard linking src/nupic/support/unittesthelpers/__init__.py -> nupic-0.3.3.dev0/src/nupic/support/unittesthelpers
hard linking src/nupic/support/unittesthelpers/algorithm_test_helpers.py -> nupic-0.3.3.dev0/src/nupic/support/unittesthelpers
hard linking src/nupic/support/unittesthelpers/testcasebase.py -> nupic-0.3.3.dev0/src/nupic/support/unittesthelpers
hard linking src/nupic/swarming/DummyModelRunner.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/ExtendedLogger.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/HypersearchV2.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/HypersearchWorker.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/ModelRunner.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/ModelTerminator.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/__init__.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/api.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/modelchooser.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/object_json.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/permutationhelpers.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/permutations_runner.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/regression.py -> nupic-0.3.3.dev0/src/nupic/swarming
hard linking src/nupic/swarming/exp_generator/ExpGenerator.py -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/__init__.py -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/claDescriptionTemplate.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/descriptionTemplate.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/experimentDescriptionSchema.json -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/nupicEnvironmentTemplate.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/opfExperimentTemplate.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/permutationsTemplateEnsemble.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/permutationsTemplateV1.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/exp_generator/permutationsTemplateV2.tpl -> nupic-0.3.3.dev0/src/nupic/swarming/exp_generator
hard linking src/nupic/swarming/hypersearch/__init__.py -> nupic-0.3.3.dev0/src/nupic/swarming/hypersearch
hard linking src/nupic/swarming/hypersearch/errorcodes.py -> nupic-0.3.3.dev0/src/nupic/swarming/hypersearch
hard linking src/nupic/swarming/hypersearch/experimentutils.py -> nupic-0.3.3.dev0/src/nupic/swarming/hypersearch
hard linking src/nupic/swarming/hypersearch/utils.py -> nupic-0.3.3.dev0/src/nupic/swarming/hypersearch
hard linking src/nupic/swarming/jsonschema/__init__.py -> nupic-0.3.3.dev0/src/nupic/swarming/jsonschema
hard linking src/nupic/swarming/jsonschema/jobParamsSchema.json -> nupic-0.3.3.dev0/src/nupic/swarming/jsonschema
hard linking src/nupic/test/__init__.py -> nupic-0.3.3.dev0/src/nupic/test
hard linking src/nupic/test/abstract_temporal_memory_test.py -> nupic-0.3.3.dev0/src/nupic/test
hard linking src/nupic/test/test_framework_helpers.py -> nupic-0.3.3.dev0/src/nupic/test
copying setup.cfg -> nupic-0.3.3.dev0
Writing nupic-0.3.3.dev0/setup.cfg
Creating tar archive
removing 'nupic-0.3.3.dev0' (and everything under it)
```