### PR TITLE
fix rawOverlap calc, add pctOverlapOfInput calc

### DIFF
--- a/src/nupic/algorithms/KNNClassifier.py
+++ b/src/nupic/algorithms/KNNClassifier.py
@@ -99,6 +99,8 @@ class KNNClassifier(object):
         "norm": When distanceNorm is 2, this is the euclidean distance,
                 When distanceNorm is 1, this is the manhattan distance
                 In general: sum(abs(x-proto) ^ distanceNorm) ^ (1/distanceNorm)
+                The distances are normalized such that farthest prototype from
+                a given input is 1.0.
         "rawOverlap": Only appropriate when inputs are binary. This computes:
                 (width of the input) - (# bits of overlap between input
                 and prototype).
@@ -787,7 +789,7 @@ class KNNClassifier(object):
         self._protoSizes = self._Memory.rowSums()
       overlapsWithProtos = self._Memory.rightVecSumAtNZ(inputPattern)
       inputPatternSum = inputPattern.sum()
-    
+
       if self.distanceMethod == "rawOverlap":
         dist = inputPattern.sum() - overlapsWithProtos
       elif self.distanceMethod == "pctOverlapOfInput":
@@ -939,7 +941,7 @@ class KNNClassifier(object):
 
     self._vt = self._vt[:self.numSVDDims]
 
-    # Added when svd is not able to decompose vectors - uses raw spare vectors  
+    # Added when svd is not able to decompose vectors - uses raw spare vectors
     if len(self._vt) == 0:
       return
 

--- a/src/nupic/algorithms/KNNClassifier.py
+++ b/src/nupic/algorithms/KNNClassifier.py
@@ -789,7 +789,7 @@ class KNNClassifier(object):
       inputPatternSum = inputPattern.sum()
     
       if self.distanceMethod == "rawOverlap":
-        dist = (inputPattern.sum() - self._Memory.rightVecSumAtNZ(inputPattern))
+        dist = inputPattern.sum() - overlapsWithProtos
       elif self.distanceMethod == "pctOverlapOfInput":
         dist = inputPatternSum - overlapsWithProtos
         if inputPatternSum > 0:
@@ -799,7 +799,7 @@ class KNNClassifier(object):
         dist = 1.0 - overlapsWithProtos
       elif self.distanceMethod == "pctOverlapOfLarger":
         maxVal = numpy.maximum(self._protoSizes, inputPatternSum)
-        if maxVal > 0:
+        if maxVal.all() > 0:
           overlapsWithProtos /= maxVal
         dist = 1.0 - overlapsWithProtos
       elif self.distanceMethod == "norm":

--- a/src/nupic/algorithms/KNNClassifier.py
+++ b/src/nupic/algorithms/KNNClassifier.py
@@ -95,19 +95,22 @@ class KNNClassifier(object):
         the p value of the Lp-norm
 
     @param distanceMethod (string) The method used to compute distance between
-        patterns. The possible options are:
+        input patterns and prototype patterns. The possible options are:
         "norm": When distanceNorm is 2, this is the euclidean distance,
                 When distanceNorm is 1, this is the manhattan distance
                 In general: sum(abs(x-proto) ^ distanceNorm) ^ (1/distanceNorm)
         "rawOverlap": Only appropriate when inputs are binary. This computes:
                 (width of the input) - (# bits of overlap between input
                 and prototype).
