### PR TITLE
Allow using MonitoredFastTemporalMemory through OPF

### DIFF
--- a/src/nupic/regions/TPRegion.py
+++ b/src/nupic/regions/TPRegion.py
@@ -46,9 +46,12 @@ def _getTPClass(temporalImp):
     return TP_shim.FastTPShim
   elif temporalImp == 'monitored_tm_py':
     return TP_shim.MonitoredTPShim
+  elif temporalImp == 'monitored_fast_tm_py':
+    return TP_shim.MonitoredFastTPShim
   else:
     raise RuntimeError("Invalid temporalImp '%s'. Legal values are: 'py', "
-              "'cpp', 'tm_py', 'tm_py_faster', 'monitored_tm_py'" % (temporalImp))
+              "'cpp', 'tm_py', 'tm_py_faster',"
+              "'monitored_tm_py', 'monitored_fast_tm_py'" % (temporalImp))
 
 
 
@@ -421,7 +424,8 @@ class TPRegion(PyRegion):
       tpClass = _getTPClass(self.temporalImp)
 
       if self.temporalImp in ['py', 'cpp', 'r',
-                              'tm_py', 'tm_py_faster', 'monitored_tm_py']:
+                              'tm_py', 'tm_py_faster',
+                              'monitored_tm_py', 'monitored_fast_tm_py']:
         self._tfdr = tpClass(
              numberOfCols=self.columnCount,
              cellsPerColumn=self.cellsPerColumn,

--- a/src/nupic/regions/TPRegion.py
+++ b/src/nupic/regions/TPRegion.py
@@ -42,13 +42,13 @@ def _getTPClass(temporalImp):
     return TP10X2.TP10X2
   elif temporalImp == 'tm_py':
     return TP_shim.TPShim
-  elif temporalImp == 'tm_cpp':
+  elif temporalImp == 'tm_py_faster':
     return TP_shim.FastTPShim
   elif temporalImp == 'monitored_tm_py':
     return TP_shim.MonitoredTPShim
   else:
     raise RuntimeError("Invalid temporalImp '%s'. Legal values are: 'py', "
-              "'cpp', 'tm_py', 'tm_cpp', 'monitored_tm_py'" % (temporalImp))
+              "'cpp', 'tm_py', 'tm_py_faster', 'monitored_tm_py'" % (temporalImp))
 
 
 
@@ -421,7 +421,7 @@ class TPRegion(PyRegion):
       tpClass = _getTPClass(self.temporalImp)
 
       if self.temporalImp in ['py', 'cpp', 'r',
-                              'tm_py', 'tm_cpp', 'monitored_tm_py']:
+                              'tm_py', 'tm_py_faster', 'monitored_tm_py']:
         self._tfdr = tpClass(
              numberOfCols=self.columnCount,
              cellsPerColumn=self.cellsPerColumn,

--- a/src/nupic/research/TP_shim.py
+++ b/src/nupic/research/TP_shim.py
@@ -30,7 +30,12 @@ from nupic.research.temporal_memory import TemporalMemory
 from nupic.research.fast_temporal_memory import FastTemporalMemory
 from nupic.research.monitor_mixin.temporal_memory_monitor_mixin import (
   TemporalMemoryMonitorMixin)
-class MonitoredTemporalMemory(TemporalMemoryMonitorMixin, TemporalMemory): pass
+
+class MonitoredTemporalMemory(TemporalMemoryMonitorMixin,
+                              TemporalMemory): pass
+
+class MonitoredFastTemporalMemory(TemporalMemoryMonitorMixin,
+                                  FastTemporalMemory): pass
 
 
 
@@ -254,6 +259,89 @@ class MonitoredTPShim(MonitoredTemporalMemory):
                              If false, do not compute the inference output
     """
     super(MonitoredTPShim, self).compute(set(bottomUpInput.nonzero()[0]),
+                                             learn=enableLearn)
+    numberOfCells = self.numberOfCells()
+
+    activeState = numpy.zeros(numberOfCells)
+    activeState[self.getCellIndices(self.activeCells)] = 1
+    self.infActiveState["t"] = activeState
+
+    output = numpy.zeros(numberOfCells)
+    output[self.getCellIndices(self.predictiveCells | self.activeCells)] = 1
+    return output
+
+
+  def getActiveState(self):
+    activeState = numpy.zeros(self.numberOfCells())
+    activeState[self.getCellIndices(self.activeCells)] = 1
+    return activeState
+
+
+  def getPredictedState(self):
+    predictedState = numpy.zeros(self.numberOfCells())
+    predictedState[self.getCellIndices(self.predictiveCells)] = 1
+    return predictedState
+
+
+
+class MonitoredFastTPShim(MonitoredFastTemporalMemory):
+  """
+  TP => Monitored Fast Temporal Memory shim class.
+
+  TODO: This class is not very DRY. This whole file needs to be replaced by a
+  pure TemporalMemory region
+  (WIP at https://github.com/numenta/nupic.research/pull/247).
+  """
+  def __init__(self,
+               numberOfCols=500,
+               cellsPerColumn=10,
+               initialPerm=0.11,
+               connectedPerm=0.50,
+               minThreshold=8,
+               newSynapseCount=15,
+               permanenceInc=0.10,
+               permanenceDec=0.10,
+               permanenceMax=1.0,
+               globalDecay=0.10,
+               activationThreshold=12,
+               predictedSegmentDecrement=0,
+               maxSegmentsPerCell=255,
+               maxSynapsesPerSegment=255,
+               seed=42):
+    """
+    Translate parameters and initialize member variables specific to `TP.py`.
+    """
+    super(MonitoredFastTPShim, self).__init__(
+      columnDimensions=(numberOfCols,),
+      cellsPerColumn=cellsPerColumn,
+      activationThreshold=activationThreshold,
+      initialPermanence=initialPerm,
+      connectedPermanence=connectedPerm,
+      minThreshold=minThreshold,
+      maxNewSynapseCount=newSynapseCount,
+      permanenceIncrement=permanenceInc,
+      permanenceDecrement=permanenceDec,
+      predictedSegmentDecrement=predictedSegmentDecrement,
+      maxSegmentsPerCell=maxSegmentsPerCell,
+      maxSynapsesPerSegment=maxSynapsesPerSegment,
+      seed=seed)
+
+    self.infActiveState = {"t": None}
+
+
+  def compute(self, bottomUpInput, enableLearn, computeInfOutput=None):
+    """
+    (From `TP.py`)
+    Handle one compute, possibly learning.
+
+    @param bottomUpInput     The bottom-up input, typically from a spatial pooler
+    @param enableLearn       If true, perform learning
+    @param computeInfOutput  If None, default behavior is to disable the inference
+                             output when enableLearn is on.
+                             If true, compute the inference output
+                             If false, do not compute the inference output
+    """
+    super(MonitoredFastTPShim, self).compute(set(bottomUpInput.nonzero()[0]),
                                              learn=enableLearn)
     numberOfCells = self.numberOfCells()
 


### PR DESCRIPTION
fixed typo on line 270; added description proposed by JonnoFTW;
 fixes run_nupic_test.py file name in lines 28 & 32
 I added the .py extension to the filename; does this resolve the
 Works for me w/o the lines, but was in