### PR TITLE
Allow getting names of inputs and outputs for a region

### DIFF
--- a/examples/network/network_api_demo.py
+++ b/examples/network/network_api_demo.py
@@ -203,10 +203,19 @@ if __name__ == "__main__":
   network = createNetwork(dataSource)
   network.initialize()
 
-  sp = network.getRegion(SPRegion).getAlgorithm()
+  spRegion = network.getRegion(SPRegion)
+  sp = spRegion.getSelf().getAlgorithm()
+  print "spatial pooler region inputs: {0}".format(spRegion.getInputNames())
+  print "spatial pooler region outputs: {0}".format(spRegion.getOutputNames())
   print "# spatial pooler columns: {0}".format(sp.getNumColumns())
-  tm = network.getRegion(TPRegion).getAlgorithm()
+  print
+
+  tmRegion = network.getRegion(TPRegion)
+  tm = tmRegion.getSelf().getAlgorithm()
+  print "temporal memory region inputs: {0}".format(tmRegion.getInputNames())
+  print "temporal memory region outputs: {0}".format(tmRegion.getOutputNames())
   print "# temporal memory columns: {0}".format(tm.numberOfCols)
+  print
 
   outputPath = os.path.join(os.path.dirname(__file__), _OUTPUT_PATH)
   with open(outputPath, "w") as outputFile:

--- a/examples/network/network_api_demo.py
+++ b/examples/network/network_api_demo.py
@@ -31,6 +31,8 @@ from nupic.algorithms.anomaly import computeRawAnomalyScore
 from nupic.data.file_record_stream import FileRecordStream
 from nupic.engine import Network
 from nupic.encoders import MultiEncoder, ScalarEncoder, DateEncoder
+from nupic.regions.SPRegion import SPRegion
+from nupic.regions.TPRegion import TPRegion
 
 _VERBOSITY = 0  # how chatty the demo should be
 _SEED = 1956  # the random seed used throughout
@@ -199,6 +201,13 @@ if __name__ == "__main__":
   dataSource = FileRecordStream(streamID=_INPUT_FILE_PATH)
 
   network = createNetwork(dataSource)
+  network.initialize()
+
+  sp = network.getRegion(SPRegion).getAlgorithm()
+  print "# spatial pooler columns: {0}".format(sp.getNumColumns())
+  tm = network.getRegion(TPRegion).getAlgorithm()
+  print "# temporal memory columns: {0}".format(tm.numberOfCols)
+
   outputPath = os.path.join(os.path.dirname(__file__), _OUTPUT_PATH)
   with open(outputPath, "w") as outputFile:
     writer = csv.writer(outputFile)

--- a/src/nupic/engine/__init__.py
+++ b/src/nupic/engine/__init__.py
@@ -735,18 +735,18 @@ class Network(engine.Network):
       raise TypeError("Save path must be of type {}.".format(str))
     engine.Network.save(self, *args, **kwargs)
 
-  def getRegion(self, regionClass):
+  def getRegionsByType(self, regionClass):
     """
-    Gets a region instance given a region class
+    Gets all region instances of a given class
     (for example, nupic.regions.SPRegion.SPRegion).
-
-    Returns None if no region was found.
     """
+    regions = []
+
     for region in self.regions.values():
       if type(region.getSelf()) is regionClass:
-        return region
+        regions.append(region)
 
-    return None
+    return regions
 
   @staticmethod
   def registerRegion(regionClass):

--- a/src/nupic/engine/__init__.py
+++ b/src/nupic/engine/__init__.py
@@ -721,10 +721,19 @@ class Network(engine.Network):
       raise TypeError("Save path must be of type {}.".format(str))
     engine.Network.save(self, *args, **kwargs)
 
-  def inspect(self):
-    """Launch a GUI inpector to inspect the network"""
-    from nupic.analysis import inspect
-    inspect(self)
+  def getRegion(self, regionClass):
+    """
+    Gets a region instance given a region class
+    (for example, nupic.regions.SPRegion.SPRegion).
+
+    Returns None if no region was found.
+    """
+    for region in self.regions.values():
+      regionInstance = region.getSelf()
+      if type(regionInstance) is regionClass:
+        return regionInstance
+
+    return None
 
   @staticmethod
   def registerRegion(regionClass):

