### PR TITLE
Change verbose variable name for classifiers to 'verbosity'

### DIFF
--- a/examples/NuPIC Walkthrough.ipynb
+++ b/examples/NuPIC Walkthrough.ipynb
@@ -1,1548 +1,1904 @@
 {
- "metadata": {
-  "name": "",
-  "signature": "sha256:d5eb0b572ecbf560e545c3b61fd48aed11d949ba39fcff4392a5486c3fe1e8dd"
- },
- "nbformat": 3,
- "nbformat_minor": 0,
- "worksheets": [
+ "cells": [
   {
-   "cells": [
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Encoders\n",
+    "\n",
+    "* Scalar\n",
+    "* Date/time\n",
+    "* Category\n",
+    "* Multi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import numpy"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nupic.encoders import ScalarEncoder\n",
+    "\n",
+    "ScalarEncoder?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
     {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Encoders\n",
-      "\n",
-      "* Scalar\n",
-      "* Date/time\n",
-      "* Category\n",
-      "* Multi"
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 = [1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n",
+      "4 = [1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n",
+      "5 = [0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n"
      ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import numpy"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 1
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.encoders import ScalarEncoder\n",
-      "\n",
-      "ScalarEncoder?\n"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 2
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# 22 bits with 3 active representing values 0 to 100\n",
-      "# clipInput=True makes values >100 encode the same as 100 (instead of throwing a ValueError)\n",
-      "# forced=True allows small values for `n` and `w`\n",
-      "enc = ScalarEncoder(n=22, w=3, minval=2.5, maxval=97.5, clipInput=True, forced=True)\n",
-      "print \"3 =\", enc.encode(3)\n",
-      "print \"4 =\", enc.encode(4)\n",
-      "print \"5 =\", enc.encode(5)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "3 = [1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n",
-        "4 = [1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n",
-        "5 = [0 1 1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 3
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Encode maxval\n",
-      "print \"100  =\", enc.encode(100)\n",
-      "# See that any larger number gets the same encoding\n",
-      "print \"1000 =\", enc.encode(1000)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "100  = [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n",
-        "1000 = [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n"
-       ]
-      }
-     ],
-     "prompt_number": 4
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.encoders.random_distributed_scalar import RandomDistributedScalarEncoder\n",
-      "\n",
-      "RandomDistributedScalarEncoder?"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 5
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# 21 bits with 3 active with buckets of size 5\n",
-      "rdse = RandomDistributedScalarEncoder(n=21, w=3, resolution=5, offset=2.5)\n",
-      "\n",
-      "print \"3 =   \", rdse.encode(3)\n",
-      "print \"4 =   \", rdse.encode(4)\n",
-      "print \"5 =   \", rdse.encode(5)\n",
-      "print\n",
-      "print \"100 = \", rdse.encode(100)\n",
-      "print \"1000 =\", rdse.encode(1000)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "3 =    [1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0]\n",
-        "4 =    [1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0]\n",
-        "5 =    [0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 0 0 0]\n",
-        "\n",
-        "100 =  [0 0 0 1 0 0 0 0 0 0 0 0 0 1 0 0 0 1 0 0 0]\n",
-        "1000 = [0 1 0 0 0 0 0 0 0 0 0 0 0 0 1 0 0 0 0 0 1]\n"
-       ]
-      }
-     ],
-     "prompt_number": 6
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "import datetime\n",
-      "from nupic.encoders.date import DateEncoder\n",
-      "\n",
-      "DateEncoder?"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 7
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "de = DateEncoder(season=5)\n",
-      "\n",
-      "now = datetime.datetime.strptime(\"2014-05-02 13:08:58\", \"%Y-%m-%d %H:%M:%S\")\n",
-      "print \"now =       \", de.encode(now)\n",
-      "nextMonth = datetime.datetime.strptime(\"2014-06-02 13:08:58\", \"%Y-%m-%d %H:%M:%S\")\n",
-      "print \"next month =\", de.encode(nextMonth)\n",
-      "xmas = datetime.datetime.strptime(\"2014-12-25 13:08:58\", \"%Y-%m-%d %H:%M:%S\")\n",
-      "print \"xmas =      \", de.encode(xmas)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "now =        [0 0 0 0 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0]\n",
-        "next month = [0 0 0 0 0 0 1 1 1 1 1 0 0 0 0 0 0 0 0 0]\n",
-        "xmas =       [1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n"
-       ]
-      }
-     ],
-     "prompt_number": 8
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.encoders.category import CategoryEncoder\n",
-      "\n",
-      "categories = (\"cat\", \"dog\", \"monkey\", \"slow loris\")\n",
-      "encoder = CategoryEncoder(w=3, categoryList=categories, forced=True)\n",
-      "cat = encoder.encode(\"cat\")\n",
-      "dog = encoder.encode(\"dog\")\n",
-      "monkey = encoder.encode(\"monkey\")\n",
-      "loris = encoder.encode(\"slow loris\")\n",
-      "print \"cat =       \", cat\n",
-      "print \"dog =       \", dog\n",
-      "print \"monkey =    \", monkey\n",
-      "print \"slow loris =\", loris"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "cat =        [0 0 0 1 1 1 0 0 0 0 0 0 0 0 0]\n",
-        "dog =        [0 0 0 0 0 0 1 1 1 0 0 0 0 0 0]\n",
-        "monkey =     [0 0 0 0 0 0 0 0 0 1 1 1 0 0 0]\n",
-        "slow loris = [0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n"
-       ]
-      }
-     ],
-     "prompt_number": 9
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print encoder.encode(None)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 10
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print encoder.encode(\"unknown\")"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[1 1 1 0 0 0 0 0 0 0 0 0 0 0 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 11
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print encoder.decode(cat)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "({'category': ([(1, 1)], 'cat')}, ['category'])\n"
-       ]
-      }
-     ],
-     "prompt_number": 12
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "catdog = numpy.array([0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0])\n",
-      "print encoder.decode(catdog)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "({'category': ([(1, 2)], 'cat, dog')}, ['category'])\n"
-       ]
-      }
-     ],
-     "prompt_number": 13
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Spatial Pooler"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.research.spatial_pooler import SpatialPooler\n",
-      "\n",
-      "print SpatialPooler?"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 14
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print SpatialPooler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print SpatialPooler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
-       ]
-      }
-     ],
-     "prompt_number": 15
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print SpatialPooler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
-       ]
-      }
-     ],
-     "prompt_number": 16
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print SpatialPooler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
-       ]
-      }
-     ],
-     "prompt_number": 17
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print SpatialPooler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
-       ]
-      }
-     ],
-     "prompt_number": 18
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print SpatialPooler"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
-       ]
-      }
-     ],
-     "prompt_number": 19
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print len(cat)\n",
-      "print cat"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "15\n",
-        "[0 0 0 1 1 1 0 0 0 0 0 0 0 0 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 20
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sp = SpatialPooler(inputDimensions=(15,),\n",
-      "                   columnDimensions=(4,),\n",
-      "                   potentialRadius=15,\n",
-      "                   numActiveColumnsPerInhArea=1,\n",
-      "                   globalInhibition=True,\n",
-      "                   synPermActiveInc=0.03,\n",
-      "                   potentialPct=1.0)\n",
-      "import numpy\n",
-      "for column in xrange(4):\n",
-      "    connected = numpy.zeros((15,), dtype=\"int\")\n",
-      "    sp.getConnectedSynapses(column, connected)\n",
-      "    print connected"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 1 0 0 1 0 0 0 0 1 1 0 1 1]\n",
-        "[1 1 0 0 0 1 0 1 0 0 0 1 1 1 1]\n",
-        "[0 1 1 0 0 1 0 1 1 1 1 0 1 0 1]\n",
-        "[1 1 1 0 0 1 0 1 1 0 1 0 1 1 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 21
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "output = numpy.zeros((4,), dtype=\"int\")\n",
-      "sp.compute(cat, learn=True, activeArray=output)\n",
-      "print output"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 1 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 22
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for _ in xrange(20):\n",
-      "    sp.compute(cat, learn=True, activeArray=output)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 23
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for column in xrange(4):\n",
-      "    connected = numpy.zeros((15,), dtype=\"int\")\n",
-      "    sp.getConnectedSynapses(column, connected)\n",
-      "    print connected"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 1 0 0 1 0 0 0 0 1 1 0 1 1]\n",
-        "[1 1 0 0 0 1 0 1 0 0 0 1 1 1 1]\n",
-        "[0 0 0 1 1 1 0 0 0 0 0 0 0 0 0]\n",
-        "[1 1 1 0 0 1 0 1 1 0 1 0 1 1 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 24
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for _ in xrange(200):\n",
-      "    sp.compute(cat, learn=True, activeArray=output)\n",
-      "    sp.compute(dog, learn=True, activeArray=output)\n",
-      "    sp.compute(monkey, learn=True, activeArray=output)\n",
-      "    sp.compute(loris, learn=True, activeArray=output)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 25
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "for column in xrange(4):\n",
-      "    connected = numpy.zeros((15,), dtype=\"int\")\n",
-      "    sp.getConnectedSynapses(column, connected)\n",
-      "    print connected"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 0 0 0 0 0 0 0 1 1 1 0 0 0]\n",
-        "[0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n",
-        "[0 0 0 1 1 1 0 0 0 0 0 0 0 0 0]\n",
-        "[0 0 0 0 0 0 1 1 1 0 0 0 0 0 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 26
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "noisyCat = numpy.zeros((15,), dtype=\"uint32\")\n",
-      "noisyCat[3] = 1\n",
-      "noisyCat[4] = 1\n",
-      "# This is part of dog!\n",
-      "noisyCat[6] = 1\n",
-      "print noisyCat"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 0 1 1 0 1 0 0 0 0 0 0 0 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 27
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "sp.compute(noisyCat, learn=False, activeArray=output)\n",
-      "print output  # matches cat!"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "[0 0 1 0]\n"
-       ]
-      }
-     ],
-     "prompt_number": 28
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Temporal Memory (a.k.a. Sequence Memory, Temporal Pooler)\n",
-      "\n",
-      "From: `examples/tp/hello_tm.py`"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.research.TP import TP\n",
-      "\n",
-      "TP?"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 29
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Step 1: create Temporal Pooler instance with appropriate parameters\n",
-      "tp = TP(numberOfCols=50, cellsPerColumn=2,\n",
-      "        initialPerm=0.5, connectedPerm=0.5,\n",
-      "        minThreshold=10, newSynapseCount=10,\n",
-      "        permanenceInc=0.1, permanenceDec=0.0,\n",
-      "        activationThreshold=8,\n",
-      "        globalDecay=0, burnIn=1,\n",
-      "        checkSynapseConsistency=False,\n",
-      "        pamLength=10)"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 30
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Step 2: create input vectors to feed to the temporal pooler. Each input vector\n",
-      "# must be numberOfCols wide. Here we create a simple sequence of 5 vectors\n",
-      "# representing the sequence A -> B -> C -> D -> E\n",
-      "x = numpy.zeros((5, tp.numberOfCols), dtype=\"uint32\")\n",
-      "x[0,0:10]  = 1   # Input SDR representing \"A\", corresponding to columns 0-9\n",
-      "x[1,10:20] = 1   # Input SDR representing \"B\", corresponding to columns 10-19\n",
-      "x[2,20:30] = 1   # Input SDR representing \"C\", corresponding to columns 20-29\n",
-      "x[3,30:40] = 1   # Input SDR representing \"D\", corresponding to columns 30-39\n",
-      "x[4,40:50] = 1   # Input SDR representing \"E\", corresponding to columns 40-49"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 31
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Step 3: send this simple sequence to the temporal pooler for learning\n",
-      "# We repeat the sequence 10 times\n",
-      "for i in range(10):\n",
-      "\n",
-      "    # Send each letter in the sequence in order\n",
-      "    for j in range(5):\n",
-      "\n",
-      "        # The compute method performs one step of learning and/or inference. Note:\n",
-      "        # here we just perform learning but you can perform prediction/inference and\n",
-      "        # learning in the same step if you want (online learning).\n",
-      "        tp.compute(x[j], enableLearn = True, computeInfOutput = False)\n",
-      "\n",
-      "        # This function prints the segments associated with every cell.$$$$\n",
-      "        # If you really want to understand the TP, uncomment this line. By following\n",
-      "        # every step you can get an excellent understanding for exactly how the TP\n",
-      "        # learns.\n",
-      "        #tp.printCells()\n",
-      "\n",
-      "    # The reset command tells the TP that a sequence just ended and essentially\n",
-      "    # zeros out all the states. It is not strictly necessary but it's a bit\n",
-      "    # messier without resets, and the TP learns quicker with resets.\n",
-      "    tp.reset()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [],
-     "prompt_number": 32
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Step 4: send the same sequence of vectors and look at predictions made by\n",
-      "# temporal pooler\n",
-      "\n",
-      "# Utility routine for printing the input vector\n",
-      "def formatRow(x):\n",
-      "    s = ''\n",
-      "    for c in range(len(x)):\n",
-      "        if c > 0 and c % 10 == 0:\n",
-      "            s += ' '\n",
-      "        s += str(x[c])\n",
-      "    s += ' '\n",
-      "    return s\n",
-      "\n",
-      "for j in range(5):\n",
-      "    print \"\\n\\n--------\",\"ABCDE\"[j],\"-----------\"\n",
-      "    print \"Raw input vector\\n\",formatRow(x[j])\n",
-      "\n",
-      "    # Send each vector to the TP, with learning turned off\n",
-      "    tp.compute(x[j], enableLearn=False, computeInfOutput=True)\n",
-      "\n",
-      "    # This method prints out the active state of each cell followed by the\n",
-      "    # predicted state of each cell. For convenience the cells are grouped\n",
-      "    # 10 at a time. When there are multiple cells per column the printout\n",
-      "    # is arranged so the cells in a column are stacked together\n",
-      "    #\n",
-      "    # What you should notice is that the columns where active state is 1\n",
-      "    # represent the SDR for the current input pattern and the columns where\n",
-      "    # predicted state is 1 represent the SDR for the next expected pattern\n",
-      "    print \"\\nAll the active and predicted cells:\"\n",
-      "    tp.printStates(printPrevious=False, printLearnState=False)\n",
-      "\n",
-      "    # tp.getPredictedState() gets the predicted cells.\n",
-      "    # predictedCells[c][i] represents the state of the i'th cell in the c'th\n",
-      "    # column. To see if a column is predicted, we can simply take the OR\n",
-      "    # across all the cells in that column. In numpy we can do this by taking\n",
-      "    # the max along axis 1.\n",
-      "    print \"\\n\\nThe following columns are predicted by the temporal pooler. This\"\n",
-      "    print \"should correspond to columns in the *next* item in the sequence.\"\n",
-      "    predictedCells = tp.getPredictedState()\n",
-      "    print formatRow(predictedCells.max(axis=1).nonzero())"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": [
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "\n",
-        "\n",
-        "-------- A -----------\n",
-        "Raw input vector\n",
-        "1111111111 0000000000 0000000000 0000000000 0000000000 \n",
-        "\n",
-        "All the active and predicted cells:\n",
-        "\n",
-        "Inference Active state\n",
-        "1111111111 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "Inference Predicted state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 1111111111 0000000000 0000000000 0000000000 \n",
-        "\n",
-        "\n",
-        "The following columns are predicted by the temporal pooler. This\n",
-        "should correspond to columns in the *next* item in the sequence.\n",
-        "[10 11 12 13 14 15 16 17 18 19] \n",
-        "\n",
-        "\n",
-        "-------- B -----------\n",
-        "Raw input vector\n",
-        "0000000000 1111111111 0000000000 0000000000 0000000000 \n",
-        "\n",
-        "All the active and predicted cells:\n",
-        "\n",
-        "Inference Active state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 1111111111 0000000000 0000000000 0000000000 \n",
-        "Inference Predicted state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 1111111111 0000000000 0000000000 \n",
-        "\n",
-        "\n",
-        "The following columns are predicted by the temporal pooler. This\n",
-        "should correspond to columns in the *next* item in the sequence.\n",
-        "[20 21 22 23 24 25 26 27 28 29] \n",
-        "\n",
-        "\n",
-        "-------- C -----------\n",
-        "Raw input vector\n",
-        "0000000000 0000000000 1111111111 0000000000 0000000000 \n",
-        "\n",
-        "All the active and predicted cells:\n",
-        "\n",
-        "Inference Active state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 1111111111 0000000000 0000000000 \n",
-        "Inference Predicted state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 0000000000 1111111111 0000000000 \n",
-        "\n",
-        "\n",
-        "The following columns are predicted by the temporal pooler. This\n",
-        "should correspond to columns in the *next* item in the sequence.\n",
-        "[30 31 32 33 34 35 36 37 38 39] \n",
-        "\n",
-        "\n",
-        "-------- D -----------\n",
-        "Raw input vector\n",
-        "0000000000 0000000000 0000000000 1111111111 0000000000 \n",
-        "\n",
-        "All the active and predicted cells:\n",
-        "\n",
-        "Inference Active state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 0000000000 1111111111 0000000000 \n",
-        "Inference Predicted state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 0000000000 0000000000 1111111111 \n",
-        "\n",
-        "\n",
-        "The following columns are predicted by the temporal pooler. This\n",
-        "should correspond to columns in the *next* item in the sequence.\n",
-        "[40 41 42 43 44 45 46 47 48 49] \n",
-        "\n",
-        "\n",
-        "-------- E -----------\n",
-        "Raw input vector\n",
-        "0000000000 0000000000 0000000000 0000000000 1111111111 \n",
-        "\n",
-        "All the active and predicted cells:\n",
-        "\n",
-        "Inference Active state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 0000000000 0000000000 1111111111 \n",
-        "Inference Predicted state\n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
-        "\n",
-        "\n",
-        "The following columns are predicted by the temporal pooler. This\n",
-        "should correspond to columns in the *next* item in the sequence.\n",
-        "[] \n"
-       ]
-      }
-     ],
-     "prompt_number": 33
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Networks and Regions\n",
-      "\n",
-      "See slides."
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Online Prediction Framework\n",
-      "\n",
-      "* CLAModel\n",
-      "* OPF Client\n",
-      "* Swarming\n",
-      "\n",
-      "# CLAModel\n",
-      "\n",
-      "From `examples/opf/clients/hotgym/simple/hotgym.py`"
-     ]
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Model Parameters\n",
-      "\n",
-      "`MODEL_PARAMS` have all of the parameters for the CLA model and subcomponents"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Model Params!\n",
-      "MODEL_PARAMS = {\n",
-      "    # Type of model that the rest of these parameters apply to.\n",
-      "    'model': \"CLA\",\n",
-      "\n",
-      "    # Version that specifies the format of the config.\n",
-      "    'version': 1,\n",
-      "\n",
-      "    # Intermediate variables used to compute fields in modelParams and also\n",
-      "    # referenced from the control section.\n",
-      "    'aggregationInfo': {   'days': 0,\n",
-      "        'fields': [('consumption', 'sum')],\n",
-      "        'hours': 1,\n",
-      "        'microseconds': 0,\n",
-      "        'milliseconds': 0,\n",
-      "        'minutes': 0,\n",
-      "        'months': 0,\n",
-      "        'seconds': 0,\n",
-      "        'weeks': 0,\n",
-      "        'years': 0},\n",
-      "\n",
-      "    'predictAheadTime': None,\n",
-      "\n",
-      "    # Model parameter dictionary.\n",
-      "    'modelParams': {\n",
-      "        # The type of inference that this model will perform\n",
-      "        'inferenceType': 'TemporalMultiStep',\n",
-      "\n",
-      "        'sensorParams': {\n",
-      "            # Sensor diagnostic output verbosity control;\n",
-      "            # if > 0: sensor region will print out on screen what it's sensing\n",
-      "            # at each step 0: silent; >=1: some info; >=2: more info;\n",
-      "            # >=3: even more info (see compute() in py/regions/RecordSensor.py)\n",
-      "            'verbosity' : 0,\n",
-      "\n",
-      "            # Include the encoders we use\n",
-      "            'encoders': {\n",
-      "                u'timestamp_timeOfDay': {\n",
-      "                    'fieldname': u'timestamp',\n",
-      "                    'name': u'timestamp_timeOfDay',\n",
-      "                    'timeOfDay': (21, 0.5),\n",
-      "                    'type': 'DateEncoder'\n",
-      "                },\n",
-      "                u'timestamp_dayOfWeek': None,\n",
-      "                u'timestamp_weekend': None,\n",
-      "                u'consumption': {\n",
-      "                    'clipInput': True,\n",
-      "                    'fieldname': u'consumption',\n",
-      "                    'maxval': 100.0,\n",
-      "                    'minval': 0.0,\n",
-      "                    'n': 50,\n",
-      "                    'name': u'c1',\n",
-      "                    'type': 'ScalarEncoder',\n",
-      "                    'w': 21\n",
-      "                },\n",
-      "            },\n",
-      "\n",
-      "            # A dictionary specifying the period for automatically-generated\n",
-      "            # resets from a RecordSensor;\n",
-      "            #\n",
-      "            # None = disable automatically-generated resets (also disabled if\n",
-      "            # all of the specified values evaluate to 0).\n",
-      "            # Valid keys is the desired combination of the following:\n",
-      "            #   days, hours, minutes, seconds, milliseconds, microseconds, weeks\n",
-      "            #\n",
-      "            # Example for 1.5 days: sensorAutoReset = dict(days=1,hours=12),\n",
-      "            #\n",
-      "            # (value generated from SENSOR_AUTO_RESET)\n",
-      "            'sensorAutoReset' : None,\n",
-      "        },\n",
-      "\n",
-      "        'spEnable': True,\n",
-      "\n",
-      "        'spParams': {\n",
-      "            # SP diagnostic output verbosity control;\n",
-      "            # 0: silent; >=1: some info; >=2: more info;\n",
-      "            'spVerbosity' : 0,\n",
-      "\n",
-      "            # Spatial Pooler implementation selector, see getSPClass\n",
-      "            # in py/regions/SPRegion.py for details\n",
-      "            # 'py' (default), 'cpp' (speed optimized, new)\n",
-      "            'spatialImp' : 'cpp',\n",
-      "\n",
-      "            'globalInhibition': 1,\n",
-      "\n",
-      "            # Number of cell columns in the cortical region (same number for\n",
-      "            # SP and TP)\n",
-      "            # (see also tpNCellsPerCol)\n",
-      "            'columnCount': 2048,\n",
-      "\n",
-      "            'inputWidth': 0,\n",
-      "\n",
-      "            # SP inhibition control (absolute value);\n",
-      "            # Maximum number of active columns in the SP region's output (when\n",
-      "            # there are more, the weaker ones are suppressed)\n",
-      "            'numActiveColumnsPerInhArea': 40,\n",
-      "\n",
-      "            'seed': 1956,\n",
-      "\n",
-      "            # potentialPct\n",
-      "            # What percent of the columns's receptive field is available\n",
-      "            # for potential synapses. At initialization time, we will\n",
-      "            # choose potentialPct * (2*potentialRadius+1)^2\n",
-      "            'potentialPct': 0.5,\n",
-      "\n",
-      "            # The default connected threshold. Any synapse whose\n",
-      "            # permanence value is above the connected threshold is\n",
-      "            # a \"connected synapse\", meaning it can contribute to the\n",
-      "            # cell's firing. Typical value is 0.10. Cells whose activity\n",
-      "            # level before inhibition falls below minDutyCycleBeforeInh\n",
-      "            # will have their own internal synPermConnectedCell\n",
-      "            # threshold set below this default value.\n",
-      "            # (This concept applies to both SP and TP and so 'cells'\n",
-      "            # is correct here as opposed to 'columns')\n",
-      "            'synPermConnected': 0.1,\n",
-      "\n",
-      "            'synPermActiveInc': 0.1,\n",
-      "\n",
-      "            'synPermInactiveDec': 0.005,\n",
-      "        },\n",
-      "\n",
-      "        # Controls whether TP is enabled or disabled;\n",
-      "        # TP is necessary for making temporal predictions, such as predicting\n",
-      "        # the next inputs.  Without TP, the model is only capable of\n",
-      "        # reconstructing missing sensor inputs (via SP).\n",
-      "        'tpEnable' : True,\n",
-      "\n",
-      "        'tpParams': {\n",
-      "            # TP diagnostic output verbosity control;\n",
-      "            # 0: silent; [1..6]: increasing levels of verbosity\n",
-      "            # (see verbosity in nupic/trunk/py/nupic/research/TP.py and TP10X*.py)\n",
-      "            'verbosity': 0,\n",
-      "\n",
-      "            # Number of cell columns in the cortical region (same number for\n",
-      "            # SP and TP)\n",
-      "            # (see also tpNCellsPerCol)\n",
-      "            'columnCount': 2048,\n",
-      "\n",
-      "            # The number of cells (i.e., states), allocated per column.\n",
-      "            'cellsPerColumn': 32,\n",
-      "\n",
-      "            'inputWidth': 2048,\n",
-      "\n",
-      "            'seed': 1960,\n",
-      "\n",
-      "            # Temporal Pooler implementation selector (see _getTPClass in\n",
-      "            # CLARegion.py).\n",
-      "            'temporalImp': 'cpp',\n",
-      "\n",
-      "            # New Synapse formation count\n",
-      "            # NOTE: If None, use spNumActivePerInhArea\n",
-      "            #\n",
-      "            # TODO: need better explanation\n",
-      "            'newSynapseCount': 20,\n",
-      "\n",
-      "            # Maximum number of synapses per segment\n",
-      "            #  > 0 for fixed-size CLA\n",
-      "            # -1 for non-fixed-size CLA\n",
-      "            #\n",
-      "            # TODO: for Ron: once the appropriate value is placed in TP\n",
-      "            # constructor, see if we should eliminate this parameter from\n",
-      "            # description.py.\n",
-      "            'maxSynapsesPerSegment': 32,\n",
-      "\n",
-      "            # Maximum number of segments per cell\n",
-      "            #  > 0 for fixed-size CLA\n",
-      "            # -1 for non-fixed-size CLA\n",
-      "            #\n",
-      "            # TODO: for Ron: once the appropriate value is placed in TP\n",
-      "            # constructor, see if we should eliminate this parameter from\n",
-      "            # description.py.\n",
-      "            'maxSegmentsPerCell': 128,\n",
-      "\n",
-      "            # Initial Permanence\n",
-      "            # TODO: need better explanation\n",
-      "            'initialPerm': 0.21,\n",
-      "\n",
-      "            # Permanence Increment\n",
-      "            'permanenceInc': 0.1,\n",
-      "\n",
-      "            # Permanence Decrement\n",
-      "            # If set to None, will automatically default to tpPermanenceInc\n",
-      "            # value.\n",
-      "            'permanenceDec' : 0.1,\n",
-      "\n",
-      "            'globalDecay': 0.0,\n",
-      "\n",
-      "            'maxAge': 0,\n",
-      "\n",
-      "            # Minimum number of active synapses for a segment to be considered\n",
-      "            # during search for the best-matching segments.\n",
-      "            # None=use default\n",
-      "            # Replaces: tpMinThreshold\n",
-      "            'minThreshold': 9,\n",
-      "\n",
-      "            # Segment activation threshold.\n",
-      "            # A segment is active if it has >= tpSegmentActivationThreshold\n",
-      "            # connected synapses that are active due to infActiveState\n",
-      "            # None=use default\n",
-      "            # Replaces: tpActivationThreshold\n",
-      "            'activationThreshold': 12,\n",
-      "\n",
-      "            'outputType': 'normal',\n",
-      "\n",
-      "            # \"Pay Attention Mode\" length. This tells the TP how many new\n",
-      "            # elements to append to the end of a learned sequence at a time.\n",
-      "            # Smaller values are better for datasets with short sequences,\n",
-      "            # higher values are better for datasets with long sequences.\n",
-      "            'pamLength': 1,\n",
-      "        },\n",
-      "\n",
-      "        'clParams': {\n",
-      "            'regionName' : 'CLAClassifierRegion',\n",
-      "\n",
-      "            # Classifier diagnostic output verbosity control;\n",
-      "            # 0: silent; [1..6]: increasing levels of verbosity\n",
-      "            'clVerbosity' : 0,\n",
-      "\n",
-      "            # This controls how fast the classifier learns/forgets. Higher values\n",
-      "            # make it adapt faster and forget older patterns faster.\n",
-      "            'alpha': 0.005,\n",
-      "\n",
-      "            # This is set after the call to updateConfigFromSubConfig and is\n",
-      "            # computed from the aggregationInfo and predictAheadTime.\n",
-      "            'steps': '1,5',\n",
-      "\n",
-      "            'implementation': 'cpp',\n",
-      "        },\n",
-      "\n",
-      "        'trainSPNetOnlyIfRequested': False,\n",
-      "    },\n",
-      "}"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Dataset Helpers"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from pkg_resources import resource_filename\n",
-      "\n",
-      "datasetPath = resource_filename(\"nupic.datafiles\", \"extra/hotgym/hotgym.csv\")\n",
-      "print datasetPath\n",
-      "\n",
-      "with open(datasetPath) as inputFile:\n",
-      "    print\n",
-      "    for _ in xrange(8):\n",
-      "        print inputFile.next().strip()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Loading Data\n",
-      "\n",
-      "`FileRecordStream` - file reader for the NuPIC file format (CSV with three header rows, understands datetimes)"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.data.file_record_stream import FileRecordStream\n",
-      "\n",
-      "def getData():\n",
-      "    return FileRecordStream(datasetPath)\n",
-      "\n",
-      "data = getData()\n",
-      "for _ in xrange(5):\n",
-      "    print data.next()"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.frameworks.opf.modelfactory import ModelFactory\n",
-      "model = ModelFactory.create(MODEL_PARAMS)\n",
-      "model.enableInference({'predictedField': 'consumption'})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "data = getData()\n",
-      "for _ in xrange(100):\n",
-      "    record = dict(zip(data.getFieldNames(), data.next()))\n",
-      "    print \"input: \", record[\"consumption\"]\n",
-      "    result = model.run(record)\n",
-      "    print \"prediction: \", result.inferences[\"multiStepBestPredictions\"][1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print \"5-step prediction: \", result.inferences[\"multiStepBestPredictions\"][5]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "# Anomaly Score"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "# Model Params!\n",
-      "MODEL_PARAMS = {\n",
-      "    # Type of model that the rest of these parameters apply to.\n",
-      "    'model': \"CLA\",\n",
-      "\n",
-      "    # Version that specifies the format of the config.\n",
-      "    'version': 1,\n",
-      "\n",
-      "    # Intermediate variables used to compute fields in modelParams and also\n",
-      "    # referenced from the control section.\n",
-      "    'aggregationInfo': {   'days': 0,\n",
-      "        'fields': [('consumption', 'sum')],\n",
-      "        'hours': 1,\n",
-      "        'microseconds': 0,\n",
-      "        'milliseconds': 0,\n",
-      "        'minutes': 0,\n",
-      "        'months': 0,\n",
-      "        'seconds': 0,\n",
-      "        'weeks': 0,\n",
-      "        'years': 0},\n",
-      "\n",
-      "    'predictAheadTime': None,\n",
-      "\n",
-      "    # Model parameter dictionary.\n",
-      "    'modelParams': {\n",
-      "        # The type of inference that this model will perform\n",
-      "        'inferenceType': 'TemporalAnomaly',\n",
-      "\n",
-      "        'sensorParams': {\n",
-      "            # Sensor diagnostic output verbosity control;\n",
-      "            # if > 0: sensor region will print out on screen what it's sensing\n",
-      "            # at each step 0: silent; >=1: some info; >=2: more info;\n",
-      "            # >=3: even more info (see compute() in py/regions/RecordSensor.py)\n",
-      "            'verbosity' : 0,\n",
-      "\n",
-      "            # Include the encoders we use\n",
-      "            'encoders': {\n",
-      "                u'timestamp_timeOfDay': {\n",
-      "                    'fieldname': u'timestamp',\n",
-      "                    'name': u'timestamp_timeOfDay',\n",
-      "                    'timeOfDay': (21, 0.5),\n",
-      "                    'type': 'DateEncoder'},\n",
-      "                u'timestamp_dayOfWeek': None,\n",
-      "                u'timestamp_weekend': None,\n",
-      "                u'consumption': {\n",
-      "                    'clipInput': True,\n",
-      "                    'fieldname': u'consumption',\n",
-      "                    'maxval': 100.0,\n",
-      "                    'minval': 0.0,\n",
-      "                    'n': 50,\n",
-      "                    'name': u'c1',\n",
-      "                    'type': 'ScalarEncoder',\n",
-      "                    'w': 21},},\n",
-      "\n",
-      "            # A dictionary specifying the period for automatically-generated\n",
-      "            # resets from a RecordSensor;\n",
-      "            #\n",
-      "            # None = disable automatically-generated resets (also disabled if\n",
-      "            # all of the specified values evaluate to 0).\n",
-      "            # Valid keys is the desired combination of the following:\n",
-      "            #   days, hours, minutes, seconds, milliseconds, microseconds, weeks\n",
-      "            #\n",
-      "            # Example for 1.5 days: sensorAutoReset = dict(days=1,hours=12),\n",
-      "            #\n",
-      "            # (value generated from SENSOR_AUTO_RESET)\n",
-      "            'sensorAutoReset' : None,\n",
-      "        },\n",
-      "\n",
-      "        'spEnable': True,\n",
-      "\n",
-      "        'spParams': {\n",
-      "            # SP diagnostic output verbosity control;\n",
-      "            # 0: silent; >=1: some info; >=2: more info;\n",
-      "            'spVerbosity' : 0,\n",
-      "\n",
-      "            # Spatial Pooler implementation selector, see getSPClass\n",
-      "            # in py/regions/SPRegion.py for details\n",
-      "            # 'py' (default), 'cpp' (speed optimized, new)\n",
-      "            'spatialImp' : 'cpp',\n",
-      "\n",
-      "            'globalInhibition': 1,\n",
-      "\n",
-      "            # Number of cell columns in the cortical region (same number for\n",
-      "            # SP and TP)\n",
-      "            # (see also tpNCellsPerCol)\n",
-      "            'columnCount': 2048,\n",
-      "\n",
-      "            'inputWidth': 0,\n",
-      "\n",
-      "            # SP inhibition control (absolute value);\n",
-      "            # Maximum number of active columns in the SP region's output (when\n",
-      "            # there are more, the weaker ones are suppressed)\n",
-      "            'numActiveColumnsPerInhArea': 40,\n",
-      "\n",
-      "            'seed': 1956,\n",
-      "\n",
-      "            # potentialPct\n",
-      "            # What percent of the columns's receptive field is available\n",
-      "            # for potential synapses. At initialization time, we will\n",
-      "            # choose potentialPct * (2*potentialRadius+1)^2\n",
-      "            'potentialPct': 0.5,\n",
-      "\n",
-      "            # The default connected threshold. Any synapse whose\n",
-      "            # permanence value is above the connected threshold is\n",
-      "            # a \"connected synapse\", meaning it can contribute to the\n",
-      "            # cell's firing. Typical value is 0.10. Cells whose activity\n",
-      "            # level before inhibition falls below minDutyCycleBeforeInh\n",
-      "            # will have their own internal synPermConnectedCell\n",
-      "            # threshold set below this default value.\n",
-      "            # (This concept applies to both SP and TP and so 'cells'\n",
-      "            # is correct here as opposed to 'columns')\n",
-      "            'synPermConnected': 0.1,\n",
-      "\n",
-      "            'synPermActiveInc': 0.1,\n",
-      "\n",
-      "            'synPermInactiveDec': 0.005,\n",
-      "        },\n",
-      "\n",
-      "        # Controls whether TP is enabled or disabled;\n",
-      "        # TP is necessary for making temporal predictions, such as predicting\n",
-      "        # the next inputs.  Without TP, the model is only capable of\n",
-      "        # reconstructing missing sensor inputs (via SP).\n",
-      "        'tpEnable' : True,\n",
-      "\n",
-      "        'tpParams': {\n",
-      "            # TP diagnostic output verbosity control;\n",
-      "            # 0: silent; [1..6]: increasing levels of verbosity\n",
-      "            # (see verbosity in nupic/trunk/py/nupic/research/TP.py and TP10X*.py)\n",
-      "            'verbosity': 0,\n",
-      "\n",
-      "            # Number of cell columns in the cortical region (same number for\n",
-      "            # SP and TP)\n",
-      "            # (see also tpNCellsPerCol)\n",
-      "            'columnCount': 2048,\n",
-      "\n",
-      "            # The number of cells (i.e., states), allocated per column.\n",
-      "            'cellsPerColumn': 32,\n",
-      "\n",
-      "            'inputWidth': 2048,\n",
-      "\n",
-      "            'seed': 1960,\n",
-      "\n",
-      "            # Temporal Pooler implementation selector (see _getTPClass in\n",
-      "            # CLARegion.py).\n",
-      "            'temporalImp': 'cpp',\n",
-      "\n",
-      "            # New Synapse formation count\n",
-      "            # NOTE: If None, use spNumActivePerInhArea\n",
-      "            #\n",
-      "            # TODO: need better explanation\n",
-      "            'newSynapseCount': 20,\n",
-      "\n",
-      "            # Maximum number of synapses per segment\n",
-      "            #  > 0 for fixed-size CLA\n",
-      "            # -1 for non-fixed-size CLA\n",
-      "            #\n",
-      "            # TODO: for Ron: once the appropriate value is placed in TP\n",
-      "            # constructor, see if we should eliminate this parameter from\n",
-      "            # description.py.\n",
-      "            'maxSynapsesPerSegment': 32,\n",
-      "\n",
-      "            # Maximum number of segments per cell\n",
-      "            #  > 0 for fixed-size CLA\n",
-      "            # -1 for non-fixed-size CLA\n",
-      "            #\n",
-      "            # TODO: for Ron: once the appropriate value is placed in TP\n",
-      "            # constructor, see if we should eliminate this parameter from\n",
-      "            # description.py.\n",
-      "            'maxSegmentsPerCell': 128,\n",
-      "\n",
-      "            # Initial Permanence\n",
-      "            # TODO: need better explanation\n",
-      "            'initialPerm': 0.21,\n",
-      "\n",
-      "            # Permanence Increment\n",
-      "            'permanenceInc': 0.1,\n",
-      "\n",
-      "            # Permanence Decrement\n",
-      "            # If set to None, will automatically default to tpPermanenceInc\n",
-      "            # value.\n",
-      "            'permanenceDec' : 0.1,\n",
-      "\n",
-      "            'globalDecay': 0.0,\n",
-      "\n",
-      "            'maxAge': 0,\n",
-      "\n",
-      "            # Minimum number of active synapses for a segment to be considered\n",
-      "            # during search for the best-matching segments.\n",
-      "            # None=use default\n",
-      "            # Replaces: tpMinThreshold\n",
-      "            'minThreshold': 9,\n",
-      "\n",
-      "            # Segment activation threshold.\n",
-      "            # A segment is active if it has >= tpSegmentActivationThreshold\n",
-      "            # connected synapses that are active due to infActiveState\n",
-      "            # None=use default\n",
-      "            # Replaces: tpActivationThreshold\n",
-      "            'activationThreshold': 12,\n",
-      "\n",
-      "            'outputType': 'normal',\n",
-      "\n",
-      "            # \"Pay Attention Mode\" length. This tells the TP how many new\n",
-      "            # elements to append to the end of a learned sequence at a time.\n",
-      "            # Smaller values are better for datasets with short sequences,\n",
-      "            # higher values are better for datasets with long sequences.\n",
-      "            'pamLength': 1,\n",
-      "        },\n",
-      "\n",
-      "        'clParams': {\n",
-      "            'regionName' : 'CLAClassifierRegion',\n",
-      "\n",
-      "            # Classifier diagnostic output verbosity control;\n",
-      "            # 0: silent; [1..6]: increasing levels of verbosity\n",
-      "            'clVerbosity' : 0,\n",
-      "\n",
-      "            # This controls how fast the classifier learns/forgets. Higher values\n",
-      "            # make it adapt faster and forget older patterns faster.\n",
-      "            'alpha': 0.005,\n",
-      "\n",
-      "            # This is set after the call to updateConfigFromSubConfig and is\n",
-      "            # computed from the aggregationInfo and predictAheadTime.\n",
-      "            'steps': '1',\n",
-      "\n",
-      "            'implementation': 'cpp',\n",
-      "        },\n",
-      "\n",
-      "        'anomalyParams': {\n",
-      "            u'anomalyCacheRecords': None,\n",
-      "            u'autoDetectThreshold': None,\n",
-      "            u'autoDetectWaitRecords': 2184\n",
-      "        },\n",
-      "\n",
-      "        'trainSPNetOnlyIfRequested': False,\n",
-      "    },\n",
-      "}"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "from nupic.frameworks.opf.modelfactory import ModelFactory\n",
-      "model = ModelFactory.create(MODEL_PARAMS)\n",
-      "model.enableInference({'predictedField': 'consumption'})"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "data = getData()\n",
-      "for _ in xrange(5):\n",
-      "    record = dict(zip(data.getFieldNames(), data.next()))\n",
-      "    print \"input: \", record[\"consumption\"]\n",
-      "    result = model.run(record)\n",
-      "    print \"prediction: \", result.inferences[\"multiStepBestPredictions\"][1]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print result"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [
-      "print \"anomaly score: \", result.inferences[\"anomalyScore\"]"
-     ],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
-    },
-    {
-     "cell_type": "markdown",
-     "metadata": {},
-     "source": [
-      "__See Subutai's talk for more info on anomaly detection!__\n",
-      "\n",
-      "# Built-in OPF Clients\n",
-      "\n",
-      "`python examples/opf/bin/OpfRunExperiment.py examples/opf/experiments/multistep/hotgym/`\n",
-      "\n",
-      "Outputs `examples/opf/experiments/multistep/hotgym/inference/DefaultTask.TemporalMultiStep.predictionLog.csv`\n",
-      "\n",
-      "`python bin/run_swarm.py examples/opf/experiments/multistep/hotgym/permutations.py`\n",
-      "\n",
-      "Outputs `examples/opf/experiments/multistep/hotgym/model_0/description.py`"
-     ]
-    },
-    {
-     "cell_type": "code",
-     "collapsed": false,
-     "input": [],
-     "language": "python",
-     "metadata": {},
-     "outputs": []
     }
    ],
