### PR TITLE
Stop relying on a nupic.core ASSERT to check parameters

### DIFF
--- a/src/nupic/algorithms/KNNClassifier.py
+++ b/src/nupic/algorithms/KNNClassifier.py
@@ -407,14 +407,12 @@ class KNNClassifier(object):
                                               cellsPerCol=self.cellsPerCol)
 
     if isSparse > 0:
-      isSorted = all(inputPattern[i] <= inputPattern[i+1]
-                     for i in xrange(len(inputPattern)-1))
-      if not isSorted:
-        raise RuntimeError("Sparse inputPattern must be sorted.")
-
-      if not all(bit < isSparse for bit in inputPattern):
-        raise RuntimeError("Sparse inputPattern contains an index outside of"
-                           "the dense representation's bounds.")
+      assert all(inputPattern[i] <= inputPattern[i+1]
+                 for i in xrange(len(inputPattern)-1)), \
+                     "Sparse inputPattern must be sorted."
+      assert all(bit < isSparse for bit in inputPattern), \
+        ("Sparse inputPattern must not index outside the dense "
+         "representation's bounds.")
 
     if rowID is None:
       rowID = self._iterationIdx

--- a/src/nupic/algorithms/KNNClassifier.py
+++ b/src/nupic/algorithms/KNNClassifier.py
@@ -406,6 +406,16 @@ class KNNClassifier(object):
       print "  active inputs:", _labeledInput(inputPattern,
                                               cellsPerCol=self.cellsPerCol)
 
+    if isSparse > 0:
+      isSorted = all(inputPattern[i] <= inputPattern[i+1]
+                     for i in xrange(len(inputPattern)-1))
+      if not isSorted:
+        raise RuntimeError("Sparse inputPattern must be sorted.")
+
+      if not all(bit < isSparse for bit in inputPattern):
+        raise RuntimeError("Sparse inputPattern contains an index outside of"
+                           "the dense representation's bounds.")
+
     if rowID is None:
       rowID = self._iterationIdx
 

--- a/tests/unit/nupic/algorithms/knn_classifier_test.py
+++ b/tests/unit/nupic/algorithms/knn_classifier_test.py
@@ -410,6 +410,7 @@ class KNNClassifierTest(unittest.TestCase):
     self.assertEquals(cat, 1)
 
 
+  @unittest.skipUnless(__debug__, "Only applicable when asserts are enabled")
   def testOverlapDistanceMethodBadSparsity(self):
     """Sparsity (input dimensionality) less than input array"""
     params = {"distanceMethod": "rawOverlap"}
@@ -418,7 +419,7 @@ class KNNClassifierTest(unittest.TestCase):
     a = np.array([1, 3, 7, 11, 13, 17, 19, 23, 29], dtype=np.int32)
 
     # Learn with incorrect dimensionality, less than some bits (23, 29)
-    with self.assertRaises(RuntimeError):
+    with self.assertRaises(AssertionError):
       classifier.learn(a, 0, isSparse=20)
 
 
@@ -442,7 +443,7 @@ class KNNClassifierTest(unittest.TestCase):
     self.assertEquals(cat, 0)
 
 
-
+  @unittest.skipUnless(__debug__, "Only applicable when asserts are enabled")
   def testOverlapDistanceMethodStandardUnsorted(self):
     """If sparse representation indices are unsorted expect error."""
     params = {"distanceMethod": "rawOverlap"}
@@ -452,10 +453,10 @@ class KNNClassifierTest(unittest.TestCase):
     a = np.array([29, 3, 7, 11, 13, 17, 19, 23, 1], dtype=np.int32)
     b = np.array([2, 4, 20, 12, 14, 18, 8, 28, 30], dtype=np.int32)
 
-    with self.assertRaises(RuntimeError):
+    with self.assertRaises(AssertionError):
       classifier.learn(a, 0, isSparse=dimensionality)
 
-    with self.assertRaises(RuntimeError):
+    with self.assertRaises(AssertionError):
       classifier.learn(b, 1, isSparse=dimensionality)
 
 


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/3110

nupic.core NTA_ASSERTs are no longer in Release builds.

An alternate fix would be to convert these NTA_ASSERTs to NTA_CHECKs. But they're potentially expensive checks. The nupic.core math code was written to become faster with NTA_ASSERTIONS_ON disabled, and it's best to keep it that way.

Since the unit tests expect this param checking, implement it on the Python side.