### PR TITLE
Completely build nupic bindings from source in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,19 @@ MAINTAINER Allan Costa <allaninocencio@yahoo.com.br>
 
 # Install dependencies
 RUN apt-get update
-RUN apt-get install -y wget git-core build-essential python2.7 python 2.7-dev
+RUN apt-get install -y \
+    wget \
+    git-core \
+    gcc \
+    g++ \
+    cmake \
+    python \
+    python2.7 \
+    python2.7-dev \
+    zlib1g-dev \
+    bzip2 \
+    libyaml-dev \
+    libyaml-0-2
 RUN wget https://raw.github.com/pypa/pip/master/contrib/get-pip.py -O - | python
 RUN pip install --upgrade setuptools
 RUN pip install wheel
@@ -31,10 +43,25 @@ ENV USER docker
 # Copy context into container file system
 ADD . $NUPIC
 
-WORKDIR /usr/local/src/nupic
+WORKDIR /usr/local/src
 
-# Install nupic.bindings
-RUN pip install https://s3-us-west-2.amazonaws.com/artifacts.numenta.org/numenta/nupic.core/releases/nupic.bindings/nupic.bindings-`git grep nupic.bindings\=\= -- external/common/requirements.txt | cut -d ':' -f 2 | sed "s/nupic\.bindings\=\=//"`-cp27-none-linux_x86_64.whl
+# Clone nupic.core
+RUN git clone `head -n 2 $NUPIC/.nupic_modules | tail -n 1 | sed -r "s/NUPIC_CORE_REMOTE = '(.+)'/\\1/"` && \
+    cd nupic.core && \
+    git reset --hard `head -n 3 $NUPIC/.nupic_modules | tail -n 1 | sed -r "s/NUPIC_CORE_COMMITISH = '(.+)'/\\1/"`
+
+WORKDIR /usr/local/src/nupic.core
+
+# Build nupic.core
+RUN pip install -r bindings/py/requirements.txt && \
+    mkdir -p build/scripts && \
+    cd build/scripts && \
+    cmake ../.. -DCMAKE_INSTALL_PREFIX=/usr/local && \
+    make install && \
+    cd ../../bindings/py && \
+    python setup.py install --nupic-core-dir=/usr/local
+
+WORKDIR /usr/local/src/nupic
 
 # Install NuPIC with using SetupTools
 RUN python setup.py install


### PR DESCRIPTION
Fixes #2721

Previous approach of mixing `pip install` with `python setup.py install` was resulting in a broken installation with respect to namespace packages.