-   "metadata": {}
+   "source": [
+    "# 22 bits with 3 active representing values 0 to 100\n",
+    "# clipInput=True makes values >100 encode the same as 100 (instead of throwing a ValueError)\n",
+    "# forced=True allows small values for `n` and `w`\n",
+    "enc = ScalarEncoder(n=22, w=3, minval=2.5, maxval=97.5, clipInput=True, forced=True)\n",
+    "print \"3 =\", enc.encode(3)\n",
+    "print \"4 =\", enc.encode(4)\n",
+    "print \"5 =\", enc.encode(5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "100  = [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n",
+      "1000 = [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Encode maxval\n",
+    "print \"100  =\", enc.encode(100)\n",
+    "# See that any larger number gets the same encoding\n",
+    "print \"1000 =\", enc.encode(1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nupic.encoders.random_distributed_scalar import RandomDistributedScalarEncoder\n",
+    "\n",
+    "RandomDistributedScalarEncoder?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "3 =    [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1]\n",
+      "4 =    [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 0 1 1]\n",
+      "5 =    [0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 0 1]\n",
+      "\n",
+      "100 =  [0 1 1 0 0 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n",
+      "1000 = [0 0 0 1 0 0 0 0 1 0 0 0 0 0 0 1 0 0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# 21 bits with 3 active with buckets of size 5\n",
+    "rdse = RandomDistributedScalarEncoder(n=21, w=3, resolution=5, offset=2.5)\n",
+    "\n",
+    "print \"3 =   \", rdse.encode(3)\n",
+    "print \"4 =   \", rdse.encode(4)\n",
+    "print \"5 =   \", rdse.encode(5)\n",
+    "print\n",
+    "print \"100 = \", rdse.encode(100)\n",
+    "print \"1000 =\", rdse.encode(1000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "import datetime\n",
+    "from nupic.encoders.date import DateEncoder\n",
+    "\n",
+    "DateEncoder?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "now =        [0 0 0 0 1 1 1 1 1 0 0 0 0 0 0 0 0 0 0 0]\n",
+      "next month = [0 0 0 0 0 0 1 1 1 1 1 0 0 0 0 0 0 0 0 0]\n",
+      "xmas =       [1 1 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "de = DateEncoder(season=5)\n",
+    "\n",
+    "now = datetime.datetime.strptime(\"2014-05-02 13:08:58\", \"%Y-%m-%d %H:%M:%S\")\n",
+    "print \"now =       \", de.encode(now)\n",
+    "nextMonth = datetime.datetime.strptime(\"2014-06-02 13:08:58\", \"%Y-%m-%d %H:%M:%S\")\n",
+    "print \"next month =\", de.encode(nextMonth)\n",
+    "xmas = datetime.datetime.strptime(\"2014-12-25 13:08:58\", \"%Y-%m-%d %H:%M:%S\")\n",
+    "print \"xmas =      \", de.encode(xmas)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "cat =        [0 0 0 1 1 1 0 0 0 0 0 0 0 0 0]\n",
+      "dog =        [0 0 0 0 0 0 1 1 1 0 0 0 0 0 0]\n",
+      "monkey =     [0 0 0 0 0 0 0 0 0 1 1 1 0 0 0]\n",
+      "slow loris = [0 0 0 0 0 0 0 0 0 0 0 0 1 1 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from nupic.encoders.category import CategoryEncoder\n",
+    "\n",
+    "categories = (\"cat\", \"dog\", \"monkey\", \"slow loris\")\n",
+    "encoder = CategoryEncoder(w=3, categoryList=categories, forced=True)\n",
+    "cat = encoder.encode(\"cat\")\n",
+    "dog = encoder.encode(\"dog\")\n",
+    "monkey = encoder.encode(\"monkey\")\n",
+    "loris = encoder.encode(\"slow loris\")\n",
+    "print \"cat =       \", cat\n",
+    "print \"dog =       \", dog\n",
+    "print \"monkey =    \", monkey\n",
+    "print \"slow loris =\", loris"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print encoder.encode(None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[1 1 1 0 0 0 0 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print encoder.encode(\"unknown\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "({'category': ([(1, 1)], 'cat')}, ['category'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "print encoder.decode(cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "({'category': ([(1, 2)], 'cat, dog')}, ['category'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "catdog = numpy.array([0, 0, 0, 1, 0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0])\n",
+    "print encoder.decode(catdog)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Spatial Pooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nupic.research.spatial_pooler import SpatialPooler\n",
+    "\n",
+    "print SpatialPooler?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "<class 'nupic.research.spatial_pooler.SpatialPooler'>\n"
+     ]
+    }
+   ],
+   "source": [
+    "print SpatialPooler"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "15\n",
+      "[0 0 0 1 1 1 0 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "print len(cat)\n",
+    "print cat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 1 1 0 0 1 0 0 0 1 1 1 1 0 0]\n",
+      "[1 1 1 1 1 0 1 0 1 1 1 0 0 1 0]\n",
+      "[0 1 0 1 1 0 1 0 1 1 0 0 1 0 1]\n",
+      "[0 1 1 1 0 1 0 0 0 1 1 1 1 1 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "sp = SpatialPooler(inputDimensions=(15,),\n",
+    "                   columnDimensions=(4,),\n",
+    "                   potentialRadius=15,\n",
+    "                   numActiveColumnsPerInhArea=1,\n",
+    "                   globalInhibition=True,\n",
+    "                   synPermActiveInc=0.03,\n",
+    "                   potentialPct=1.0)\n",
+    "import numpy\n",
+    "for column in xrange(4):\n",
+    "    connected = numpy.zeros((15,), dtype=\"int\")\n",
+    "    sp.getConnectedSynapses(column, connected)\n",
+    "    print connected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 0 0 1]\n"
+     ]
+    }
+   ],
+   "source": [
+    "output = numpy.zeros((4,), dtype=\"int\")\n",
+    "sp.compute(cat, learn=True, activeArray=output)\n",
+    "print output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for _ in xrange(20):\n",
+    "    sp.compute(cat, learn=True, activeArray=output)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 1 1 0 0 1 0 0 0 1 1 1 1 0 0]\n",
+      "[1 1 1 1 1 0 1 0 1 1 1 0 0 1 0]\n",
+      "[0 1 0 1 1 0 1 0 1 1 0 0 1 0 1]\n",
+      "[0 0 1 1 1 1 0 0 0 1 1 1 1 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for column in xrange(4):\n",
+    "    connected = numpy.zeros((15,), dtype=\"int\")\n",
+    "    sp.getConnectedSynapses(column, connected)\n",
+    "    print connected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "for _ in xrange(200):\n",
+    "    sp.compute(cat, learn=True, activeArray=output)\n",
+    "    sp.compute(dog, learn=True, activeArray=output)\n",
+    "    sp.compute(monkey, learn=True, activeArray=output)\n",
+    "    sp.compute(loris, learn=True, activeArray=output)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 1 1 0 0 1 0 0 0 1 1 1 1 0 0]\n",
+      "[1 1 1 1 1 0 1 0 1 1 1 0 1 1 0]\n",
+      "[0 0 0 0 0 0 1 1 1 0 0 0 1 1 1]\n",
+      "[0 0 0 1 1 1 0 0 0 1 1 1 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "for column in xrange(4):\n",
+    "    connected = numpy.zeros((15,), dtype=\"int\")\n",
+    "    sp.getConnectedSynapses(column, connected)\n",
+    "    print connected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 0 0 1 1 0 1 0 0 0 0 0 0 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "noisyCat = numpy.zeros((15,), dtype=\"uint32\")\n",
+    "noisyCat[3] = 1\n",
+    "noisyCat[4] = 1\n",
+    "# This is part of dog!\n",
+    "noisyCat[6] = 1\n",
+    "print noisyCat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[0 1 0 0]\n"
+     ]
+    }
+   ],
+   "source": [
+    "sp.compute(noisyCat, learn=False, activeArray=output)\n",
+    "print output  # matches cat!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Temporal Memory (a.k.a. Sequence Memory, Temporal Pooler)\n",
+    "\n",
+    "From: `examples/tp/hello_tm.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nupic.research.TP import TP\n",
+    "\n",
+    "TP?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Step 1: create Temporal Pooler instance with appropriate parameters\n",
+    "tp = TP(numberOfCols=50, cellsPerColumn=2,\n",
+    "        initialPerm=0.5, connectedPerm=0.5,\n",
+    "        minThreshold=10, newSynapseCount=10,\n",
+    "        permanenceInc=0.1, permanenceDec=0.0,\n",
+    "        activationThreshold=8,\n",
+    "        globalDecay=0, burnIn=1,\n",
+    "        checkSynapseConsistency=False,\n",
+    "        pamLength=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 33,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Step 2: create input vectors to feed to the temporal pooler. Each input vector\n",
+    "# must be numberOfCols wide. Here we create a simple sequence of 5 vectors\n",
+    "# representing the sequence A -> B -> C -> D -> E\n",
+    "x = numpy.zeros((5, tp.numberOfCols), dtype=\"uint32\")\n",
+    "x[0,0:10]  = 1   # Input SDR representing \"A\", corresponding to columns 0-9\n",
+    "x[1,10:20] = 1   # Input SDR representing \"B\", corresponding to columns 10-19\n",
+    "x[2,20:30] = 1   # Input SDR representing \"C\", corresponding to columns 20-29\n",
+    "x[3,30:40] = 1   # Input SDR representing \"D\", corresponding to columns 30-39\n",
+    "x[4,40:50] = 1   # Input SDR representing \"E\", corresponding to columns 40-49"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 34,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Step 3: send this simple sequence to the temporal pooler for learning\n",
+    "# We repeat the sequence 10 times\n",
+    "for i in range(10):\n",
+    "\n",
+    "    # Send each letter in the sequence in order\n",
+    "    for j in range(5):\n",
+    "\n",
+    "        # The compute method performs one step of learning and/or inference. Note:\n",
+    "        # here we just perform learning but you can perform prediction/inference and\n",
+    "        # learning in the same step if you want (online learning).\n",
+    "        tp.compute(x[j], enableLearn = True, computeInfOutput = False)\n",
+    "\n",
+    "        # This function prints the segments associated with every cell.$$$$\n",
+    "        # If you really want to understand the TP, uncomment this line. By following\n",
+    "        # every step you can get an excellent understanding for exactly how the TP\n",
+    "        # learns.\n",
+    "        #tp.printCells()\n",
+    "\n",
+    "    # The reset command tells the TP that a sequence just ended and essentially\n",
+    "    # zeros out all the states. It is not strictly necessary but it's a bit\n",
+    "    # messier without resets, and the TP learns quicker with resets.\n",
+    "    tp.reset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n",
+      "\n",
+      "-------- A -----------\n",
+      "Raw input vector\n",
+      "1111111111 0000000000 0000000000 0000000000 0000000000 \n",
+      "\n",
+      "All the active and predicted cells:\n",
+      "\n",
+      "Inference Active state\n",
+      "1111111111 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "Inference Predicted state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 1111111111 0000000000 0000000000 0000000000 \n",
+      "\n",
+      "\n",
+      "The following columns are predicted by the temporal pooler. This\n",
+      "should correspond to columns in the *next* item in the sequence.\n",
+      "[10 11 12 13 14 15 16 17 18 19] \n",
+      "\n",
+      "\n",
+      "-------- B -----------\n",
+      "Raw input vector\n",
+      "0000000000 1111111111 0000000000 0000000000 0000000000 \n",
+      "\n",
+      "All the active and predicted cells:\n",
+      "\n",
+      "Inference Active state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 1111111111 0000000000 0000000000 0000000000 \n",
+      "Inference Predicted state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 1111111111 0000000000 0000000000 \n",
+      "\n",
+      "\n",
+      "The following columns are predicted by the temporal pooler. This\n",
+      "should correspond to columns in the *next* item in the sequence.\n",
+      "[20 21 22 23 24 25 26 27 28 29] \n",
+      "\n",
+      "\n",
+      "-------- C -----------\n",
+      "Raw input vector\n",
+      "0000000000 0000000000 1111111111 0000000000 0000000000 \n",
+      "\n",
+      "All the active and predicted cells:\n",
+      "\n",
+      "Inference Active state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 1111111111 0000000000 0000000000 \n",
+      "Inference Predicted state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 0000000000 1111111111 0000000000 \n",
+      "\n",
+      "\n",
+      "The following columns are predicted by the temporal pooler. This\n",
+      "should correspond to columns in the *next* item in the sequence.\n",
+      "[30 31 32 33 34 35 36 37 38 39] \n",
+      "\n",
+      "\n",
+      "-------- D -----------\n",
+      "Raw input vector\n",
+      "0000000000 0000000000 0000000000 1111111111 0000000000 \n",
+      "\n",
+      "All the active and predicted cells:\n",
+      "\n",
+      "Inference Active state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 0000000000 1111111111 0000000000 \n",
+      "Inference Predicted state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 0000000000 0000000000 1111111111 \n",
+      "\n",
+      "\n",
+      "The following columns are predicted by the temporal pooler. This\n",
+      "should correspond to columns in the *next* item in the sequence.\n",
+      "[40 41 42 43 44 45 46 47 48 49] \n",
+      "\n",
+      "\n",
+      "-------- E -----------\n",
+      "Raw input vector\n",
+      "0000000000 0000000000 0000000000 0000000000 1111111111 \n",
+      "\n",
+      "All the active and predicted cells:\n",
+      "\n",
+      "Inference Active state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 0000000000 0000000000 1111111111 \n",
+      "Inference Predicted state\n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "0000000000 0000000000 0000000000 0000000000 0000000000 \n",
+      "\n",
+      "\n",
+      "The following columns are predicted by the temporal pooler. This\n",
+      "should correspond to columns in the *next* item in the sequence.\n",
+      "[] \n"
+     ]
+    }
+   ],
+   "source": [
+    "# Step 4: send the same sequence of vectors and look at predictions made by\n",
+    "# temporal pooler\n",
+    "\n",
+    "# Utility routine for printing the input vector\n",
+    "def formatRow(x):\n",
+    "    s = ''\n",
+    "    for c in range(len(x)):\n",
+    "        if c > 0 and c % 10 == 0:\n",
+    "            s += ' '\n",
+    "        s += str(x[c])\n",
+    "    s += ' '\n",
+    "    return s\n",
+    "\n",
+    "for j in range(5):\n",
+    "    print \"\\n\\n--------\",\"ABCDE\"[j],\"-----------\"\n",
+    "    print \"Raw input vector\\n\",formatRow(x[j])\n",
+    "\n",
+    "    # Send each vector to the TP, with learning turned off\n",
+    "    tp.compute(x[j], enableLearn=False, computeInfOutput=True)\n",
+    "\n",
+    "    # This method prints out the active state of each cell followed by the\n",
+    "    # predicted state of each cell. For convenience the cells are grouped\n",
+    "    # 10 at a time. When there are multiple cells per column the printout\n",
+    "    # is arranged so the cells in a column are stacked together\n",
+    "    #\n",
+    "    # What you should notice is that the columns where active state is 1\n",
+    "    # represent the SDR for the current input pattern and the columns where\n",
+    "    # predicted state is 1 represent the SDR for the next expected pattern\n",
+    "    print \"\\nAll the active and predicted cells:\"\n",
+    "    tp.printStates(printPrevious=False, printLearnState=False)\n",
+    "\n",
+    "    # tp.getPredictedState() gets the predicted cells.\n",
+    "    # predictedCells[c][i] represents the state of the i'th cell in the c'th\n",
+    "    # column. To see if a column is predicted, we can simply take the OR\n",
+    "    # across all the cells in that column. In numpy we can do this by taking\n",
+    "    # the max along axis 1.\n",
+    "    print \"\\n\\nThe following columns are predicted by the temporal pooler. This\"\n",
+    "    print \"should correspond to columns in the *next* item in the sequence.\"\n",
+    "    predictedCells = tp.getPredictedState()\n",
+    "    print formatRow(predictedCells.max(axis=1).nonzero())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Networks and Regions\n",
+    "\n",
+    "See slides."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Online Prediction Framework\n",
+    "\n",
+    "* CLAModel\n",
+    "* OPF Client\n",
+    "* Swarming\n",
+    "\n",
+    "# CLAModel\n",
+    "\n",
+    "From `examples/opf/clients/hotgym/simple/hotgym.py`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model Parameters\n",
+    "\n",
+    "`MODEL_PARAMS` have all of the parameters for the CLA model and subcomponents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Model Params!\n",
+    "MODEL_PARAMS = {\n",
+    "    # Type of model that the rest of these parameters apply to.\n",
+    "    'model': \"CLA\",\n",
+    "\n",
+    "    # Version that specifies the format of the config.\n",
+    "    'version': 1,\n",
+    "\n",
+    "    # Intermediate variables used to compute fields in modelParams and also\n",
+    "    # referenced from the control section.\n",
+    "    'aggregationInfo': {   'days': 0,\n",
+    "        'fields': [('consumption', 'sum')],\n",
+    "        'hours': 1,\n",
+    "        'microseconds': 0,\n",
+    "        'milliseconds': 0,\n",
+    "        'minutes': 0,\n",
+    "        'months': 0,\n",
+    "        'seconds': 0,\n",
+    "        'weeks': 0,\n",
+    "        'years': 0},\n",
+    "\n",
+    "    'predictAheadTime': None,\n",
+    "\n",
+    "    # Model parameter dictionary.\n",
+    "    'modelParams': {\n",
+    "        # The type of inference that this model will perform\n",
+    "        'inferenceType': 'TemporalMultiStep',\n",
+    "\n",
+    "        'sensorParams': {\n",
+    "            # Sensor diagnostic output verbosity control;\n",
+    "            # if > 0: sensor region will print out on screen what it's sensing\n",
+    "            # at each step 0: silent; >=1: some info; >=2: more info;\n",
+    "            # >=3: even more info (see compute() in py/regions/RecordSensor.py)\n",
+    "            'verbosity' : 0,\n",
+    "\n",
+    "            # Include the encoders we use\n",
+    "            'encoders': {\n",
+    "                u'timestamp_timeOfDay': {\n",
+    "                    'fieldname': u'timestamp',\n",
+    "                    'name': u'timestamp_timeOfDay',\n",
+    "                    'timeOfDay': (21, 0.5),\n",
+    "                    'type': 'DateEncoder'\n",
+    "                },\n",
+    "                u'timestamp_dayOfWeek': None,\n",
+    "                u'timestamp_weekend': None,\n",
+    "                u'consumption': {\n",
+    "                    'clipInput': True,\n",
+    "                    'fieldname': u'consumption',\n",
+    "                    'maxval': 100.0,\n",
+    "                    'minval': 0.0,\n",
+    "                    'n': 50,\n",
+    "                    'name': u'c1',\n",
+    "                    'type': 'ScalarEncoder',\n",
+    "                    'w': 21\n",
+    "                },\n",
+    "            },\n",
+    "\n",
+    "            # A dictionary specifying the period for automatically-generated\n",
+    "            # resets from a RecordSensor;\n",
+    "            #\n",
+    "            # None = disable automatically-generated resets (also disabled if\n",
+    "            # all of the specified values evaluate to 0).\n",
+    "            # Valid keys is the desired combination of the following:\n",
+    "            #   days, hours, minutes, seconds, milliseconds, microseconds, weeks\n",
+    "            #\n",
+    "            # Example for 1.5 days: sensorAutoReset = dict(days=1,hours=12),\n",
+    "            #\n",
+    "            # (value generated from SENSOR_AUTO_RESET)\n",
+    "            'sensorAutoReset' : None,\n",
+    "        },\n",
+    "\n",
+    "        'spEnable': True,\n",
+    "\n",
+    "        'spParams': {\n",
+    "            # SP diagnostic output verbosity control;\n",
+    "            # 0: silent; >=1: some info; >=2: more info;\n",
+    "            'spVerbosity' : 0,\n",
+    "\n",
+    "            # Spatial Pooler implementation selector, see getSPClass\n",
+    "            # in py/regions/SPRegion.py for details\n",
+    "            # 'py' (default), 'cpp' (speed optimized, new)\n",
+    "            'spatialImp' : 'cpp',\n",
+    "\n",
+    "            'globalInhibition': 1,\n",
+    "\n",
+    "            # Number of cell columns in the cortical region (same number for\n",
+    "            # SP and TP)\n",
+    "            # (see also tpNCellsPerCol)\n",
+    "            'columnCount': 2048,\n",
+    "\n",
+    "            'inputWidth': 0,\n",
+    "\n",
+    "            # SP inhibition control (absolute value);\n",
+    "            # Maximum number of active columns in the SP region's output (when\n",
+    "            # there are more, the weaker ones are suppressed)\n",
+    "            'numActiveColumnsPerInhArea': 40,\n",
+    "\n",
+    "            'seed': 1956,\n",
+    "\n",
+    "            # potentialPct\n",
+    "            # What percent of the columns's receptive field is available\n",
+    "            # for potential synapses. At initialization time, we will\n",
+    "            # choose potentialPct * (2*potentialRadius+1)^2\n",
+    "            'potentialPct': 0.5,\n",
+    "\n",
+    "            # The default connected threshold. Any synapse whose\n",
+    "            # permanence value is above the connected threshold is\n",
+    "            # a \"connected synapse\", meaning it can contribute to the\n",
+    "            # cell's firing. Typical value is 0.10. Cells whose activity\n",
+    "            # level before inhibition falls below minDutyCycleBeforeInh\n",
+    "            # will have their own internal synPermConnectedCell\n",
+    "            # threshold set below this default value.\n",
+    "            # (This concept applies to both SP and TP and so 'cells'\n",
+    "            # is correct here as opposed to 'columns')\n",
+    "            'synPermConnected': 0.1,\n",
+    "\n",
+    "            'synPermActiveInc': 0.1,\n",
+    "\n",
+    "            'synPermInactiveDec': 0.005,\n",
+    "        },\n",
+    "\n",
+    "        # Controls whether TP is enabled or disabled;\n",
+    "        # TP is necessary for making temporal predictions, such as predicting\n",
+    "        # the next inputs.  Without TP, the model is only capable of\n",
+    "        # reconstructing missing sensor inputs (via SP).\n",
+    "        'tpEnable' : True,\n",
+    "\n",
+    "        'tpParams': {\n",
+    "            # TP diagnostic output verbosity control;\n",
+    "            # 0: silent; [1..6]: increasing levels of verbosity\n",
+    "            # (see verbosity in nupic/trunk/py/nupic/research/TP.py and TP10X*.py)\n",
+    "            'verbosity': 0,\n",
+    "\n",
+    "            # Number of cell columns in the cortical region (same number for\n",
+    "            # SP and TP)\n",
+    "            # (see also tpNCellsPerCol)\n",
+    "            'columnCount': 2048,\n",
+    "\n",
+    "            # The number of cells (i.e., states), allocated per column.\n",
+    "            'cellsPerColumn': 32,\n",
+    "\n",
+    "            'inputWidth': 2048,\n",
+    "\n",
+    "            'seed': 1960,\n",
+    "\n",
+    "            # Temporal Pooler implementation selector (see _getTPClass in\n",
+    "            # CLARegion.py).\n",
+    "            'temporalImp': 'cpp',\n",
+    "\n",
+    "            # New Synapse formation count\n",
+    "            # NOTE: If None, use spNumActivePerInhArea\n",
+    "            #\n",
+    "            # TODO: need better explanation\n",
+    "            'newSynapseCount': 20,\n",
+    "\n",
+    "            # Maximum number of synapses per segment\n",
+    "            #  > 0 for fixed-size CLA\n",
+    "            # -1 for non-fixed-size CLA\n",
+    "            #\n",
+    "            # TODO: for Ron: once the appropriate value is placed in TP\n",
+    "            # constructor, see if we should eliminate this parameter from\n",
+    "            # description.py.\n",
+    "            'maxSynapsesPerSegment': 32,\n",
+    "\n",
+    "            # Maximum number of segments per cell\n",
+    "            #  > 0 for fixed-size CLA\n",
+    "            # -1 for non-fixed-size CLA\n",
+    "            #\n",
+    "            # TODO: for Ron: once the appropriate value is placed in TP\n",
+    "            # constructor, see if we should eliminate this parameter from\n",
+    "            # description.py.\n",
+    "            'maxSegmentsPerCell': 128,\n",
+    "\n",
+    "            # Initial Permanence\n",
+    "            # TODO: need better explanation\n",
+    "            'initialPerm': 0.21,\n",
+    "\n",
+    "            # Permanence Increment\n",
+    "            'permanenceInc': 0.1,\n",
+    "\n",
+    "            # Permanence Decrement\n",
+    "            # If set to None, will automatically default to tpPermanenceInc\n",
+    "            # value.\n",
+    "            'permanenceDec' : 0.1,\n",
+    "\n",
+    "            'globalDecay': 0.0,\n",
+    "\n",
+    "            'maxAge': 0,\n",
+    "\n",
+    "            # Minimum number of active synapses for a segment to be considered\n",
+    "            # during search for the best-matching segments.\n",
+    "            # None=use default\n",
+    "            # Replaces: tpMinThreshold\n",
+    "            'minThreshold': 9,\n",
+    "\n",
+    "            # Segment activation threshold.\n",
+    "            # A segment is active if it has >= tpSegmentActivationThreshold\n",
+    "            # connected synapses that are active due to infActiveState\n",
+    "            # None=use default\n",
+    "            # Replaces: tpActivationThreshold\n",
+    "            'activationThreshold': 12,\n",
+    "\n",
+    "            'outputType': 'normal',\n",
+    "\n",
+    "            # \"Pay Attention Mode\" length. This tells the TP how many new\n",
+    "            # elements to append to the end of a learned sequence at a time.\n",
+    "            # Smaller values are better for datasets with short sequences,\n",
+    "            # higher values are better for datasets with long sequences.\n",
+    "            'pamLength': 1,\n",
+    "        },\n",
+    "\n",
+    "        'clParams': {\n",
+    "            'regionName' : 'CLAClassifierRegion',\n",
+    "\n",
+    "            # Classifier diagnostic output verbosity control;\n",
+    "            # 0: silent; [1..6]: increasing levels of verbosity\n",
+    "            'verbosity' : 0,\n",
+    "\n",
+    "            # This controls how fast the classifier learns/forgets. Higher values\n",
+    "            # make it adapt faster and forget older patterns faster.\n",
+    "            'alpha': 0.005,\n",
+    "\n",
+    "            # This is set after the call to updateConfigFromSubConfig and is\n",
+    "            # computed from the aggregationInfo and predictAheadTime.\n",
+    "            'steps': '1,5',\n",
+    "\n",
+    "            'implementation': 'cpp',\n",
+    "        },\n",
+    "\n",
+    "        'trainSPNetOnlyIfRequested': False,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Dataset Helpers"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 37,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/nromano/workspace/nupic/src/nupic/datafiles/extra/hotgym/hotgym.csv\n",
+      "\n",
+      "gym,address,timestamp,consumption\n",
+      "string,string,datetime,float\n",
+      "S,,T,\n",
+      "Balgowlah Platinum,Shop 67 197-215 Condamine Street Balgowlah 2093,2010-07-02 00:00:00.0,5.3\n",
+      "Balgowlah Platinum,Shop 67 197-215 Condamine Street Balgowlah 2093,2010-07-02 00:15:00.0,5.5\n",
+      "Balgowlah Platinum,Shop 67 197-215 Condamine Street Balgowlah 2093,2010-07-02 00:30:00.0,5.1\n",
+      "Balgowlah Platinum,Shop 67 197-215 Condamine Street Balgowlah 2093,2010-07-02 00:45:00.0,5.3\n",
+      "Balgowlah Platinum,Shop 67 197-215 Condamine Street Balgowlah 2093,2010-07-02 01:00:00.0,5.2\n"
+     ]
+    }
+   ],
+   "source": [
+    "from pkg_resources import resource_filename\n",
+    "\n",
+    "datasetPath = resource_filename(\"nupic.datafiles\", \"extra/hotgym/hotgym.csv\")\n",
+    "print datasetPath\n",
+    "\n",
+    "with open(datasetPath) as inputFile:\n",
+    "    print\n",
+    "    for _ in xrange(8):\n",
+    "        print inputFile.next().strip()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Loading Data\n",
+    "\n",
+    "`FileRecordStream` - file reader for the NuPIC file format (CSV with three header rows, understands datetimes)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['Balgowlah Platinum', 'Shop 67 197-215 Condamine Street Balgowlah 2093', datetime.datetime(2010, 7, 2, 0, 0), 5.3]\n",
+      "['Balgowlah Platinum', 'Shop 67 197-215 Condamine Street Balgowlah 2093', datetime.datetime(2010, 7, 2, 0, 15), 5.5]\n",
+      "['Balgowlah Platinum', 'Shop 67 197-215 Condamine Street Balgowlah 2093', datetime.datetime(2010, 7, 2, 0, 30), 5.1]\n",
+      "['Balgowlah Platinum', 'Shop 67 197-215 Condamine Street Balgowlah 2093', datetime.datetime(2010, 7, 2, 0, 45), 5.3]\n",
+      "['Balgowlah Platinum', 'Shop 67 197-215 Condamine Street Balgowlah 2093', datetime.datetime(2010, 7, 2, 1, 0), 5.2]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from nupic.data.file_record_stream import FileRecordStream\n",
+    "\n",
+    "def getData():\n",
+    "    return FileRecordStream(datasetPath)\n",
+    "\n",
+    "data = getData()\n",
+    "for _ in xrange(5):\n",
+    "    print data.next()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nupic.frameworks.opf.modelfactory import ModelFactory\n",
+    "model = ModelFactory.create(MODEL_PARAMS)\n",
+    "model.enableInference({'predictedField': 'consumption'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "input:  5.3\n",
+      "prediction:  5.3\n",
+      "input:  5.5\n",
+      "prediction:  5.5\n",
+      "input:  5.1\n",
+      "prediction:  5.36\n",
+      "input:  5.3\n",
+      "prediction:  5.1\n",
+      "input:  5.2\n",
+      "prediction:  5.342\n",
+      "input:  5.5\n",
+      "prediction:  5.2994\n",
+      "input:  4.5\n",
+      "prediction:  5.35958\n",
+      "input:  1.2\n",
+      "prediction:  5.35958\n",
+      "input:  1.1\n",
+      "prediction:  5.35958\n",
+      "input:  1.2\n",
+      "prediction:  1.17\n",
+      "input:  1.2\n",
+      "prediction:  1.179\n",
+      "input:  1.2\n",
+      "prediction:  1.1853\n",
+      "input:  1.2\n",
+      "prediction:  1.18971\n",
+      "input:  1.2\n",
+      "prediction:  1.192797\n",
+      "input:  1.1\n",
+      "prediction:  1.1949579\n",
+      "input:  1.2\n",
+      "prediction:  1.16647053\n",
+      "input:  1.1\n",
+      "prediction:  1.176529371\n",
+      "input:  1.2\n",
+      "prediction:  1.1535705597\n",
+      "input:  1.2\n",
+      "prediction:  1.16749939179\n",
+      "input:  1.1\n",
+      "prediction:  1.17724957425\n",
+      "input:  1.2\n",
+      "prediction:  1.15407470198\n",
+      "input:  6.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  7.9\n",
+      "prediction:  1.16785229138\n",
+      "input:  8.4\n",
+      "prediction:  1.16785229138\n",
+      "input:  10.6\n",
+      "prediction:  1.16785229138\n",
+      "input:  12.4\n",
+      "prediction:  1.16785229138\n",
+      "input:  12.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  12.4\n",
+      "prediction:  1.16785229138\n",
+      "input:  11.4\n",
+      "prediction:  1.16785229138\n",
+      "input:  11.2\n",
+      "prediction:  1.16785229138\n",
+      "input:  10.8\n",
+      "prediction:  1.16785229138\n",
+      "input:  12.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  11.8\n",
+      "prediction:  11.23252\n",
+      "input:  11.9\n",
+      "prediction:  11.402764\n",
+      "input:  11.4\n",
+      "prediction:  11.5519348\n",
+      "input:  11.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.8\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.8\n",
+      "prediction:  10.8881136364\n",
+      "input:  10.8\n",
+      "prediction:  10.5616795455\n",
+      "input:  11.1\n",
+      "prediction:  10.6331756818\n",
+      "input:  11.1\n",
+      "prediction:  10.7732229773\n",
+      "input:  11.0\n",
+      "prediction:  10.8712560841\n",
+      "input:  10.7\n",
+      "prediction:  10.9098792589\n",
+      "input:  10.6\n",
+      "prediction:  10.8469154812\n",
+      "input:  10.3\n",
+      "prediction:  10.7728408368\n",
+      "input:  10.1\n",
+      "prediction:  10.6309885858\n",
+      "input:  12.9\n",
+      "prediction:  10.4716920101\n",
+      "input:  10.5\n",
+      "prediction:  10.4716920101\n",
+      "input:  9.7\n",
+      "prediction:  10.480184407\n",
+      "input:  9.7\n",
+      "prediction:  10.2461290849\n",
+      "input:  9.2\n",
+      "prediction:  10.0822903594\n",
+      "input:  9.2\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.2\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.3\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  8.9\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  8.9\n",
+      "prediction:  1.16785229138\n",
+      "input:  8.9\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.2\n",
+      "prediction:  1.16785229138\n",
+      "input:  10.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  10.7\n",
+      "prediction:  1.16785229138\n",
+      "input:  8.9\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.3\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.3\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.2\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.4\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.3\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.3\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.1\n",
+      "prediction:  1.16785229138\n",
+      "input:  11.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  9.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  8.6\n",
+      "prediction:  1.16785229138\n",
+      "input:  3.0\n",
+      "prediction:  1.16785229138\n",
+      "input:  1.3\n",
+      "prediction:  1.16785229138\n",
+      "input:  1.2\n",
+      "prediction:  1.20749660397\n",
+      "input:  1.3\n",
+      "prediction:  1.20524762278\n",
+      "input:  1.3\n",
+      "prediction:  1.23367333594\n",
+      "input:  1.3\n",
+      "prediction:  1.25357133516\n",
+      "input:  1.2\n",
+      "prediction:  1.26749993461\n",
+      "input:  1.3\n",
+      "prediction:  1.24724995423\n",
+      "input:  1.2\n",
+      "prediction:  1.26307496796\n",
+      "input:  1.3\n",
+      "prediction:  1.24415247757\n",
+      "input:  1.2\n",
+      "prediction:  1.2609067343\n",
+      "input:  1.3\n",
+      "prediction:  1.24263471401\n",
+      "input:  1.2\n",
+      "prediction:  1.25984429981\n",
+      "input:  1.1\n",
+      "prediction:  1.24189100987\n",
+      "input:  2.3\n",
+      "prediction:  1.19932370691\n",
+      "input:  5.5\n",
+      "prediction:  1.19932370691\n",
+      "input:  5.5\n",
+      "prediction:  1.19932370691\n",
+      "input:  5.8\n",
+      "prediction:  1.19932370691\n",
+      "input:  5.7\n",
+      "prediction:  9.50994186712\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = getData()\n",
+    "for _ in xrange(100):\n",
+    "    record = dict(zip(data.getFieldNames(), data.next()))\n",
+    "    print \"input: \", record[\"consumption\"]\n",
+    "    result = model.run(record)\n",
+    "    print \"prediction: \", result.inferences[\"multiStepBestPredictions\"][1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "5-step prediction:  9.50994186712\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"5-step prediction: \", result.inferences[\"multiStepBestPredictions\"][5]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Anomaly Score"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Model Params!\n",
+    "MODEL_PARAMS = {\n",
+    "    # Type of model that the rest of these parameters apply to.\n",
+    "    'model': \"CLA\",\n",
+    "\n",
+    "    # Version that specifies the format of the config.\n",
+    "    'version': 1,\n",
+    "\n",
+    "    # Intermediate variables used to compute fields in modelParams and also\n",
+    "    # referenced from the control section.\n",
+    "    'aggregationInfo': {   'days': 0,\n",
+    "        'fields': [('consumption', 'sum')],\n",
+    "        'hours': 1,\n",
+    "        'microseconds': 0,\n",
+    "        'milliseconds': 0,\n",
+    "        'minutes': 0,\n",
+    "        'months': 0,\n",
+    "        'seconds': 0,\n",
+    "        'weeks': 0,\n",
+    "        'years': 0},\n",
+    "\n",
+    "    'predictAheadTime': None,\n",
+    "\n",
+    "    # Model parameter dictionary.\n",
+    "    'modelParams': {\n",
+    "        # The type of inference that this model will perform\n",
+    "        'inferenceType': 'TemporalAnomaly',\n",
+    "\n",
+    "        'sensorParams': {\n",
+    "            # Sensor diagnostic output verbosity control;\n",
+    "            # if > 0: sensor region will print out on screen what it's sensing\n",
+    "            # at each step 0: silent; >=1: some info; >=2: more info;\n",
+    "            # >=3: even more info (see compute() in py/regions/RecordSensor.py)\n",
+    "            'verbosity' : 0,\n",
+    "\n",
+    "            # Include the encoders we use\n",
+    "            'encoders': {\n",
+    "                u'timestamp_timeOfDay': {\n",
+    "                    'fieldname': u'timestamp',\n",
+    "                    'name': u'timestamp_timeOfDay',\n",
+    "                    'timeOfDay': (21, 0.5),\n",
+    "                    'type': 'DateEncoder'},\n",
+    "                u'timestamp_dayOfWeek': None,\n",
+    "                u'timestamp_weekend': None,\n",
+    "                u'consumption': {\n",
+    "                    'clipInput': True,\n",
+    "                    'fieldname': u'consumption',\n",
+    "                    'maxval': 100.0,\n",
+    "                    'minval': 0.0,\n",
+    "                    'n': 50,\n",
+    "                    'name': u'c1',\n",
+    "                    'type': 'ScalarEncoder',\n",
+    "                    'w': 21},},\n",
+    "\n",
+    "            # A dictionary specifying the period for automatically-generated\n",
+    "            # resets from a RecordSensor;\n",
+    "            #\n",
+    "            # None = disable automatically-generated resets (also disabled if\n",
+    "            # all of the specified values evaluate to 0).\n",
+    "            # Valid keys is the desired combination of the following:\n",
+    "            #   days, hours, minutes, seconds, milliseconds, microseconds, weeks\n",
+    "            #\n",
+    "            # Example for 1.5 days: sensorAutoReset = dict(days=1,hours=12),\n",
+    "            #\n",
+    "            # (value generated from SENSOR_AUTO_RESET)\n",
+    "            'sensorAutoReset' : None,\n",
+    "        },\n",
+    "\n",
+    "        'spEnable': True,\n",
+    "\n",
+    "        'spParams': {\n",
+    "            # SP diagnostic output verbosity control;\n",
+    "            # 0: silent; >=1: some info; >=2: more info;\n",
+    "            'spVerbosity' : 0,\n",
+    "\n",
+    "            # Spatial Pooler implementation selector, see getSPClass\n",
+    "            # in py/regions/SPRegion.py for details\n",
+    "            # 'py' (default), 'cpp' (speed optimized, new)\n",
+    "            'spatialImp' : 'cpp',\n",
+    "\n",
+    "            'globalInhibition': 1,\n",
+    "\n",
+    "            # Number of cell columns in the cortical region (same number for\n",
+    "            # SP and TP)\n",
+    "            # (see also tpNCellsPerCol)\n",
+    "            'columnCount': 2048,\n",
+    "\n",
+    "            'inputWidth': 0,\n",
+    "\n",
+    "            # SP inhibition control (absolute value);\n",
+    "            # Maximum number of active columns in the SP region's output (when\n",
+    "            # there are more, the weaker ones are suppressed)\n",
+    "            'numActiveColumnsPerInhArea': 40,\n",
+    "\n",
+    "            'seed': 1956,\n",
+    "\n",
+    "            # potentialPct\n",
+    "            # What percent of the columns's receptive field is available\n",
+    "            # for potential synapses. At initialization time, we will\n",
+    "            # choose potentialPct * (2*potentialRadius+1)^2\n",
+    "            'potentialPct': 0.5,\n",
+    "\n",
+    "            # The default connected threshold. Any synapse whose\n",
+    "            # permanence value is above the connected threshold is\n",
+    "            # a \"connected synapse\", meaning it can contribute to the\n",
+    "            # cell's firing. Typical value is 0.10. Cells whose activity\n",
+    "            # level before inhibition falls below minDutyCycleBeforeInh\n",
+    "            # will have their own internal synPermConnectedCell\n",
+    "            # threshold set below this default value.\n",
+    "            # (This concept applies to both SP and TP and so 'cells'\n",
+    "            # is correct here as opposed to 'columns')\n",
+    "            'synPermConnected': 0.1,\n",
+    "\n",
+    "            'synPermActiveInc': 0.1,\n",
+    "\n",
+    "            'synPermInactiveDec': 0.005,\n",
+    "        },\n",
+    "\n",
+    "        # Controls whether TP is enabled or disabled;\n",
+    "        # TP is necessary for making temporal predictions, such as predicting\n",
+    "        # the next inputs.  Without TP, the model is only capable of\n",
+    "        # reconstructing missing sensor inputs (via SP).\n",
+    "        'tpEnable' : True,\n",
+    "\n",
+    "        'tpParams': {\n",
+    "            # TP diagnostic output verbosity control;\n",
+    "            # 0: silent; [1..6]: increasing levels of verbosity\n",
+    "            # (see verbosity in nupic/trunk/py/nupic/research/TP.py and TP10X*.py)\n",
+    "            'verbosity': 0,\n",
+    "\n",
+    "            # Number of cell columns in the cortical region (same number for\n",
+    "            # SP and TP)\n",
+    "            # (see also tpNCellsPerCol)\n",
+    "            'columnCount': 2048,\n",
+    "\n",
+    "            # The number of cells (i.e., states), allocated per column.\n",
+    "            'cellsPerColumn': 32,\n",
+    "\n",
+    "            'inputWidth': 2048,\n",
+    "\n",
+    "            'seed': 1960,\n",
+    "\n",
+    "            # Temporal Pooler implementation selector (see _getTPClass in\n",
+    "            # CLARegion.py).\n",
+    "            'temporalImp': 'cpp',\n",
+    "\n",
+    "            # New Synapse formation count\n",
+    "            # NOTE: If None, use spNumActivePerInhArea\n",
+    "            #\n",
+    "            # TODO: need better explanation\n",
+    "            'newSynapseCount': 20,\n",
+    "\n",
+    "            # Maximum number of synapses per segment\n",
+    "            #  > 0 for fixed-size CLA\n",
+    "            # -1 for non-fixed-size CLA\n",
+    "            #\n",
+    "            # TODO: for Ron: once the appropriate value is placed in TP\n",
+    "            # constructor, see if we should eliminate this parameter from\n",
+    "            # description.py.\n",
+    "            'maxSynapsesPerSegment': 32,\n",
+    "\n",
+    "            # Maximum number of segments per cell\n",
+    "            #  > 0 for fixed-size CLA\n",
+    "            # -1 for non-fixed-size CLA\n",
+    "            #\n",
+    "            # TODO: for Ron: once the appropriate value is placed in TP\n",
+    "            # constructor, see if we should eliminate this parameter from\n",
+    "            # description.py.\n",
+    "            'maxSegmentsPerCell': 128,\n",
+    "\n",
+    "            # Initial Permanence\n",
+    "            # TODO: need better explanation\n",
+    "            'initialPerm': 0.21,\n",
+    "\n",
+    "            # Permanence Increment\n",
+    "            'permanenceInc': 0.1,\n",
+    "\n",
+    "            # Permanence Decrement\n",
+    "            # If set to None, will automatically default to tpPermanenceInc\n",
+    "            # value.\n",
+    "            'permanenceDec' : 0.1,\n",
+    "\n",
+    "            'globalDecay': 0.0,\n",
+    "\n",
+    "            'maxAge': 0,\n",
+    "\n",
+    "            # Minimum number of active synapses for a segment to be considered\n",
+    "            # during search for the best-matching segments.\n",
+    "            # None=use default\n",
+    "            # Replaces: tpMinThreshold\n",
+    "            'minThreshold': 9,\n",
+    "\n",
+    "            # Segment activation threshold.\n",
+    "            # A segment is active if it has >= tpSegmentActivationThreshold\n",
+    "            # connected synapses that are active due to infActiveState\n",
+    "            # None=use default\n",
+    "            # Replaces: tpActivationThreshold\n",
+    "            'activationThreshold': 12,\n",
+    "\n",
+    "            'outputType': 'normal',\n",
+    "\n",
+    "            # \"Pay Attention Mode\" length. This tells the TP how many new\n",
+    "            # elements to append to the end of a learned sequence at a time.\n",
+    "            # Smaller values are better for datasets with short sequences,\n",
+    "            # higher values are better for datasets with long sequences.\n",
+    "            'pamLength': 1,\n",
+    "        },\n",
+    "\n",
+    "        'clParams': {\n",
+    "            'regionName' : 'CLAClassifierRegion',\n",
+    "\n",
+    "            # Classifier diagnostic output verbosity control;\n",
+    "            # 0: silent; [1..6]: increasing levels of verbosity\n",
+    "            'verbosity' : 0,\n",
+    "\n",
+    "            # This controls how fast the classifier learns/forgets. Higher values\n",
+    "            # make it adapt faster and forget older patterns faster.\n",
+    "            'alpha': 0.005,\n",
+    "\n",
+    "            # This is set after the call to updateConfigFromSubConfig and is\n",
+    "            # computed from the aggregationInfo and predictAheadTime.\n",
+    "            'steps': '1',\n",
+    "\n",
+    "            'implementation': 'cpp',\n",
+    "        },\n",
+    "\n",
+    "        'anomalyParams': {\n",
+    "            u'anomalyCacheRecords': None,\n",
+    "            u'autoDetectThreshold': None,\n",
+    "            u'autoDetectWaitRecords': 2184\n",
+    "        },\n",
+    "\n",
+    "        'trainSPNetOnlyIfRequested': False,\n",
+    "    },\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from nupic.frameworks.opf.modelfactory import ModelFactory\n",
+    "model = ModelFactory.create(MODEL_PARAMS)\n",
+    "model.enableInference({'predictedField': 'consumption'})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "input:  5.3\n",
+      "prediction:  5.3\n",
+      "input:  5.5\n",
+      "prediction:  5.5\n",
+      "input:  5.1\n",
+      "prediction:  5.36\n",
+      "input:  5.3\n",
+      "prediction:  5.1\n",
+      "input:  5.2\n",
+      "prediction:  5.342\n"
+     ]
+    }
+   ],
+   "source": [
+    "data = getData()\n",
+    "for _ in xrange(5):\n",
+    "    record = dict(zip(data.getFieldNames(), data.next()))\n",
+    "    print \"input: \", record[\"consumption\"]\n",
+    "    result = model.run(record)\n",
+    "    print \"prediction: \", result.inferences[\"multiStepBestPredictions\"][1]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "ModelResult(\tpredictionNumber=4\n",
+      "\trawInput={'timestamp': datetime.datetime(2010, 7, 2, 1, 0), 'gym': 'Balgowlah Platinum', 'consumption': 5.2, 'address': 'Shop 67 197-215 Condamine Street Balgowlah 2093'}\n",
+      "\tsensorInput=SensorInput(\tdataRow=(5.2, 1.0)\n",
+      "\tdataDict={'timestamp': datetime.datetime(2010, 7, 2, 1, 0), 'gym': 'Balgowlah Platinum', 'consumption': 5.2, 'address': 'Shop 67 197-215 Condamine Street Balgowlah 2093'}\n",
+      "\tdataEncodings=[array([ 0.,  0.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,\n",
+      "        1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  1.,  0.,  0.,  0.,\n",
+      "        0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,\n",
+      "        0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.,  0.], dtype=float32), array([ 0.,  0.,  0., ...,  0.,  0.,  0.], dtype=float32)]\n",
+      "\tsequenceReset=0.0\n",
+      "\tcategory=-1\n",
+      ")\n",
+      "\tinferences={'multiStepPredictions': {1: {5.1: 0.29314434936959172, 5.341999999999999: 0.70685565063040834}}, 'multiStepBucketLikelihoods': {1: {1: 0.29314434936959172, 2: 0.70685565063040834}}, 'multiStepBestPredictions': {1: 5.341999999999999}, 'anomalyLabel': '[]', 'anomalyScore': 0.29999999999999999}\n",
+      "\tmetrics=None\n",
+      "\tpredictedFieldIdx=0\n",
+      "\tpredictedFieldName=consumption\n",
+      "\tclassifierInput=ClassifierInput(\tdataRow=5.2\n",
+      "\tbucketIndex=2\n",
+      ")\n",
+      ")\n"
+     ]
+    }
+   ],
+   "source": [
+    "print result"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "anomaly score:  0.3\n"
+     ]
+    }
+   ],
+   "source": [
+    "print \"anomaly score: \", result.inferences[\"anomalyScore\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "__See Subutai's talk for more info on anomaly detection!__\n",
+    "\n",
+    "# Built-in OPF Clients\n",
+    "\n",
+    "`python examples/opf/bin/OpfRunExperiment.py examples/opf/experiments/multistep/hotgym/`\n",
+    "\n",
+    "Outputs `examples/opf/experiments/multistep/hotgym/inference/DefaultTask.TemporalMultiStep.predictionLog.csv`\n",
+    "\n",
+    "`python bin/run_swarm.py examples/opf/experiments/multistep/hotgym/permutations.py`\n",
+    "\n",
+    "Outputs `examples/opf/experiments/multistep/hotgym/model_0/description.py`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
   }
