### PR TITLE
Fix pip install that fails to download.

### DIFF
--- a/ci/bamboo/build-linux.sh
+++ b/ci/bamboo/build-linux.sh
@@ -36,8 +36,8 @@ apt-get install -y \
     build-essential \
     python \
     python2.7 \
-    python2.7-dev
-wget https://bootstrap.pypa.io/get-pip.py -O - | python
+    python2.7-dev \
+    python-pip
 pip install --upgrade --ignore-installed setuptools
 pip install wheel
 


### PR DESCRIPTION
@BoltzmannBrain this should fix pip error in build

@oxtopus please review

merging pre-approval because it only affects Bamboo build script (that is currently failing)