### PR TITLE
Fix bugs and inconsistencies in the custom region demo

### DIFF
--- a/examples/network/custom_region/identity_region.py
+++ b/examples/network/custom_region/identity_region.py
@@ -33,11 +33,10 @@ class IdentityRegion(PyRegion):
   def __init__(self, dataWidth):
     if dataWidth <= 0:
       raise ValueError("Parameter dataWidth must be > 0")
-    
     self._dataWidth = dataWidth
 
 
-  def initialize(self, inputs, outputs):
+  def initialize(self, dims, splitterMaps):
     pass
 
 
@@ -45,14 +44,12 @@ class IdentityRegion(PyRegion):
     """
     Run one iteration of IdentityRegion's compute
     """
-    outputs["out"] = inputs["in"]
+    outputs["out"][:] = inputs["in"]
 
 
   @classmethod
   def getSpec(cls):
-    """Return the base Spec for MySPRegion.
-
-    Doesn't include the spatial, temporal and other parameters
+    """Return the Spec for IdentityRegion.
     """
     spec = {
         "description":IdentityRegion.__doc__,
@@ -90,4 +87,7 @@ class IdentityRegion(PyRegion):
 
 
   def getOutputElementCount(self, name):
+    if name == "out":
       return self._dataWidth
+    else:
+      raise Exception("Unrecognized output: " + name)

--- a/examples/network/custom_region_demo.py
+++ b/examples/network/custom_region_demo.py
@@ -40,12 +40,6 @@ _INPUT_FILE_PATH = resource_filename(
 _OUTPUT_PATH = "network-demo-output.csv"
 _NUM_RECORDS = 2000
 
-# Config field for IdentityRegion
-I_PARAMS = {
-    "dataWidth": 1,
-}
-
-
 
 def createEncoder():
   """Create the encoder instance for our test and return it."""
@@ -97,11 +91,13 @@ def createNetwork(dataSource):
   Network.registerRegion(IdentityRegion)
 
   # Create a custom region
-  network.addRegion("identityRegion", "py.IdentityRegion", json.dumps(I_PARAMS))
+  network.addRegion("identityRegion", "py.IdentityRegion",
+                    json.dumps({
+                      "dataWidth": sensor.encoder.getWidth(),
+                    }))
 
-  # Link the Identity region to the sensor input
-  network.link("sensor", "identityRegion", "UniformLink", "",
-               srcOutput="sourceOut", destInput="in")
+  # Link the Identity region to the sensor output
+  network.link("sensor", "identityRegion", "UniformLink", "")
 
   network.initialize()
 
@@ -120,9 +116,9 @@ def runNetwork(network, writer):
     # Run the network for a single iteration
     network.run(1)
 
-    # Write out the record number and original value
-    consumption = identityRegion.getOutputData("out")[0]
-    writer.writerow((i, consumption))
+    # Write out the record number and encoding
+    encoding = identityRegion.getOutputData("out")
+    writer.writerow((i, encoding))
 
 
 


### PR DESCRIPTION
Fixes #3031 

It's weird that the IdentityRegion doesn't infer the output size from the input size, but a quick look tells me that this is a flaw in Python regions in general. It's possible to do that with C++ regions, but not Python regions. I can't find a way to access inputs from the `initialize` method. (The parameter names are lies -- they're not "inputs, outputs", they're "dims, splitterMaps"). You can see incorrect args in the nupic bindings... https://github.com/numenta/nupic.core/blob/master/bindings/py/nupic/bindings/regions/PyRegion.py#L131

Also `getOutputElementCount` is getting called before `initialize`, which seems like a bug.

So I fixed the inconsistencies in this demo, but there's more to investigate here.