- ]
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
 }

--- a/examples/network/hierarchy_network_demo.py
+++ b/examples/network/hierarchy_network_demo.py
@@ -226,7 +226,7 @@ def createNetwork(dataSource):
 
                         # Diagnostic output verbosity control;
                         # 0: silent; [1..6]: increasing levels of verbosity
-                        'clVerbosity': 0}
+                        'verbosity': 0}
 
   l1Classifier = network.addRegion(_L1_CLASSIFIER, "py.CLAClassifierRegion",
                                    json.dumps(classifierParams))

--- a/examples/opf/clients/cpu/model_params.py
+++ b/examples/opf/clients/cpu/model_params.py
@@ -208,7 +208,7 @@ MODEL_PARAMS = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/clients/hotgym/anomaly/one_gym/model_params/rec_center_hourly_model_params.py
+++ b/examples/opf/clients/hotgym/anomaly/one_gym/model_params/rec_center_hourly_model_params.py
@@ -14,7 +14,7 @@ MODEL_PARAMS = \
                                       u'autoDetectThreshold': None,
                                       u'autoDetectWaitRecords': None},
                    'clParams': { 'alpha': 0.01962508905154251,
-                                 'clVerbosity': 0,
+                                 'verbosity': 0,
                                  'regionName': 'CLAClassifierRegion',
                                  'steps': '1'},
                    'inferenceType': 'TemporalAnomaly',

