### PR TITLE
Use resource handler deeper into expGen tests

### DIFF
--- a/tests/integration/nupic/opf/expgenerator_test.py
+++ b/tests/integration/nupic/opf/expgenerator_test.py
@@ -49,8 +49,7 @@ from nupic.frameworks.opf.opfutils import (InferenceType,
                                            InferenceElement)
 
 LOGGER = logging.getLogger(__name__)
-HOTGYM_INPUT = resource_filename("nupic.datafiles",
-                                  os.path.join("extra", "hotgym", "hotgym.csv"))
+HOTGYM_INPUT = "extra/hotgym/hotgym.csv"
 
 
 g_debug = False


### PR DESCRIPTION
Fixes #2735 This sorts out the last failing integration tests on Windows. The four expGenerator tests that load and run the generated description.py and permutations.py for each test. Relying on the use of the resource handler when the HOTGYM_INPUT is not an absolute path. And no requirement to modify anything other than the look up of this data file.