### PR TITLE
Fix erroneous documentation in SDR classifier

### DIFF
--- a/src/nupic/algorithms/sdr_classifier.py
+++ b/src/nupic/algorithms/sdr_classifier.py
@@ -310,8 +310,7 @@ class SDRClassifier(object):
   def infer(self, patternNZ, classification):
     """
     Return the inference value from one input sample. The actual
-    learning happens in compute(). The method customCompute() is here to
-    maintain backward compatibility.
+    learning happens in compute().
 
     Parameters:
     --------------------------------------------------------------------


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/3067
@cogmission Thanks for catching the erroneous documentation. It was a legacy of the CLAclassifier. I have removed it.