--- a/examples/opf/clients/hotgym/simple/model_params.py
+++ b/examples/opf/clients/hotgym/simple/model_params.py
@@ -225,7 +225,7 @@ MODEL_PARAMS = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/10field_few2_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_few2_skewed/description.py
@@ -289,7 +289,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/10field_few_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_few_skewed/description.py
@@ -289,7 +289,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/10field_many_balanced/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/anomaly/spatial/10field_many_balanced/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/10field_many_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_many_balanced/description.py
@@ -289,7 +289,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/10field_many_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/10field_many_skewed/description.py
@@ -280,7 +280,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/1field_few_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/1field_few_balanced/description.py
@@ -280,7 +280,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/1field_few_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/1field_few_skewed/description.py
@@ -280,7 +280,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/2field_few_6040/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_few_6040/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/2field_few_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_few_balanced/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/2field_few_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_few_skewed/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/2field_many_balanced/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_many_balanced/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/2field_many_novelAtEnd/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2field_many_novelAtEnd/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/2fields_many_skewed/description.py
+++ b/examples/opf/experiments/anomaly/spatial/2fields_many_skewed/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/novel_combination/description.py
+++ b/examples/opf/experiments/anomaly/spatial/novel_combination/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/spatial/simple/description.py
+++ b/examples/opf/experiments/anomaly/spatial/simple/description.py
@@ -281,7 +281,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/hotgym/description.py
+++ b/examples/opf/experiments/anomaly/temporal/hotgym/description.py
@@ -301,7 +301,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/noisy_saw/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/anomaly/temporal/noisy_saw/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/noisy_saw/description.py
+++ b/examples/opf/experiments/anomaly/temporal/noisy_saw/description.py
@@ -291,7 +291,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/saw_200/description.py
+++ b/examples/opf/experiments/anomaly/temporal/saw_200/description.py
@@ -291,7 +291,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/saw_200_category/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/anomaly/temporal/saw_200_category/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/saw_200_category/description.py
+++ b/examples/opf/experiments/anomaly/temporal/saw_200_category/description.py
@@ -280,7 +280,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/saw_big/description.py
+++ b/examples/opf/experiments/anomaly/temporal/saw_big/description.py
@@ -291,7 +291,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/anomaly/temporal/simple/description.py
+++ b/examples/opf/experiments/anomaly/temporal/simple/description.py
@@ -295,7 +295,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/classification/base_category/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/classification/base_category/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/classification/base_category/description.py
+++ b/examples/opf/experiments/classification/base_category/description.py
@@ -287,7 +287,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             'distanceMethod': 'pctOverlapOfProto',
             'cellsPerCol': 32,