--- a/src/nupic/engine/__init__.py
+++ b/src/nupic/engine/__init__.py
@@ -457,6 +457,20 @@ class Region(LockAttributesMixin):
     """
     return self._region.getOutputArray(outputName)
 
+  def getInputNames(self):
+    """
+    Returns list of input names in spec.
+    """
+    inputs = self.getSpec().inputs
+    return [inputs.getByIndex(i)[0] for i in xrange(inputs.getCount())]
+
+  def getOutputNames(self):
+    """
+    Returns list of output names in spec.
+    """
+    outputs = self.getSpec().outputs
+    return [outputs.getByIndex(i)[0] for i in xrange(outputs.getCount())]
+
   def executeCommand(self, args):
     """
     @doc:place_holder(Region.executeCommand)
@@ -729,9 +743,8 @@ class Network(engine.Network):
     Returns None if no region was found.
     """
     for region in self.regions.values():
-      regionInstance = region.getSelf()
-      if type(regionInstance) is regionClass:
-        return regionInstance
+      if type(region.getSelf()) is regionClass:
+        return region
 
     return None
 

--- a/src/nupic/regions/PyRegion.py
+++ b/src/nupic/regions/PyRegion.py
@@ -177,6 +177,15 @@ class PyRegion(object):
     name: the name of the output
     """
 
+  def getAlgorithm(self):
+    """
+    Returns the underlying algorithm that is performing the computation.
+    This method should be overridden by the region subclass.
+
+    Returns None if there is no underlying algorithm for the region.
+    """
+    return None
+
   def getParameter(self, name, index):
     """Default implementation that return an attribute with the requested name
 

--- a/src/nupic/regions/SPRegion.py
+++ b/src/nupic/regions/SPRegion.py
@@ -756,6 +756,10 @@ class SPRegion(PyRegion):
     return spec
 
 
+  def getAlgorithm(self):
+    return self._sfdr
+
+
   def getParameter(self, parameterName, index=-1):
     """
       Get the value of a NodeSpec parameter. Most parameters are handled

--- a/src/nupic/regions/TPRegion.py
+++ b/src/nupic/regions/TPRegion.py
@@ -677,6 +677,10 @@ class TPRegion(PyRegion):
     return spec
 
 
+  def getAlgorithm(self):
+    return self._tfdr
+
+
   def getParameter(self, parameterName, index=-1):
     """
       Get the value of a parameter. Most parameters are handled automatically by

--- a/tests/integration/nupic/opf/opf_region_test.py
+++ b/tests/integration/nupic/opf/opf_region_test.py
@@ -59,6 +59,7 @@ from nupic.bindings.algorithms import SpatialPooler
 from nupic.research.TP10X2 import TP10X2
 from nupic.regions.SPRegion import SPRegion
 from nupic.regions.TPRegion import TPRegion
+from nupic.regions.AnomalyRegion import AnomalyRegion
 
 _VERBOSITY = 0         # how chatty the unit tests should be
 _SEED = 35             # the random seed used throughout
@@ -313,7 +314,7 @@ class OPFRegionTest(TestCaseBase):
     network = _createOPFNetwork(addSP = True, addTP = True)
     network.run(1)
 
-    spRegion = network.getRegion(SPRegion)
+    spRegion = network.getRegionsByType(SPRegion)[0]
     self.assertEqual(spRegion.getInputNames(),
                      ['bottomUpIn', 'resetIn', 'topDownIn'])
     self.assertEqual(spRegion.getOutputNames(),
@@ -326,8 +327,16 @@ class OPFRegionTest(TestCaseBase):
     network = _createOPFNetwork(addSP = True, addTP = True)
     network.run(1)
 
-    spRegion = network.getRegion(SPRegion)
-    tpRegion = network.getRegion(TPRegion)
+    spRegions = network.getRegionsByType(SPRegion)
+    tpRegions = network.getRegionsByType(TPRegion)
+    anomalyRegions = network.getRegionsByType(AnomalyRegion)
+
+    self.assertEqual(len(spRegions), 1)
+    self.assertEqual(len(tpRegions), 1)
+    self.assertEqual(len(anomalyRegions), 0)
+
+    spRegion = spRegions[0]
+    tpRegion = tpRegions[0]
 
     sp = spRegion.getSelf().getAlgorithm()
     tp = tpRegion.getSelf().getAlgorithm()

--- a/tests/integration/nupic/opf/opf_region_test.py
+++ b/tests/integration/nupic/opf/opf_region_test.py
@@ -309,6 +309,19 @@ class OPFRegionTest(TestCaseBase):
     """
 
 
