### PR TITLE
Suppress optional dependency on matplotlib without logging

### DIFF
--- a/src/nupic/research/monitor_mixin/plot.py
+++ b/src/nupic/research/monitor_mixin/plot.py
@@ -31,10 +31,12 @@ try:
   import matplotlib.pyplot as plt
   import matplotlib.cm as cm
 except ImportError:
-  # Suppress; we log it at debug level to avoid polluting the logs of apps
-  # and services that don't care about plotting
-  logging.debug("Cannot import matplotlib. Plot class will not work.",
-                exc_info=True)
+  # Suppress this optional dependency on matplotlib. NOTE we don't log this,
+  # because python logging implicitly adds the StreamHandler to root logger when
+  # calling `logging.debug`, etc., which may undermine an application's logging
+  # configuration.
+  plt = None
+  cm = None
 
 
 

--- a/src/nupic/research/monitor_mixin/plot.py
+++ b/src/nupic/research/monitor_mixin/plot.py
@@ -23,7 +23,6 @@
 Plot class used in monitor mixin framework.
 """
 
-import logging
 import os
 
 try:


### PR DESCRIPTION
Suppress this optional dependency on matplotlib without logging, because
python logging implicitly adds the StreamHandler to root logger when
calling `logging.debug`, etc., which may undermine an application's logging
configuration.

For example, the old behavior resulted in a bug in an application that had to be addressed by this workaround: https://github.com/numenta/numenta-apps/pull/757