### PR TITLE
Optimization for _getNeighborsND

### DIFF
--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1610,8 +1610,10 @@ class SpatialPooler(object):
 
       rangeND.append(numpy.unique(curRange))
 
-    neighbors = [numpy.ravel_multi_index(coord, dimensions) for coord in
-      itertools.product(*rangeND)]
+    neighbors = numpy.ravel_multi_index(
+      numpy.array(list(itertools.product(*rangeND))).T, 
+      dimensions).tolist()
+
     neighbors.remove(columnIndex)
     return neighbors
 


### PR DESCRIPTION
Fixes #2708 

Using typical values of  `dimensions` and `rangeND` this optimization produces around a 5.3x speedup for the affected lines in _getNeighborsND. When profiling code that used _getNeighborsND, this line contributed 68% of total runtime, making this optimization very significant for such code. This change passes all unit and integration test.

@scottpurdy @vitaly-krugl 