### PR TITLE
Skipping unit tests that rely on pycapnp (win32 only)

### DIFF
--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -20,6 +20,8 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
+import sys
+import pytest
 from mock import Mock
 from mock import patch
 import unittest2 as unittest
@@ -31,6 +33,7 @@ from nupic import engine
 class NetworkTest(unittest.TestCase):
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testErrorHandling(self):
     n = engine.Network()
 
@@ -276,6 +279,7 @@ class NetworkTest(unittest.TestCase):
       print "Time for 1M getParameter calls: %.2f seconds" % (t2 - t1)
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testTwoRegionNetwork(self):
     n = engine.Network()
 
@@ -341,6 +345,7 @@ class NetworkTest(unittest.TestCase):
     print r.getSpec()
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testPyNodeGetSetParameter(self):
     n = engine.Network()
 
@@ -361,6 +366,7 @@ class NetworkTest(unittest.TestCase):
     self.assertEqual(result, 77.7)
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testPyNodeGetNodeSpec(self):
     n = engine.Network()
 
@@ -383,6 +389,7 @@ class NetworkTest(unittest.TestCase):
     self.assertEqual(i.description, 'Primary output for the node')
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testTwoRegionPyNodeNetwork(self):
     n = engine.Network()
 

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -21,7 +21,6 @@
 # ----------------------------------------------------------------------
 
 import sys
-import pytest
 from mock import Mock
 from mock import patch
 import unittest2 as unittest
@@ -33,7 +32,8 @@ from nupic import engine
 class NetworkTest(unittest.TestCase):
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testErrorHandling(self):
     n = engine.Network()
 
@@ -279,7 +279,8 @@ class NetworkTest(unittest.TestCase):
       print "Time for 1M getParameter calls: %.2f seconds" % (t2 - t1)
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testTwoRegionNetwork(self):
     n = engine.Network()
 
@@ -345,7 +346,8 @@ class NetworkTest(unittest.TestCase):
     print r.getSpec()
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testPyNodeGetSetParameter(self):
     n = engine.Network()
 
@@ -366,7 +368,8 @@ class NetworkTest(unittest.TestCase):
     self.assertEqual(result, 77.7)
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testPyNodeGetNodeSpec(self):
     n = engine.Network()
 
@@ -389,7 +392,8 @@ class NetworkTest(unittest.TestCase):
     self.assertEqual(i.description, 'Primary output for the node')
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testTwoRegionPyNodeNetwork(self):
     n = engine.Network()
 

--- a/tests/unit/nupic/engine/syntactic_sugar_test.py
+++ b/tests/unit/nupic/engine/syntactic_sugar_test.py
@@ -22,7 +22,6 @@
 
 
 import sys
-import pytest
 import unittest2 as unittest
 import nupic.engine as net
 
@@ -113,7 +112,8 @@ class NetworkSugarTest(unittest.TestCase):
                                  (('r2', r2), ('r1', r1)))
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testRegion(self):
     r = net.Network().addRegion('r', 'py.TestNode', '')
 
@@ -123,7 +123,8 @@ class NetworkSugarTest(unittest.TestCase):
     self.assertTrue(r.dimensions.isUnspecified())
 
 
-  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testSpec(self):
     ns = net.Region.getSpecFromType('py.TestNode')
     self.assertEqual(ns.description,

--- a/tests/unit/nupic/engine/syntactic_sugar_test.py
+++ b/tests/unit/nupic/engine/syntactic_sugar_test.py
@@ -20,8 +20,10 @@
 # http://numenta.org/licenses/
 # ----------------------------------------------------------------------
 
-import unittest2 as unittest
 
+import sys
+import pytest
+import unittest2 as unittest
 import nupic.engine as net
 
 
@@ -111,6 +113,7 @@ class NetworkSugarTest(unittest.TestCase):
                                  (('r2', r2), ('r1', r1)))
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testRegion(self):
     r = net.Network().addRegion('r', 'py.TestNode', '')
 
@@ -120,6 +123,7 @@ class NetworkSugarTest(unittest.TestCase):
     self.assertTrue(r.dimensions.isUnspecified())
 
 
+  @pytest.mark.skipif("sys.platform == 'win32'", reason="not supported on Windows, yet!")
   def testSpec(self):
     ns = net.Region.getSpecFromType('py.TestNode')
     self.assertEqual(ns.description,


### PR DESCRIPTION
Fixes #2778 Relies on https://github.com/numenta/nupic.core/pull/705

Local output of `py.test tests\unit 2>&1 > .\unit_tests.log` can be found here; https://gist.github.com/rcrowder/b4702019cbda3e323968