--- a/examples/opf/experiments/classification/base_scalar/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/classification/base_scalar/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/classification/base_scalar/description.py
+++ b/examples/opf/experiments/classification/base_scalar/description.py
@@ -289,7 +289,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             'distanceMethod': 'pctOverlapOfProto',
             'cellsPerCol': 32,

--- a/examples/opf/experiments/classification/category_SP_0/description.py
+++ b/examples/opf/experiments/classification/category_SP_0/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/category_SP_0.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 1},
+  'modelParams': { 'clParams': { 'verbosity': 1},
                    'inferenceType': 'NontemporalClassification',
                    'sensorParams': { 'encoders': { }, 'verbosity': 1},
                    'spParams': { 'spVerbosity': 1 },

--- a/examples/opf/experiments/classification/category_SP_1/description.py
+++ b/examples/opf/experiments/classification/category_SP_1/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/category_SP_1.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalClassification',
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },

--- a/examples/opf/experiments/classification/category_TP_0/description.py
+++ b/examples/opf/experiments/classification/category_TP_0/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/category_TP_0.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpEnable': True,

--- a/examples/opf/experiments/classification/category_TP_1/description.py
+++ b/examples/opf/experiments/classification/category_TP_1/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/category_TP_1.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { 'spVerbosity': 0},
                    'tpEnable': True,

