### PR TITLE
Make it easier to subclass RecordSensor.py

### DIFF
--- a/src/nupic/regions/RecordSensor.py
+++ b/src/nupic/regions/RecordSensor.py
@@ -572,4 +572,4 @@ class RecordSensor(PyRegion):
     instance.numCategories = proto.numCategories
 
     return instance
-  
+

--- a/src/nupic/regions/RecordSensor.py
+++ b/src/nupic/regions/RecordSensor.py
@@ -251,8 +251,8 @@ class RecordSensor(PyRegion):
     This method is separate from compute() so that we can use
     a standalone RecordSensor to get filtered data"""
 
-    foundData = False
-    while not foundData:
+    allFiltersHaveEnoughData = False
+    while not allFiltersHaveEnoughData:
       # Get the data from the dataSource
       data = self.dataSource.getNextRecordDict()
 
@@ -267,36 +267,48 @@ class RecordSensor(PyRegion):
       if "_category" not in data:
         data["_category"] = [None]
 
-      if self.verbosity > 0:
-        print "RecordSensor got data: %s" % data
-
-
-      # Apply pre-encoding filters.
-      # These filters may modify or add data
-      # If a filter needs another record (e.g. a delta filter)
-      # it will request another record by returning False and the current record
-      # will be skipped (but will still be given to all filters)
-      #
-      # We have to be very careful about resets. A filter may add a reset,
-      # but other filters should not see the added reset, each filter sees
-      # the original reset value, and we keep track of whether any filter
-      # adds a reset.
-      foundData = True
-      if len(self.preEncodingFilters) > 0:
-        originalReset = data['_reset']
-        actualReset = originalReset
-        for f in self.preEncodingFilters:
-          # if filter needs more data, it returns False
-          result = f.process(data)
-          foundData = foundData and result
-          actualReset = actualReset or data['_reset']
-          data['_reset'] = originalReset
-        data['_reset'] = actualReset
-
+      data, filterHasEnoughData = self.applyFilters(data)
 
     self.lastRecord = data
 
     return data
+
+
+  def applyFilters(self, data):
+    """Apply pre-encoding filters.
+    These filters may modify or add data
+    If a filter needs another record (e.g. a delta filter)
+    it will request another record by returning False and the current record
+    will be skipped (but will still be given to all filters)
+
+    We have to be very careful about resets. A filter may add a reset,
+    but other filters should not see the added reset, each filter sees
+    the original reset value, and we keep track of whether any filter
+    adds a reset.
+
+    @param data: The data that will be processed by the filter.
+    @type data: dict
+    @return: a tuple with the data processed by the filter and a boolean to 
+      know whether or not the filter needs mode data.
+    """
+
+    if self.verbosity > 0:
+      print "RecordSensor got data: %s" % data
+
+    allFiltersHaveEnoughData = True
+    if len(self.preEncodingFilters) > 0:
+      originalReset = data['_reset']
+      actualReset = originalReset
+      for f in self.preEncodingFilters:
+        # if filter needs more data, it returns False
+        filterHasEnoughData = f.process(data)
+        allFiltersHaveEnoughData = (allFiltersHaveEnoughData 
+                                    and filterHasEnoughData)
+        actualReset = actualReset or data['_reset']
+        data['_reset'] = originalReset
+      data['_reset'] = actualReset
+
+    return data, allFiltersHaveEnoughData
 
 
   def populateCategoriesOut(self, categories, output):


### PR DESCRIPTION
This PR supplements an addition to nupic.research: I needed to subclass RecordSensor.py to create a new sensor region that has the flexibility to be fed data manually [1] so I slightly refactored `RecordSensor.py`. Basically I just took out a chunk of code (that could have used its own method anyway) into a new method that I named `self.applyFilters`. I'm calling this method in the subclass when I override `self.getNextRecord`.

[1] Use case described in the companion `nupic.research` PR https://github.com/numenta/nupic.research/pull/460: I needed the flexibility to read data from a CSV or get data from RabbitMQ and feed it message by message to the region.

cc @subutai @rhyolight 

Fixes: #3065 