-        "pctOverlapOfLarger": Only appropriate for binary inputs. This computes
+        "pctOverlapOfInput": Only appropriate for binary inputs. This computes
                 1.0 - (# bits overlap between input and prototype) /
-                        max(# bits in input, # bits in prototype)
+                        (# ON bits in input)
         "pctOverlapOfProto": Only appropriate for binary inputs. This computes
                 1.0 - (# bits overlap between input and prototype) /
-                        (# bits in prototype)
+                        (# ON bits in prototype)
+        "pctOverlapOfLarger": Only appropriate for binary inputs. This computes
+                1.0 - (# bits overlap between input and prototype) /
+                        max(# ON bits in input, # ON bits in prototype)
 
     @param distThreshold (float) A threshold on the distance between learned
         patterns and a new pattern proposed to be learned. The distance must be
@@ -167,7 +170,7 @@ class KNNClassifier(object):
     self.exact = exact
     self.distanceNorm = distanceNorm
     assert (distanceMethod in ("norm", "rawOverlap", "pctOverlapOfLarger",
-                               "pctOverlapOfProto"))
+                               "pctOverlapOfProto", "pctOverlapOfInput"))
     self.distanceMethod = distanceMethod
     self.distThreshold = distThreshold
     self.doBinarization = doBinarization
@@ -780,35 +783,33 @@ class KNNClassifier(object):
 
     # Sparse memory
     if self.useSparseMemory:
-      if self.distanceMethod == "pctOvlerapOfLarger":
-        if self._protoSizes is None:
-          self._protoSizes = self._Memory.rowSums()
-        dist =  self._Memory.rightVecSumAtNZ(inputPattern)
-        maxVal = numpy.maximum(self._protoSizes, inputPattern.sum())
-        if maxVal > 0:
-          dist /= maxVal
-        dist = 1.0 - dist
-      elif self.distanceMethod == "rawOverlap":
-        if self._protoSizes is None:
-          self._protoSizes = self._Memory.rowSums()
-        inputPatternSum = inputPattern.sum()
-        dist = (inputPatternSum - self._Memory.rightVecSumAtNZ(inputPattern))
+      if self._protoSizes is None:
+        self._protoSizes = self._Memory.rowSums()
+      overlapsWithProtos = self._Memory.rightVecSumAtNZ(inputPattern)
+      inputPatternSum = inputPattern.sum()
+    
+      if self.distanceMethod == "rawOverlap":
+        dist = (inputPattern.sum() - self._Memory.rightVecSumAtNZ(inputPattern))
+      elif self.distanceMethod == "pctOverlapOfInput":
+        dist = inputPatternSum - overlapsWithProtos
         if inputPatternSum > 0:
           dist /= inputPatternSum
       elif self.distanceMethod == "pctOverlapOfProto":
-        if self._protoSizes is None:
-          self._protoSizes = self._Memory.rowSums()
-        dist =  self._Memory.rightVecSumAtNZ(inputPattern)
-        dist /= self._protoSizes
-        dist = 1.0 - dist
+        overlapsWithProtos /= self._protoSizes
+        dist = 1.0 - overlapsWithProtos
+      elif self.distanceMethod == "pctOverlapOfLarger":
+        maxVal = numpy.maximum(self._protoSizes, inputPatternSum)
+        if maxVal > 0:
+          overlapsWithProtos /= maxVal
+        dist = 1.0 - overlapsWithProtos
       elif self.distanceMethod == "norm":
         dist = self._Memory.vecLpDist(self.distanceNorm, inputPattern)
         distMax = dist.max()
         if distMax > 0:
           dist /= distMax
       else:
-        raise RuntimeError("Unimplemented distance method %s" % \
-                           (self.distanceMethod))
+        raise RuntimeError("Unimplemented distance method %s" %
+          self.distanceMethod)
 
     # Dense memory
     else:

--- a/src/nupic/regions/KNNClassifierRegion.py
+++ b/src/nupic/regions/KNNClassifierRegion.py
@@ -232,7 +232,7 @@ class KNNClassifierRegion(PyRegion):
             dataType="Byte",
             count=0,
             constraints='enum: norm, rawOverlap, pctOverlapOfLarger, '
-              'pctOverlapOfProto',
+              'pctOverlapOfProto, pctOverlapOfInput',
             defaultValue='norm',
             accessMode='ReadWrite'),
 

--- a/tests/unit/nupic/algorithms/knn_classifier_test.py
+++ b/tests/unit/nupic/algorithms/knn_classifier_test.py
@@ -51,35 +51,38 @@ class KNNClassifierTest(unittest.TestCase):
     _, _, dist, _ = classifier.infer(input)
     l2Distances = [0.65465367,  1.0]
     for actual, predicted in zip(l2Distances, dist):
-      self.assertAlmostEqual(actual, predicted, places=5,
+      self.assertAlmostEqual(
+        actual, predicted, places=5,
         msg="l2 distance norm is not calculated as expected.")
   
     _, _, dist0, _ = classifier.infer(input0)
-    self.assertEqual(0.0, dist0[0],
-      msg="l2 norm did not calculate 0 distance as expected.")
+    self.assertEqual(
+      0.0, dist0[0], msg="l2 norm did not calculate 0 distance as expected.")
 
     # Test l1 norm metric
     classifier.distanceNorm = 1.0
     _, _, dist, _ = classifier.infer(input)
     l1Distances = [0.42857143,  1.0]
     for actual, predicted in zip(l1Distances, dist):
-      self.assertAlmostEqual(actual, predicted, places=5,
+      self.assertAlmostEqual(
+        actual, predicted, places=5,
         msg="l1 distance norm is not calculated as expected.")
     
     _, _, dist0, _ = classifier.infer(input0)
-    self.assertEqual(0.0, dist0[0],
-      msg="l1 norm did not calculate 0 distance as expected.")
+    self.assertEqual(
+      0.0, dist0[0], msg="l1 norm did not calculate 0 distance as expected.")
   
     # Test raw overlap metric
     classifier.distanceMethod = "rawOverlap"
     _, _, dist, _ = classifier.infer(input)
     rawOverlaps = [1, 4]
     for actual, predicted in zip(rawOverlaps, dist):
-      self.assertEqual(actual, predicted,
-        msg="Raw overlap is not calculated as expected.")
+      self.assertEqual(
+        actual, predicted, msg="Raw overlap is not calculated as expected.")
 
     _, _, dist0, _ = classifier.infer(input0)
-    self.assertEqual(0.0, dist0[0],
+    self.assertEqual(
+      0.0, dist0[0],
       msg="Raw overlap did not calculate 0 distance as expected.")
 
     # Test pctOverlapOfInput metric
@@ -87,11 +90,13 @@ class KNNClassifierTest(unittest.TestCase):
     _, _, dist, _ = classifier.infer(input)
     pctOverlaps = [0.25, 1.0]
     for actual, predicted in zip(pctOverlaps, dist):
-      self.assertAlmostEqual(actual, predicted, places=5,
+      self.assertAlmostEqual(
+        actual, predicted, places=5,
         msg="pctOverlapOfInput is not calculated as expected.")
    
     _, _, dist0, _ = classifier.infer(input0)
-    self.assertEqual(0.0, dist0[0],
+    self.assertEqual(
+      0.0, dist0[0],
       msg="pctOverlapOfInput did not calculate 0 distance as expected.")
 
     # Test pctOverlapOfProto metric
@@ -99,11 +104,13 @@ class KNNClassifierTest(unittest.TestCase):
     _, _, dist, _ = classifier.infer(input)
     pctOverlaps = [0.40, 1.0]
     for actual, predicted in zip(pctOverlaps, dist):
-      self.assertAlmostEqual(actual, predicted, places=5,
+      self.assertAlmostEqual(
+        actual, predicted, places=5,
         msg="pctOverlapOfProto is not calculated as expected.")
 
     _, _, dist0, _ = classifier.infer(input0)
-    self.assertEqual(0.0, dist0[0],
+    self.assertEqual(
+      0.0, dist0[0],
       msg="pctOverlapOfProto did not calculate 0 distance as expected.")
 
     # Test pctOverlapOfLarger metric
@@ -111,11 +118,13 @@ class KNNClassifierTest(unittest.TestCase):
     _, _, dist, _ = classifier.infer(input)
     pctOverlaps = [0.40, 1.0]
     for actual, predicted in zip(pctOverlaps, dist):
-      self.assertAlmostEqual(actual, predicted, places=5,
+      self.assertAlmostEqual(
+      actual, predicted, places=5,
         msg="pctOverlapOfLarger is not calculated as expected.")
 
     _, _, dist0, _ = classifier.infer(input0)
-    self.assertEqual(0.0, dist0[0],
+    self.assertEqual(
+      0.0, dist0[0],
       msg="pctOverlapOfLarger did not calculate 0 distance as expected.")
 
 

--- a/tests/unit/nupic/algorithms/knn_classifier_test.py
+++ b/tests/unit/nupic/algorithms/knn_classifier_test.py
@@ -40,15 +40,23 @@ class KNNClassifierTest(unittest.TestCase):
     classifier.learn(protoA, 0, isSparse=dimensionality)
     classifier.learn(protoB, 0, isSparse=dimensionality)
     
+    # input is an arbitrary point, close to protoA, orthogonal to protoB
     input = np.zeros(dimensionality)
     input[:4] = 1.0
-    
+    # input0 is used to test that the distance from a point to itself is 0
+    input0 = np.zeros(dimensionality)
+    input0[protoA] = 1.0
+
     # Test l2 norm metric
     _, _, dist, _ = classifier.infer(input)
     l2Distances = [0.65465367,  1.0]
     for actual, predicted in zip(l2Distances, dist):
       self.assertAlmostEqual(actual, predicted, places=5,
         msg="l2 distance norm is not calculated as expected.")
+  
+    _, _, dist0, _ = classifier.infer(input0)
+    self.assertEqual(0.0, dist0[0],
+      msg="l2 norm did not calculate 0 distance as expected.")
 
     # Test l1 norm metric
     classifier.distanceNorm = 1.0
@@ -57,6 +65,10 @@ class KNNClassifierTest(unittest.TestCase):
     for actual, predicted in zip(l1Distances, dist):
       self.assertAlmostEqual(actual, predicted, places=5,
         msg="l1 distance norm is not calculated as expected.")
+    
+    _, _, dist0, _ = classifier.infer(input0)
+    self.assertEqual(0.0, dist0[0],
+      msg="l1 norm did not calculate 0 distance as expected.")
   
     # Test raw overlap metric
     classifier.distanceMethod = "rawOverlap"
@@ -66,6 +78,10 @@ class KNNClassifierTest(unittest.TestCase):
       self.assertEqual(actual, predicted,
         msg="Raw overlap is not calculated as expected.")
 
+    _, _, dist0, _ = classifier.infer(input0)
+    self.assertEqual(0.0, dist0[0],
+      msg="Raw overlap did not calculate 0 distance as expected.")
+
     # Test pctOverlapOfInput metric
     classifier.distanceMethod = "pctOverlapOfInput"
     _, _, dist, _ = classifier.infer(input)
@@ -73,6 +89,10 @@ class KNNClassifierTest(unittest.TestCase):
     for actual, predicted in zip(pctOverlaps, dist):
       self.assertAlmostEqual(actual, predicted, places=5,
         msg="pctOverlapOfInput is not calculated as expected.")
+   
+    _, _, dist0, _ = classifier.infer(input0)
+    self.assertEqual(0.0, dist0[0],
+      msg="pctOverlapOfInput did not calculate 0 distance as expected.")
 
     # Test pctOverlapOfProto metric
     classifier.distanceMethod = "pctOverlapOfProto"
@@ -82,6 +102,10 @@ class KNNClassifierTest(unittest.TestCase):
       self.assertAlmostEqual(actual, predicted, places=5,
         msg="pctOverlapOfProto is not calculated as expected.")
 
+    _, _, dist0, _ = classifier.infer(input0)
+    self.assertEqual(0.0, dist0[0],
+      msg="pctOverlapOfProto did not calculate 0 distance as expected.")
+
     # Test pctOverlapOfLarger metric
     classifier.distanceMethod = "pctOverlapOfLarger"
     _, _, dist, _ = classifier.infer(input)
@@ -89,6 +113,10 @@ class KNNClassifierTest(unittest.TestCase):
     for actual, predicted in zip(pctOverlaps, dist):
       self.assertAlmostEqual(actual, predicted, places=5,
         msg="pctOverlapOfLarger is not calculated as expected.")
+
+    _, _, dist0, _ = classifier.infer(input0)
+    self.assertEqual(0.0, dist0[0],
+      msg="pctOverlapOfLarger did not calculate 0 distance as expected.")
 
 
   def testOverlapDistanceMethodStandard(self):

--- a/tests/unit/nupic/algorithms/knn_classifier_test.py
+++ b/tests/unit/nupic/algorithms/knn_classifier_test.py
@@ -30,6 +30,67 @@ from nupic.algorithms.KNNClassifier import KNNClassifier
 class KNNClassifierTest(unittest.TestCase):
 
 
+  def testDistanceMetrics(self):
+    classifier = KNNClassifier(distanceMethod="norm", distanceNorm=2.0)
+  
+    dimensionality = 40
+    protoA = np.array([0, 1, 3, 7, 11], dtype=np.int32)
+    protoB = np.array([20, 28, 30], dtype=np.int32)
+    
+    classifier.learn(protoA, 0, isSparse=dimensionality)
+    classifier.learn(protoB, 0, isSparse=dimensionality)
+    
+    input = np.zeros(dimensionality)
+    input[:4] = 1.0
+    
+    # Test l2 norm metric
+    _, _, dist, _ = classifier.infer(input)
+    l2Distances = [0.65465367,  1.0]
+    for actual, predicted in zip(l2Distances, dist):
+      self.assertAlmostEqual(actual, predicted, places=5,
+        msg="l2 distance norm is not calculated as expected.")
+
+    # Test l1 norm metric
+    classifier.distanceNorm = 1.0
+    _, _, dist, _ = classifier.infer(input)
+    l1Distances = [0.42857143,  1.0]
+    for actual, predicted in zip(l1Distances, dist):
+      self.assertAlmostEqual(actual, predicted, places=5,
+        msg="l1 distance norm is not calculated as expected.")
+  
+    # Test raw overlap metric
+    classifier.distanceMethod = "rawOverlap"
+    _, _, dist, _ = classifier.infer(input)
+    rawOverlaps = [1, 4]
+    for actual, predicted in zip(rawOverlaps, dist):
+      self.assertEqual(actual, predicted,
+        msg="Raw overlap is not calculated as expected.")
+
+    # Test pctOverlapOfInput metric
+    classifier.distanceMethod = "pctOverlapOfInput"
+    _, _, dist, _ = classifier.infer(input)
+    pctOverlaps = [0.25, 1.0]
+    for actual, predicted in zip(pctOverlaps, dist):
+      self.assertAlmostEqual(actual, predicted, places=5,
+        msg="pctOverlapOfInput is not calculated as expected.")
+
+    # Test pctOverlapOfProto metric
+    classifier.distanceMethod = "pctOverlapOfProto"
+    _, _, dist, _ = classifier.infer(input)
+    pctOverlaps = [0.40, 1.0]
+    for actual, predicted in zip(pctOverlaps, dist):
+      self.assertAlmostEqual(actual, predicted, places=5,
+        msg="pctOverlapOfProto is not calculated as expected.")
+
+    # Test pctOverlapOfLarger metric
+    classifier.distanceMethod = "pctOverlapOfLarger"
+    _, _, dist, _ = classifier.infer(input)
+    pctOverlaps = [0.40, 1.0]
+    for actual, predicted in zip(pctOverlaps, dist):
+      self.assertAlmostEqual(actual, predicted, places=5,
+        msg="pctOverlapOfLarger is not calculated as expected.")
+
+
   def testOverlapDistanceMethodStandard(self):
     """Tests standard learning case for raw overlap"""
     params = {"distanceMethod": "rawOverlap"}


### PR DESCRIPTION
Fixes #2712 by correcting the `rawOverlap` metric, and adding a `pctOverlapOfInput` metric.