### PR TITLE
Fixed Username Regex in ClientJobsDAO

### DIFF
--- a/src/nupic/database/ClientJobsDAO.py
+++ b/src/nupic/database/ClientJobsDAO.py
@@ -522,8 +522,9 @@ class ClientJobsDAO(object):
     # DB Name suffix
     suffix = Configuration.get('nupic.cluster.database.nameSuffix')
 
-    # Replace dash with underscore (dash will break SQL e.g. 'ec2-user')
+    # Replace dash and dot with underscore (e.g. 'ec2-user' or ec2.user will break SQL)
     suffix = suffix.replace("-", "_")
+    suffix = suffix.replace(".", "_")
 
     # Create the name of the database for the given DB version
     dbName = '%s_%s' % (prefix, suffix)


### PR DESCRIPTION
While building and installing Nupic faced issue with dot in the user name. Having a dot in the username will not work because most SQL languages use the dot as a relation.

cc: @rhyolight 

Fixes #3073 