### PR TITLE
Update temporal memory compatibility test to use C++ TM.

### DIFF
--- a/src/nupic/regions/TPRegion.py
+++ b/src/nupic/regions/TPRegion.py
@@ -42,6 +42,8 @@ def _getTPClass(temporalImp):
     return TP10X2.TP10X2
   elif temporalImp == 'tm_py':
     return TP_shim.TPShim
+  elif temporalImp == 'tm_cpp':
+    return TP_shim.TPCPPShim
   elif temporalImp == 'tm_py_fast':
     return TP_shim.FastTPShim
   elif temporalImp == 'monitored_tm_py':
@@ -424,7 +426,7 @@ class TPRegion(PyRegion):
       tpClass = _getTPClass(self.temporalImp)
 
       if self.temporalImp in ['py', 'cpp', 'r',
-                              'tm_py', 'tm_py_fast',
+                              'tm_py', 'tm_cpp', 'tm_py_fast',
                               'monitored_tm_py', 'monitored_tm_py_fast']:
         self._tfdr = tpClass(
              numberOfCols=self.columnCount,

--- a/src/nupic/research/TP_shim.py
+++ b/src/nupic/research/TP_shim.py
@@ -27,9 +27,12 @@ for use with OPF.
 import numpy
 
 from nupic.research.temporal_memory import TemporalMemory
+from nupic.bindings.algorithms import TemporalMemory as TemporalMemoryCPP
 from nupic.research.fast_temporal_memory import FastTemporalMemory
 from nupic.research.monitor_mixin.temporal_memory_monitor_mixin import (
   TemporalMemoryMonitorMixin)
+
+
 
 class MonitoredTemporalMemory(TemporalMemoryMonitorMixin,
                               TemporalMemory): pass
@@ -39,7 +42,7 @@ class MonitoredFastTemporalMemory(TemporalMemoryMonitorMixin,
 
 
 
-class TPShim(TemporalMemory):
+class TPShimMixin(object):
   """
   TP => Temporal Memory shim class.
   """
@@ -66,7 +69,7 @@ class TPShim(TemporalMemory):
     """
     Translate parameters and initialize member variables specific to `TP.py`.
     """
-    super(TPShim, self).__init__(
+    super(TPShimMixin, self).__init__(
       columnDimensions=(numberOfCols,),
       cellsPerColumn=cellsPerColumn,
       activationThreshold=activationThreshold,
@@ -96,7 +99,7 @@ class TPShim(TemporalMemory):
                              If true, compute the inference output
                              If false, do not compute the inference output
     """
-    super(TPShim, self).compute(set(bottomUpInput.nonzero()[0]),
+    super(TPShimMixin, self).compute(set(bottomUpInput.nonzero()[0]),
                                             learn=enableLearn)
     numberOfCells = self.numberOfCells()
 
@@ -137,8 +140,18 @@ class TPShim(TemporalMemory):
 
 
   def getLearnActiveStateT(self):
-    state = numpy.zeros([self.numberOfColumns(), self.cellsPerColumn])
+    state = numpy.zeros([self.numberOfColumns(), self.getCellsPerColumn()])
     return state
+
+
+
+class TPShim(TPShimMixin, TemporalMemory):
+  pass
+
+
+
+class TPCPPShim(TPShimMixin, TemporalMemoryCPP):
+  pass
 
 
 

--- a/src/nupic/research/temporal_memory.py
+++ b/src/nupic/research/temporal_memory.py
@@ -709,6 +709,15 @@ class TemporalMemory(object):
     return self.getCellIndices(self.matchingCells)
 
 
+  def getCellsPerColumn(self):
+    """
+    Returns the number of cells per column.
+
+    @return (int) The number of cells per column.
+    """
+    return self.cellsPerColumn
+
+
   def mapCellsToColumns(self, cells):
     """
     Maps cells to the columns they belong to

--- a/tests/integration/nupic/engine/temporal_memory_compatibility_test.py
+++ b/tests/integration/nupic/engine/temporal_memory_compatibility_test.py
@@ -39,10 +39,8 @@ class TemporalMemoryCompatibilityTest(unittest.TestCase):
     results1 = createAndRunNetwork(TPRegion,
                                    "bottomUpOut",
                                    checkpointMidway=False,
-                                   temporalImp="tm_py")
+                                   temporalImp="tm_cpp")
 
-    # temporalImp="tm_py" here is a temporary placeholder value until C++ TM is
-    # finished, at which point it should be changed to "cpp"
     results2 = createAndRunNetwork(TPRegion,
                                    "bottomUpOut",
                                    checkpointMidway=False,


### PR DESCRIPTION
Fixes #2980 

CI build won't pass until these are merged:
- numenta/nupic.core#841 (merged)
- numenta/nupic.core#842 (merged)

Additionally, although I believe the compatibility test is correct, it does not pass. Added skip with reference to issue #2986.

Update: skip removed. Should pass once numenta/nupic.core#846 is merged.