+  def testGetInputOutputNamesOnRegions(self):
+    network = _createOPFNetwork(addSP = True, addTP = True)
+    network.run(1)
+
+    spRegion = network.getRegion(SPRegion)
+    self.assertEqual(spRegion.getInputNames(),
+                     ['bottomUpIn', 'resetIn', 'topDownIn'])
+    self.assertEqual(spRegion.getOutputNames(),
+                     ['topDownOut', 'spatialTopDownOut', 'temporalTopDownOut',
+                      'bottomUpOut', 'anomalyScore'])
+
+
+
   def testGetAlgorithmOnRegions(self):
     network = _createOPFNetwork(addSP = True, addTP = True)
     network.run(1)
@@ -316,8 +329,8 @@ class OPFRegionTest(TestCaseBase):
     spRegion = network.getRegion(SPRegion)
     tpRegion = network.getRegion(TPRegion)
 
-    sp = spRegion.getAlgorithm()
-    tp = tpRegion.getAlgorithm()
+    sp = spRegion.getSelf().getAlgorithm()
+    tp = tpRegion.getSelf().getAlgorithm()
 
     self.assertEqual(type(sp), SpatialPooler)
     self.assertEqual(type(tp), TP10X2)

--- a/tests/integration/nupic/opf/opf_region_test.py
+++ b/tests/integration/nupic/opf/opf_region_test.py
@@ -55,6 +55,11 @@ from nupic.engine import Network
 from nupic.encoders import MultiEncoder
 from nupic.support.unittesthelpers.testcasebase import TestCaseBase
 
+from nupic.bindings.algorithms import SpatialPooler
+from nupic.research.TP10X2 import TP10X2
+from nupic.regions.SPRegion import SPRegion
+from nupic.regions.TPRegion import TPRegion
+
 _VERBOSITY = 0         # how chatty the unit tests should be
 _SEED = 35             # the random seed used throughout
 
@@ -302,6 +307,20 @@ class OPFRegionTest(TestCaseBase):
     netOPF.run(1)
     print "RUN SUCCEEDED"
     """
+
+
+  def testGetAlgorithmOnRegions(self):
+    network = _createOPFNetwork(addSP = True, addTP = True)
+    network.run(1)
+
+    spRegion = network.getRegion(SPRegion)
+    tpRegion = network.getRegion(TPRegion)
+
+    sp = spRegion.getAlgorithm()
+    tp = tpRegion.getAlgorithm()
+
+    self.assertEqual(type(sp), SpatialPooler)
+    self.assertEqual(type(tp), TP10X2)
 
 
 

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -25,6 +25,8 @@ from mock import patch
 import unittest2 as unittest
 
 from nupic import engine
+from nupic.bindings.regions.TestNode import TestNode
+from nupic.regions.SPRegion import SPRegion
 
 
 
@@ -406,6 +408,15 @@ class NetworkTest(unittest.TestCase):
     self.assertEqual(len(r2dims), 2)
     self.assertEqual(r2dims[0], 3)
     self.assertEqual(r2dims[1], 2)
+
+
+  def testGetRegion(self):
+    n = engine.Network()
+
+    region1 = n.addRegion("region1", "py.TestNode", "")
+
+    self.assertEqual(n.getRegion(TestNode), region1.getSelf())
+    self.assertEqual(n.getRegion(SPRegion), None)
 
 
 

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -412,11 +412,12 @@ class NetworkTest(unittest.TestCase):
 
   def testGetRegion(self):
     n = engine.Network()
+    n.addRegion("region1", "py.TestNode", "")
 
-    region1 = n.addRegion("region1", "py.TestNode", "")
+    region = n.getRegionsByType(TestNode)[0]
+    self.assertEqual(type(region.getSelf()), TestNode)
 
-    self.assertEqual(n.getRegion(TestNode), region1.getSelf())
-    self.assertEqual(n.getRegion(SPRegion), None)
+    self.assertEqual(n.getRegionsByType(SPRegion), [])
 
 
 


### PR DESCRIPTION
Builds on https://github.com/numenta/nupic/pull/2781.

Fixes https://github.com/numenta/nupic/issues/2784.

Adds examples to `network_api_demo.py` for getting names of inputs and outputs for region (it already has examples for getting input and output data given a name).