### PR TITLE
Lower TM epsilon threshold for compatibility.

### DIFF
--- a/src/nupic/research/temporal_memory.py
+++ b/src/nupic/research/temporal_memory.py
@@ -31,7 +31,7 @@ from nupic.research.connections import Connections
 
 
 
-EPSILON = 0.0000001
+EPSILON = 0.000001
 
 
 
@@ -594,7 +594,7 @@ class TemporalMemory(object):
       # Keep permanence within min/max bounds
       permanence = max(0.0, min(1.0, permanence))
 
-      if (abs(permanence) < EPSILON):
+      if (permanence < EPSILON):
         connections.destroySynapse(synapse)
       else:
         connections.updateSynapsePermanence(synapse, permanence)


### PR DESCRIPTION
Replaces #3000 
Starts on #2999 

Probably depends on numenta/nupic.core#860