### PR TITLE
Adding src to package_dir to help with uninstall

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ if __name__ == "__main__":
     name="nupic",
     version=getVersion(),
     install_requires=requirements,
-    package_dir = {"": "src"},
+    package_dir = {"": "src", "src": "src/nupic"},
     packages=find_packages("src"),
     namespace_packages = ["nupic"],
     package_data={


### PR DESCRIPTION
Fixes #1101

@rhyolight cc @scottpurdy Matt, this helps locally to pip uninstall nupic. Been faced recently with it failing and complaining about egg-info not matching src one. This may not solve all of 1101 for 'develop' installs (not deleting egg-info dirs). Be great for someone there to have a test, and awaiting Travis for green light.