--- a/examples/opf/experiments/classification/category_hub_TP_0/description.py
+++ b/examples/opf/experiments/classification/category_hub_TP_0/description.py
@@ -29,7 +29,7 @@ config = \
 { 'claEvalClassification': True,
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/category_hub_TP_0.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpEnable': True,

--- a/examples/opf/experiments/classification/scalar_TP_0/description.py
+++ b/examples/opf/experiments/classification/scalar_TP_0/description.py
@@ -29,7 +29,7 @@ config = \
 { 'claEvalClassification': True,
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/scalar_TP_0.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpEnable': True,

--- a/examples/opf/experiments/classification/scalar_TP_1/description.py
+++ b/examples/opf/experiments/classification/scalar_TP_1/description.py
@@ -29,7 +29,7 @@ config = \
 { 'claEvalClassification': True,
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/scalar_TP_1.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpEnable': True,

--- a/examples/opf/experiments/classification/scalar_encoder_0/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/classification/scalar_encoder_0/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/classification/scalar_encoder_0/description.py
+++ b/examples/opf/experiments/classification/scalar_encoder_0/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/scalar_SP_0.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0},
+  'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalClassification',
                    'sensorParams': { 'encoders': { 'field1': { 'clipInput': True,
                                                                'fieldname': u'field1',

--- a/examples/opf/experiments/missing_record/base/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/missing_record/base/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/missing_record/base/description.py
+++ b/examples/opf/experiments/missing_record/base/description.py
@@ -312,7 +312,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/missing_record/simple_0/description.py
+++ b/examples/opf/experiments/missing_record/simple_0/description.py
@@ -41,7 +41,7 @@ config = \
       }
     },
     'clParams': {
-      'clVerbosity': 0,
+      'verbosity': 0,
     }
   }
 }

--- a/examples/opf/experiments/multistep/base/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/multistep/base/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/multistep/base/description.py
+++ b/examples/opf/experiments/multistep/base/description.py
@@ -298,7 +298,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/multistep/first_order_0/description.py
+++ b/examples/opf/experiments/multistep/first_order_0/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/first_order_0.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0, 'steps': '1,2,3'},
+  'modelParams': { 'clParams': { 'verbosity': 0, 'steps': '1,2,3'},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpParams': { }},

--- a/examples/opf/experiments/multistep/hotgym/description.py
+++ b/examples/opf/experiments/multistep/hotgym/description.py
@@ -306,7 +306,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/multistep/hotgym_best_enc/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_enc/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',

--- a/examples/opf/experiments/multistep/hotgym_best_sp/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_sp/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',

--- a/examples/opf/experiments/multistep/hotgym_best_sp_16K/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_sp_16K/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',

--- a/examples/opf/experiments/multistep/hotgym_best_sp_5step/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_sp_5step/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',

--- a/examples/opf/experiments/multistep/hotgym_best_sp_5step_16K/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_sp_5step_16K/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',

--- a/examples/opf/experiments/multistep/hotgym_best_tp/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_tp/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',
                                                                     'n': 28,

--- a/examples/opf/experiments/multistep/hotgym_best_tp_16K/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_tp_16K/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',
                                                                     'n': 28,

--- a/examples/opf/experiments/multistep/hotgym_best_tp_5step/description.py
+++ b/examples/opf/experiments/multistep/hotgym_best_tp_5step/description.py
@@ -26,7 +26,7 @@ from nupic.frameworks.opf.expdescriptionhelpers import importBaseDescription
 
 # the sub-experiment configuration
 config = \
-{ 'modelParams': { 'clParams': { 'clVerbosity': 0},
+{ 'modelParams': { 'clParams': { 'verbosity': 0},
                    'sensorParams': { 'encoders': { 'consumption': { 'clipInput': True,
                                                                     'fieldname': u'consumption',
                                                                     'n': 28,

--- a/examples/opf/experiments/multistep/simple_3/description.py
+++ b/examples/opf/experiments/multistep/simple_3/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/simple_3.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0, 'steps': '1,3'},
+  'modelParams': { 'clParams': { 'verbosity': 0, 'steps': '1,3'},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpParams': { }},

--- a/examples/opf/experiments/multistep/simple_3_enc/description.py
+++ b/examples/opf/experiments/multistep/simple_3_enc/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/simple_3.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 1, 'steps': '1,3'},
+  'modelParams': { 'clParams': { 'verbosity': 1, 'steps': '1,3'},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { }, 'verbosity': 1},
                    'spEnable': False,

--- a/examples/opf/experiments/multistep/simple_3_f2/description.py
+++ b/examples/opf/experiments/multistep/simple_3_f2/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/simple_3.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0, 'steps': '1,3'},
+  'modelParams': { 'clParams': { 'verbosity': 0, 'steps': '1,3'},
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },
                    'tpParams': { }},

--- a/examples/opf/experiments/multistep/simple_3_sp/description.py
+++ b/examples/opf/experiments/multistep/simple_3_sp/description.py
@@ -29,7 +29,7 @@ config = \
 { 
   'dataSource': 'file://' + os.path.join(os.path.dirname(__file__), 
                                          '../datasets/simple_3.csv'),
-  'modelParams': { 'clParams': { 'clVerbosity': 0, 'steps': '1,3'},
+  'modelParams': { 'clParams': { 'verbosity': 0, 'steps': '1,3'},
                    'inferenceType': 'NontemporalMultiStep',
                    'sensorParams': { 'encoders': { }, 'verbosity': 0},
                    'spParams': { },

--- a/examples/opf/experiments/opfrunexperiment_test/checkpoints/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/opfrunexperiment_test/checkpoints/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/opfrunexperiment_test/checkpoints/base.py
+++ b/examples/opf/experiments/opfrunexperiment_test/checkpoints/base.py
@@ -303,7 +303,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : VERBOSITY,
+            'verbosity' : VERBOSITY,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym/description.py
+++ b/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym/description.py
@@ -284,7 +284,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/description.py
+++ b/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_1hr_agg/description.py
@@ -305,7 +305,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_no_agg/description.py
+++ b/examples/opf/experiments/opfrunexperiment_test/simpleOPF/hotgym_no_agg/description.py
@@ -305,7 +305,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/spatial_classification/auto_generated/UNDER_DEVELOPMENT
+++ b/examples/opf/experiments/spatial_classification/auto_generated/UNDER_DEVELOPMENT
@@ -286,7 +286,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/spatial_classification/base/description.py
+++ b/examples/opf/experiments/spatial_classification/base/description.py
@@ -298,7 +298,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/opf/experiments/spatial_classification/category_0/description.py
+++ b/examples/opf/experiments/spatial_classification/category_0/description.py
@@ -35,7 +35,7 @@ config = \
   'modelParams': { 
     'sensorParams': { 'verbosity': 0},
     'clParams': { 
-      'clVerbosity': 0,
+      'verbosity': 0,
     },
   }
 }

--- a/examples/opf/experiments/spatial_classification/category_1/description.py
+++ b/examples/opf/experiments/spatial_classification/category_1/description.py
@@ -34,7 +34,7 @@ config = \
   'modelParams': { 
     'sensorParams': { 'verbosity': 0},
     'clParams': { 
-      'clVerbosity': 0,
+      'verbosity': 0,
     },
   }
 }

--- a/examples/opf/experiments/spatial_classification/scalar_0/description.py
+++ b/examples/opf/experiments/spatial_classification/scalar_0/description.py
@@ -59,7 +59,7 @@ config = \
       },
     },
     'clParams': { 
-      'clVerbosity': 0,
+      'verbosity': 0,
     },
   }
 }

--- a/examples/opf/experiments/spatial_classification/scalar_1/description.py
+++ b/examples/opf/experiments/spatial_classification/scalar_1/description.py
@@ -59,7 +59,7 @@ config = \
        },
     },
     'clParams': { 
-      'clVerbosity': 0,
+      'verbosity': 0,
     },
   }
 }

