### PR TITLE
Capnp lite network test

### DIFF
--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -26,7 +26,14 @@ from mock import patch
 import unittest2 as unittest
 
 from nupic import engine
-from nupic.bindings.regions.TestNode import TestNode
+
+try:
+  import capnp
+except ImportError:
+  capnp = None
+if capnp:
+  from nupic.bindings.regions.TestNode import TestNode
+
 from nupic.regions.SPRegion import SPRegion
 
 
@@ -421,6 +428,8 @@ class NetworkTest(unittest.TestCase):
     self.assertEqual(r2dims[1], 2)
 
 
+  @unittest.skipIf(sys.platform.lower().startswith("win"),
+                   "Not supported on Windows, yet!")
   def testGetRegion(self):
     n = engine.Network()
     n.addRegion("region1", "py.TestNode", "")


### PR DESCRIPTION
Fixes #2812 Isolating testGetRegion (https://github.com/numenta/nupic/pull/2785/files#diff-a65356031cc33c41b0275ad30a763af6R413) unit test. And isolating the TestNode import.