### PR TITLE
Make Cap'n Proto serialization optional in NuPIC.

### DIFF
--- a/ci/travis/install.sh
+++ b/ci/travis/install.sh
@@ -34,7 +34,7 @@ pip --version
 
 # Build NuPIC
 cd ${TRAVIS_BUILD_DIR}
-pip install --user .
+pip install --user .[capnp]
 
 # Show nupic installation folder by trying to import nupic, if works, it prints
 # the absolute path of nupic.__file__, which the installation folder itself.

--- a/external/common/requirements.txt
+++ b/external/common/requirements.txt
@@ -17,6 +17,5 @@ pyproj==1.9.3
 prettytable==0.7.2
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-pycapnp==0.5.5
 nupic.bindings==0.2.2
 numpy==1.9.2

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ if __name__ == "__main__":
     },
     include_package_data=True,
     zip_safe=False,
+    extras_require = {"capnp": ["pycapnp==0.5.5"]},
     description="Numenta Platform for Intelligent Computing",
     author="Numenta",
     author_email="help@numenta.org",


### PR DESCRIPTION
@rcrowder - Does this work for Windows for now?
@oxtopus - Please review.

This is intended to be a temporary solution until we get pycapnp working on Windows.

fixes #2750