--- a/examples/opf/simple_server/model_params.py
+++ b/examples/opf/simple_server/model_params.py
@@ -225,7 +225,7 @@ MODEL_PARAMS = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/examples/prediction/category_prediction/run.py
+++ b/examples/prediction/category_prediction/run.py
@@ -120,7 +120,7 @@ MODEL_PARAMS = {
       "clParams": {
         "implementation": "cpp",
         "regionName" : "CLAClassifierRegion",
-        "clVerbosity" : 0,
+        "verbosity" : 0,
         "alpha": 0.0001,
         "steps": "1",
       },

--- a/src/nupic/frameworks/opf/common_models/anomaly_params_random_encoder/best_single_metric_anomaly_params_cpp.json
+++ b/src/nupic/frameworks/opf/common_models/anomaly_params_random_encoder/best_single_metric_anomaly_params_cpp.json
@@ -89,7 +89,7 @@
         "alpha": 0.035828933612157998,
         "regionName": "CLAClassifierRegion",
         "steps": "1",
-        "clVerbosity": 0
+        "verbosity": 0
       },
       "anomalyParams": {
         "anomalyCacheRecords": null,

--- a/src/nupic/frameworks/opf/common_models/anomaly_params_random_encoder/best_single_metric_anomaly_params_tm_cpp.json
+++ b/src/nupic/frameworks/opf/common_models/anomaly_params_random_encoder/best_single_metric_anomaly_params_tm_cpp.json
@@ -89,7 +89,7 @@
         "alpha": 0.035828933612157998,
         "regionName": "CLAClassifierRegion",
         "steps": "1",
-        "clVerbosity": 0
+        "verbosity": 0
       },
       "anomalyParams": {
         "anomalyCacheRecords": null,

--- a/src/nupic/frameworks/opf/expdescriptionapi.py
+++ b/src/nupic/frameworks/opf/expdescriptionapi.py
@@ -316,7 +316,7 @@ class ExperimentDescriptionAPI(DescriptionIface):
     if 'clRegionName' in config:
       clParams = dict(
         regionName = config['clRegionName'],
-        clVerbosity = config['clVerbosity'],
+        verbosity = config['verbosity'],
       )
       if config['clRegionName'] == 'KNNClassifierRegion':
         clParams['replaceDuplicates'] = 1

--- a/src/nupic/regions/CLAClassifierRegion.py
+++ b/src/nupic/regions/CLAClassifierRegion.py
@@ -192,7 +192,7 @@ class CLAClassifierRegion(PyRegion):
           count=0,
           constraints='enum: py, cpp'),
 
