### PR TITLE
SP use same params for Py / C++

### DIFF
--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -18,5 +18,5 @@ prettytable==0.7.2
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
 pycapnp==0.5.5
-nupic.bindings==0.2.2
+nupic.bindings==0.2.3
 numpy==1.9.2

--- a/src/nupic/research/TP.py
+++ b/src/nupic/research/TP.py
@@ -62,7 +62,7 @@ class TP(ConsolePrinterMixin):
   """
 
   def __init__(self,
-               numberOfCols=500,
+               numberOfCols=2048,
                cellsPerColumn=10,
                initialPerm=0.11,
                connectedPerm=0.50,

--- a/src/nupic/research/TP10X2.py
+++ b/src/nupic/research/TP10X2.py
@@ -72,7 +72,7 @@ class TP10X2(TP):
 
   # We use the same keyword arguments as TP()
   def __init__(self,
-               numberOfCols = 500,
+               numberOfCols = 2048,
                cellsPerColumn = 10,
                initialPerm = 0.11, # TODO: check perm numbers with Ron
                connectedPerm = 0.50,

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1127,8 +1127,6 @@ class SpatialPooler(object):
       self._raisePermanenceToThreshold(perm, maskPotential)
     perm[perm < self._synPermTrimThreshold] = 0
     numpy.clip(perm, self._synPermMin, self._synPermMax, out=perm)
-    # round perm for stability (Py vs Cpp problems)
-    perm = [self._round5(x) for x in perm]
     newConnected = numpy.where(perm >= self._synPermConnected)[0]
     self._permanences.update(columnIndex, perm)
     self._connectedSynapses.replace(columnIndex, newConnected)

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -33,7 +33,7 @@ realDType = GetNTAReal()
 uintType = "uint32"
 
 VERSION = 2
-
+DEFAULT_RNG_SEED = 42
 
 
 class InvalidSPParamValueError(ValueError):
@@ -125,7 +125,7 @@ class SpatialPooler(object):
                minPctActiveDutyCycle=0.001,
                dutyCyclePeriod=1000,
                maxBoost=10.0,
-               seed=-1,
+               seed=DEFAULT_RNG_SEED,
                spVerbosity=0,
                wrapAround=True
                ):
@@ -232,8 +232,8 @@ class SpatialPooler(object):
       maxBoost is used if the duty cycle is 0, and any duty cycle in between is
       linearly extrapolated from these 2 endpoints.
     @param seed:
-      Seed for our own pseudo-random number generator. Default -1 means a random
-      value for a seed is used. 
+      Seed for our own pseudo-random number generator. Default value used is in
+      DEFAULT_RNG_SEED (=42).
     @param spVerbosity:
       spVerbosity level: 0, 1, 2, or 3
     @param wrapAround:

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -332,9 +332,8 @@ class SpatialPooler(object):
 
     # Initialize a tiny random tie breaker. This is used to determine winning
     # columns where the overlaps are identical.
-    # FIXME: this could be only 1/0 at the (PRECISION+1)-th decimal place
-    self._tieBreaker = pow(10, -1*(self.getPrecision()+1))*numpy.array(
-            [self._random.getReal64() for i in xrange(self._numColumns)])
+    self._tieBreaker = 0.01*numpy.array([self._random.getReal64() for i in
+                                        xrange(self._numColumns)])
 
     # 'self._connectedSynapses' is a similar matrix to 'self._permanences'
     # (rows represent cortical columns, columns represent input bits) whose

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1127,6 +1127,8 @@ class SpatialPooler(object):
       self._raisePermanenceToThreshold(perm, maskPotential)
     perm[perm < self._synPermTrimThreshold] = 0
     numpy.clip(perm, self._synPermMin, self._synPermMax, out=perm)
+    # round perm for stability (Py vs Cpp problems)
+    perm = [self._round5(x) for x in perm]
     newConnected = numpy.where(perm >= self._synPermConnected)[0]
     self._permanences.update(columnIndex, perm)
     self._connectedSynapses.replace(columnIndex, newConnected)

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -330,12 +330,6 @@ class SpatialPooler(object):
     # non-zero.
     self._permanences = CorticalColumns(numColumns, numInputs)
 
-    # Initialize a tiny random tie breaker. This is used to determine winning
-    # columns where the overlaps are identical.
-    # FIXME: this could be only 1/0 at the (PRECISION+1)-th decimal place
-    self._tieBreaker = pow(10, -1*(self.getPrecision()+1))*numpy.array(
-            [self._random.getReal64() for i in xrange(self._numColumns)])
-
     # 'self._connectedSynapses' is a similar matrix to 'self._permanences'
     # (rows represent cortical columns, columns represent input bits) whose
     # entries represent whether the cortical column is connected to the input
@@ -1419,9 +1413,6 @@ class SpatialPooler(object):
       density = float(self._numActiveColumnsPerInhArea) / inhibitionArea
       density = min(density, 0.5)
 
-    # Add our fixed little bit of random noise to the scores to help break ties.
-    overlaps += self._tieBreaker
-
     if self._globalInhibition or \
       self._inhibitionRadius > max(self._columnDimensions):
       return self._inhibitColumnsGlobal(overlaps, density)
@@ -1710,10 +1701,6 @@ class SpatialPooler(object):
     self._potentialPools.write(proto.potentialPools)
     self._permanences.write(proto.permanences)
 
-    tieBreakersProto = proto.init("tieBreaker", len(self._tieBreaker))
-    for i, v in enumerate(self._tieBreaker):
-      tieBreakersProto[i] = float(v)
-
     overlapDutyCyclesProto = proto.init("overlapDutyCycles",
                                         len(self._overlapDutyCycles))
     for i, v in enumerate(self._overlapDutyCycles):
@@ -1786,8 +1773,6 @@ class SpatialPooler(object):
       self._updatePermanencesForColumn(
         self._permanences[columnIndex], columnIndex, False
       )
-
-    self._tieBreaker = numpy.array(proto.tieBreaker)
 
     self._overlapDutyCycles = numpy.array(proto.overlapDutyCycles,
                                           dtype=realDType)

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -111,7 +111,7 @@ class SpatialPooler(object):
 
   def __init__(self,
                inputDimensions,
-               columnDimensions,
+               columnDimensions=(2048,),
                potentialRadius=16,
                potentialPct=0.5,
                globalInhibition=True,

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -332,8 +332,9 @@ class SpatialPooler(object):
 
     # Initialize a tiny random tie breaker. This is used to determine winning
     # columns where the overlaps are identical.
-    self._tieBreaker = 0.01*numpy.array([self._random.getReal64() for i in
-                                        xrange(self._numColumns)])
+    # FIXME: this could be only 1/0 at the (PRECISION+1)-th decimal place
+    self._tieBreaker = pow(10, -1*(self.getPrecision()+1))*numpy.array(
+            [self._random.getReal64() for i in xrange(self._numColumns)])
 
     # 'self._connectedSynapses' is a similar matrix to 'self._permanences'
     # (rows represent cortical columns, columns represent input bits) whose

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -110,17 +110,17 @@ class SpatialPooler(object):
   """
 
   def __init__(self,
-               inputDimensions=(32, 32),
-               columnDimensions=(64, 64),
+               inputDimensions,
+               columnDimensions,
                potentialRadius=16,
                potentialPct=0.5,
-               globalInhibition=False,
+               globalInhibition=True,
                localAreaDensity=-1.0,
                numActiveColumnsPerInhArea=10.0,
                stimulusThreshold=0,
-               synPermInactiveDec=0.008,
-               synPermActiveInc=0.05,
-               synPermConnected=0.10,
+               synPermInactiveDec=0.01,
+               synPermActiveInc=0.1,
+               synPermConnected=0.1,
                minPctOverlapDutyCycle=0.001,
                minPctActiveDutyCycle=0.001,
                dutyCyclePeriod=1000,
@@ -232,7 +232,8 @@ class SpatialPooler(object):
       maxBoost is used if the duty cycle is 0, and any duty cycle in between is
       linearly extrapolated from these 2 endpoints.
     @param seed:
-      Seed for our own pseudo-random number generator.
+      Seed for our own pseudo-random number generator. Default -1 means a random
+      value for a seed is used. 
     @param spVerbosity:
       spVerbosity level: 0, 1, 2, or 3
     @param wrapAround:

--- a/tests/unit/nupic/research/spatial_pooler_compatability_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_compatability_test.py
@@ -56,6 +56,8 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
 
 
   def compare(self, pySp, cppSp):
+    self.assertAlmostEqual(pySp.getPrecision(),
+                           cppSp.getPrecision())
     self.assertAlmostEqual(pySp.getNumColumns(),
                            cppSp.getNumColumns())
     self.assertAlmostEqual(pySp.getNumInputs(),

--- a/tests/unit/nupic/research/spatial_pooler_compatability_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_compatability_test.py
@@ -441,6 +441,17 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
         d1, d2, "SP outputs are not equal: \n%s \n%s" % (str(d1), str(d2)))
 
 
+  def testSameInitParams(self):
+    """Py and C++ SP implementations must use the same init parameters"""
+    pySp = PySpatialPooler(
+        inputDimensions=[121, 1], columnDimensions=[30, 30])
+    cppSp = CPPSpatialPooler(
+        inputDimensions=[121, 1], columnDimensions=[30, 30])
+
+    self.compare(pySp, cppSp)
+
+
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/nupic/research/spatial_pooler_compatability_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_compatability_test.py
@@ -445,13 +445,10 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
 
   def testSameInitParams(self):
     """Py and C++ SP implementations must use the same init parameters"""
-    pySp = PySpatialPooler(
-        inputDimensions=[121, 1], columnDimensions=[30, 30])
-    cppSp = CPPSpatialPooler(
-        inputDimensions=[121, 1], columnDimensions=[30, 30])
+    pySp = PySpatialPooler(inputDimensions=[121, 1])
+    cppSp = CPPSpatialPooler(inputDimensions=[121, 1])
 
     self.compare(pySp, cppSp)
-
 
 
 


### PR DESCRIPTION
Set same default parameters in C++ and PY implementations of SP.
SP tie-breaker is way too significant, effects the shape of SDR, fixed here.

TODO: 
- [ ] Needs the C++ part merged, please see the issue.
- [x] remove tieBreaker, as discussed in nupic.core related PR by Scott -- moved to a sepratate issue
- [x] merge cleanup at https://github.com/numenta/nupic/pull/2628 -- not needed, separate issue

Fixes: #2616