-        clVerbosity=dict(
+        verbosity=dict(
           description='An integer that controls the verbosity level, '
                       '0 means no verbose output, increasing integers '
                       'provide more verbosity.',
@@ -212,7 +212,7 @@ class CLAClassifierRegion(PyRegion):
   def __init__(self,
                steps='1',
                alpha=0.001,
-               clVerbosity=0,
+               verbosity=0,
                implementation=None,
                maxCategoryCount=None
                ):
@@ -226,7 +226,7 @@ class CLAClassifierRegion(PyRegion):
     self.steps = steps
     self.stepsList = eval("[%s]" % (steps))
     self.alpha = alpha
-    self.verbosity = clVerbosity
+    self.verbosity = verbosity
 
     # Initialize internal structures
     self._claClassifier = CLAClassifierFactory.create(

--- a/src/nupic/regions/KNNClassifierRegion.py
+++ b/src/nupic/regions/KNNClassifierRegion.py
@@ -389,7 +389,7 @@ class KNNClassifierRegion(PyRegion):
             defaultValue=0,
             accessMode='Create'),
 
-          clVerbosity=dict(
+          verbosity=dict(
             description='An integer that controls the verbosity level, '
                         '0 means no verbose output, increasing integers '
                         'provide more verbosity.',
@@ -474,7 +474,7 @@ class KNNClassifierRegion(PyRegion):
                fractionOfMax=0,
                useAuxiliary=0,
                justUseAuxiliary=0,
-               clVerbosity=0,
+               verbosity=0,
                replaceDuplicates=False,
                cellsPerCol=0,
                maxStoredPatterns=-1,
@@ -517,7 +517,7 @@ class KNNClassifierRegion(PyRegion):
         numSVDSamples=SVDSampleCount,
         numSVDDims=SVDDimCount,
         fractionOfMax=fractionOfMax,
-        verbosity=clVerbosity,
+        verbosity=verbosity,
         replaceDuplicates=replaceDuplicates,
         cellsPerCol=cellsPerCol,
         maxStoredPatterns=maxStoredPatterns,
@@ -545,7 +545,7 @@ class KNNClassifierRegion(PyRegion):
     self._labels  = None
 
     # Debugging
-    self.verbosity = clVerbosity
+    self.verbosity = verbosity
 
     # Taps
     self._tapFileIn = None
@@ -752,7 +752,7 @@ class KNNClassifierRegion(PyRegion):
           self._protoScoreCount = 1
         else:
           self._protoScoreCount = 0
-    elif name == "clVerbosity":
+    elif name == "verbosity":
       self.verbosity = value
       self._knn.verbosity = value
     else:

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -193,7 +193,7 @@ class SDRClassifierRegion(PyRegion):
           count=0,
           constraints='enum: py'),
 
-        clVerbosity=dict(
+        verbosity=dict(
           description='An integer that controls the verbosity level, '
                       '0 means no verbose output, increasing integers '
                       'provide more verbosity.',
@@ -212,7 +212,7 @@ class SDRClassifierRegion(PyRegion):
   def __init__(self,
                steps='1',
                alpha=0.001,
-               clVerbosity=0,
+               verbosity=0,
                implementation=None,
                maxCategoryCount=None
                ):
@@ -227,7 +227,7 @@ class SDRClassifierRegion(PyRegion):
     self.steps = steps
     self.stepsList = [int(i) for i in steps.split(",")]
     self.alpha = alpha
-    self.verbosity = clVerbosity
+    self.verbosity = verbosity
 
     # Initialize internal structures
     self._sdrClassifier = None

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -193,7 +193,7 @@ class SDRClassifierRegion(PyRegion):
           count=0,
           constraints='enum: py'),
 
-        verbosity=dict(
+        clVerbosity=dict(
           description='An integer that controls the verbosity level, '
                       '0 means no verbose output, increasing integers '
                       'provide more verbosity.',

--- a/src/nupic/swarming/exp_generator/claDescriptionTemplate.tpl
+++ b/src/nupic/swarming/exp_generator/claDescriptionTemplate.tpl
@@ -232,7 +232,7 @@ config = {
             
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/src/nupic/swarming/exp_generator/descriptionTemplate.tpl
+++ b/src/nupic/swarming/exp_generator/descriptionTemplate.tpl
@@ -372,7 +372,7 @@ config = {
   # Classifier diagnostic output verbosity control;
   # 0: silent; [1..6]: increasing levels of verbosity
   #
-  'clVerbosity' : 0,
+  'verbosity' : 0,
 
   # Comma separated list of steps ahead to learn in the classifier.
   'clSteps': $PREDICTION_STEPS,

--- a/tests/integration/nupic/opf/opf_checkpoint_stress_test.py
+++ b/tests/integration/nupic/opf/opf_checkpoint_stress_test.py
@@ -105,7 +105,7 @@ MODEL_PARAMS = {
         },
         'clParams': {
             'regionName' : 'CLAClassifierRegion',
-            'clVerbosity' : 0,
+            'verbosity' : 0,
             'alpha': 0.005,
             'steps': '1,5',
         },

--- a/tests/integration/nupic/opf/opf_checkpoint_test/experiments/backwards_compatibility/base.py
+++ b/tests/integration/nupic/opf/opf_checkpoint_test/experiments/backwards_compatibility/base.py
@@ -305,7 +305,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : VERBOSITY,
+            'verbosity' : VERBOSITY,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/integration/nupic/opf/opf_checkpoint_test/experiments/non_temporal_multi_step/base.py
+++ b/tests/integration/nupic/opf/opf_checkpoint_test/experiments/non_temporal_multi_step/base.py
@@ -305,7 +305,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : VERBOSITY,
+            'verbosity' : VERBOSITY,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/integration/nupic/opf/opf_checkpoint_test/experiments/temporal_anomaly/base.py
+++ b/tests/integration/nupic/opf/opf_checkpoint_test/experiments/temporal_anomaly/base.py
@@ -305,7 +305,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : VERBOSITY,
+            'verbosity' : VERBOSITY,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/integration/nupic/opf/opf_checkpoint_test/experiments/temporal_multi_step/base.py
+++ b/tests/integration/nupic/opf/opf_checkpoint_test/experiments/temporal_multi_step/base.py
@@ -305,7 +305,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : VERBOSITY,
+            'verbosity' : VERBOSITY,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/integration/nupic/opf/opf_description_template_test/experiments/gym/base.py
+++ b/tests/integration/nupic/opf/opf_description_template_test/experiments/gym/base.py
@@ -280,7 +280,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -114,7 +114,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     self.assertAlmostEqual(float(classifier.getParameter("alpha")), 0.001)
     self.assertEqual(int(classifier.getParameter("steps")), 0)
     self.assertTrue(classifier.getParameter("implementation") == "py")
-    self.assertEqual(classifier.getParameter("clVerbosity"), 0)
+    self.assertEqual(classifier.getParameter("verbosity"), 0)
 
 
     expectedCats = ([0.0], [1.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0],)

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -114,7 +114,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     self.assertAlmostEqual(float(classifier.getParameter("alpha")), 0.001)
     self.assertEqual(int(classifier.getParameter("steps")), 0)
     self.assertTrue(classifier.getParameter("implementation") == "py")
-    self.assertEqual(classifier.getParameter("verbosity"), 0)
+    self.assertEqual(classifier.getParameter("clVerbosity"), 0)
 
 
     expectedCats = ([0.0], [1.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0],)

--- a/tests/swarming/nupic/swarming/experiments/delta/description.py
+++ b/tests/swarming/nupic/swarming/experiments/delta/description.py
@@ -296,7 +296,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/dummyV2/description.py
+++ b/tests/swarming/nupic/swarming/experiments/dummyV2/description.py
@@ -310,7 +310,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/dummy_multi_v2/description.py
+++ b/tests/swarming/nupic/swarming/experiments/dummy_multi_v2/description.py
@@ -309,7 +309,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/field_contrib_temporal/description.py
+++ b/tests/swarming/nupic/swarming/experiments/field_contrib_temporal/description.py
@@ -309,7 +309,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/field_threshold_temporal/description.py
+++ b/tests/swarming/nupic/swarming/experiments/field_threshold_temporal/description.py
@@ -322,7 +322,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/input_predicted_field/description.py
+++ b/tests/swarming/nupic/swarming/experiments/input_predicted_field/description.py
@@ -289,7 +289,7 @@ config = {
             
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/legacy_cla_multistep/description.py
+++ b/tests/swarming/nupic/swarming/experiments/legacy_cla_multistep/description.py
@@ -269,7 +269,7 @@ config = {
             
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/max_branching_temporal/description.py
+++ b/tests/swarming/nupic/swarming/experiments/max_branching_temporal/description.py
@@ -322,7 +322,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/oneField/description.py
+++ b/tests/swarming/nupic/swarming/experiments/oneField/description.py
@@ -294,7 +294,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/simpleV2/description.py
+++ b/tests/swarming/nupic/swarming/experiments/simpleV2/description.py
@@ -310,7 +310,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/simple_cla_multistep/description.py
+++ b/tests/swarming/nupic/swarming/experiments/simple_cla_multistep/description.py
@@ -277,7 +277,7 @@ config = {
             
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/smart_speculation_spatial_classification/description.py
+++ b/tests/swarming/nupic/swarming/experiments/smart_speculation_spatial_classification/description.py
@@ -328,7 +328,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/smart_speculation_temporal/description.py
+++ b/tests/swarming/nupic/swarming/experiments/smart_speculation_temporal/description.py
@@ -327,7 +327,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/swarming/nupic/swarming/experiments/spatial_classification/description.py
+++ b/tests/swarming/nupic/swarming/experiments/spatial_classification/description.py
@@ -323,7 +323,7 @@ config = {
 
             # Classifier diagnostic output verbosity control;
             # 0: silent; [1..6]: increasing levels of verbosity
-            'clVerbosity' : 0,
+            'verbosity' : 0,
 
             # This controls how fast the classifier learns/forgets. Higher values
             # make it adapt faster and forget older patterns faster.

--- a/tests/unit/nupic/algorithms/nab_detector_test.py
+++ b/tests/unit/nupic/algorithms/nab_detector_test.py
@@ -150,7 +150,7 @@ class NABTest(TestCaseBase):
                       "clEnable": False,
                       "clParams": {
                           "alpha": 0.035828933612158,
-                          "clVerbosity": 0,
+                          "verbosity": 0,
                           "regionName": "CLAClassifierRegion",
                           "steps": "1"
                       },

--- a/tests/unit/nupic/frameworks/opf/clamodel_test.py
+++ b/tests/unit/nupic/frameworks/opf/clamodel_test.py
@@ -99,7 +99,7 @@ class CLAModelTest(unittest.TestCase):
                                            u'autoDetectWaitRecords': 5030},
                         u'clEnable': False,
                         u'clParams': {u'alpha': 0.035828933612158,
-                                      u'clVerbosity': 0,
+                                      u'verbosity': 0,
                                       u'regionName': u'CLAClassifierRegion',
                                       u'steps': u'1'},
                         u'inferenceType': u'TemporalAnomaly',


### PR DESCRIPTION
Fixes #3165 by changing the verbosity variable proto in SDRClassifierRegion.py. 

The parameter name for verbose level is now `clVerbosity`rather than `verbosity`, for consistency with the other classifiers and other regions (spatial pooler uses `spVerbosity` for instance).