### PR TITLE
Updates SDR classifier internals

### DIFF
--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = '064f8b1ef003d5ee07405cd5ac41583f83ab1d35'
+NUPIC_CORE_COMMITISH = 'e71b815c6c044918f4d58e12e169a2376b41845d'

--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = '7212c23cbfe7bdb25141cb33307e8252f5a202d6'
+NUPIC_CORE_COMMITISH = 'b7f2bd4fdb3bb7b649ed062c62906cb482a75b7b'

--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = 'b7f2bd4fdb3bb7b649ed062c62906cb482a75b7b'
+NUPIC_CORE_COMMITISH = 'f7fc03ace5422c7bdcbabe509f28f0ec1d9d0e40'

--- a/.nupic_modules
+++ b/.nupic_modules
@@ -1,3 +1,3 @@
 # Default nupic.core dependencies (override in optional .nupic_config)
 NUPIC_CORE_REMOTE = 'git://github.com/numenta/nupic.core.git'
-NUPIC_CORE_COMMITISH = 'e71b815c6c044918f4d58e12e169a2376b41845d'
+NUPIC_CORE_COMMITISH = '7212c23cbfe7bdb25141cb33307e8252f5a202d6'

--- a/src/nupic/algorithms/sdr_classifier_factory.py
+++ b/src/nupic/algorithms/sdr_classifier_factory.py
@@ -22,6 +22,7 @@
 """Module providing a factory for instantiating a SDR classifier."""
 
 from nupic.algorithms.sdr_classifier import SDRClassifier
+from nupic.bindings.algorithms import SDRClassifier as FastSDRClassifier
 from nupic.support.configuration import Configuration
 
 
@@ -45,9 +46,11 @@ class SDRClassifierFactory(object):
       impl = Configuration.get('nupic.opf.sdrClassifier.implementation')
     if impl == 'py':
       return SDRClassifier(*args, **kwargs)
+    elif impl == 'cpp':
+      return FastSDRClassifier(*args, **kwargs)
     else:
       raise ValueError('Invalid classifier implementation (%r). Value must be '
-                       '"py".' % impl)
+                       '"py" or "cpp.' % impl)
 
 
   @staticmethod
@@ -58,6 +61,8 @@ class SDRClassifierFactory(object):
     impl = proto.implementation
     if impl == 'py':
       return SDRClassifier.read(proto.sdrClassifier)
+    elif impl == 'cpp':
+      return FastSDRClassifier.read(proto.sdrClassifier)
     else:
       raise ValueError('Invalid classifier implementation (%r). Value must be '
-                       '"py".' % impl)
+                       '"py" or "cpp".' % impl)

--- a/src/nupic/algorithms/sdr_classifier_factory.py
+++ b/src/nupic/algorithms/sdr_classifier_factory.py
@@ -50,7 +50,7 @@ class SDRClassifierFactory(object):
       return FastSDRClassifier(*args, **kwargs)
     else:
       raise ValueError('Invalid classifier implementation (%r). Value must be '
-                       '"py" or "cpp.' % impl)
+                       '"py" or "cpp".' % impl)
 
 
   @staticmethod

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -385,7 +385,7 @@ class SDRClassifierRegion(PyRegion):
                                     infer=False)
 
     # fill outputs with clResults
-    if clResults is not None and clResults:
+    if clResults is not None and len(clResults) > 0:
       outputs['actualValues'][:len(clResults["actualValues"])] = \
         clResults["actualValues"]
 

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -385,7 +385,7 @@ class SDRClassifierRegion(PyRegion):
                                     infer=False)
 
     # fill outputs with clResults
-    if clResults is not None:
+    if clResults is not None and clResults:
       outputs['actualValues'][:len(clResults["actualValues"])] = \
         clResults["actualValues"]
 

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -191,7 +191,7 @@ class SDRClassifierRegion(PyRegion):
           accessMode='ReadWrite',
           dataType='Byte',
           count=0,
-          constraints='enum: py'),
+          constraints='enum: py, cpp'),
 
         verbosity=dict(
           description='An integer that controls the verbosity level, '
@@ -246,8 +246,8 @@ class SDRClassifierRegion(PyRegion):
 
   def initialize(self, inputs, outputs):
     """
-    Is called once by NuPIC before the first call to compute(). Initializes self._sdrClassifier
-    is it is not already initialized.
+    Is called once by NuPIC before the first call to compute().
+    Initializes self._sdrClassifier is it is not already initialized.
     @param inputs -- inputs of the classifier region
     @param outputs -- outputs of the classifier region
     """

--- a/src/nupic/support/nupic-default.xml
+++ b/src/nupic/support/nupic-default.xml
@@ -17,9 +17,9 @@
 
 <property>
   <name>nupic.opf.sdrClassifier.implementation</name>
-  <value>py</value>
+  <value>cpp</value>
   <description>The SDR classifier implementation to use by default. The current
-  options are 'py'.
+  options are 'py' and 'cpp'.
   </description>
 </property>
 

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -196,7 +196,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     self.assertEqual(classifier.getParameter("maxCategoryCount"), 100)
     self.assertAlmostEqual(float(classifier.getParameter("alpha")), 0.001)
     self.assertEqual(int(classifier.getParameter("steps")), 0)
-    self.assertTrue(classifier.getParameter("implementation") == "py")
+    self.assertTrue(classifier.getParameter("implementation") == "cpp")
     self.assertEqual(classifier.getParameter("verbosity"), 0)
 
     expectedCats = ([0.0], [1.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0],)

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -130,6 +130,88 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     os.remove(filename)
 
 
+  def testSimpleMulticlassNetworkCPP(self):
+    # Setup data record stream of fake data (with three categories)
+    filename = _getTempFileName()
+    fields = [("timestamp", "datetime", "T"),
+              ("value", "float", ""),
+              ("reset", "int", "R"),
+              ("sid", "int", "S"),
+              ("categories", "list", "C")]
+    records = (
+      [datetime(day=1, month=3, year=2010), 0.0, 1, 0, "0"],
+      [datetime(day=2, month=3, year=2010), 1.0, 0, 0, "1"],
+      [datetime(day=3, month=3, year=2010), 0.0, 0, 0, "0"],
+      [datetime(day=4, month=3, year=2010), 1.0, 0, 0, "1"],
+      [datetime(day=5, month=3, year=2010), 0.0, 0, 0, "0"],
+      [datetime(day=6, month=3, year=2010), 1.0, 0, 0, "1"],
+      [datetime(day=7, month=3, year=2010), 0.0, 0, 0, "0"],
+      [datetime(day=8, month=3, year=2010), 1.0, 0, 0, "1"])
+    dataSource = FileRecordStream(streamID=filename, write=True,
+                                  fields=fields)
+    for r in records:
+      dataSource.appendRecord(list(r))
+
+    # Create the network and get region instances.
+    net = Network()
+    net.addRegion("sensor", "py.RecordSensor", "{'numCategories': 3}")
+    net.addRegion("classifier", "py.SDRClassifierRegion",
+                  "{steps: '0', alpha: 0.001, implementaiton: cpp}")
+    net.link("sensor", "classifier", "UniformLink", "",
+             srcOutput="dataOut", destInput="bottomUpIn")
+    net.link("sensor", "classifier", "UniformLink", "",
+             srcOutput="categoryOut", destInput="categoryIn")
+    sensor = net.regions["sensor"]
+    classifier = net.regions["classifier"]
+
+    # Setup sensor region encoder and data stream.
+    dataSource.close()
+    dataSource = FileRecordStream(filename)
+    sensorRegion = sensor.getSelf()
+    sensorRegion.encoder = MultiEncoder()
+    sensorRegion.encoder.addEncoder(
+      "value", ScalarEncoder(21, 0.0, 13.0, n=256, name="value"))
+    sensorRegion.dataSource = dataSource
+
+    # Get ready to run.
+    net.initialize()
+
+    # Train the network (by default learning is ON in the classifier, but assert
+    # anyway) and then turn off learning and turn on inference mode.
+    self.assertEqual(classifier.getParameter("learningMode"), 1)
+    net.run(8)
+
+    # Test the network on the same data as it trained on; should classify with
+    # 100% accuracy.
+    classifier.setParameter("inferenceMode", 1)
+    classifier.setParameter("learningMode", 0)
+
+    # Assert learning is OFF and that the classifier learned the dataset.
+    self.assertEqual(classifier.getParameter("learningMode"), 0,
+                     "Learning mode is not turned off.")
+    self.assertEqual(classifier.getParameter("inferenceMode"), 1,
+                     "Inference mode is not turned on.")
+
+    # make sure we can access all the parameters with getParameter
+    self.assertEqual(classifier.getParameter("maxCategoryCount"), 100)
+    self.assertAlmostEqual(float(classifier.getParameter("alpha")), 0.001)
+    self.assertEqual(int(classifier.getParameter("steps")), 0)
+    self.assertTrue(classifier.getParameter("implementation") == "py")
+    self.assertEqual(classifier.getParameter("verbosity"), 0)
+
+    expectedCats = ([0.0], [1.0], [0.0], [1.0], [0.0], [1.0], [0.0], [1.0],)
+    dataSource.rewind()
+    for i in xrange(8):
+      net.run(1)
+      inferredCats = classifier.getOutputData("categoriesOut")
+      self.assertSequenceEqual(expectedCats[i], inferredCats.tolist(),
+                               "Classififer did not infer expected category "
+                               "for record number {}.".format(i))
+    # Close data stream, delete file.
+    dataSource.close()
+    os.remove(filename)
+
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -156,7 +156,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     net = Network()
     net.addRegion("sensor", "py.RecordSensor", "{'numCategories': 3}")
     net.addRegion("classifier", "py.SDRClassifierRegion",
-                  "{steps: '0', alpha: 0.001, implementaiton: cpp}")
+                  "{steps: '0', alpha: 0.001, implementation: cpp}")
     net.link("sensor", "classifier", "UniformLink", "",
              srcOutput="dataOut", destInput="bottomUpIn")
     net.link("sensor", "classifier", "UniformLink", "",

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -48,7 +48,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
   """
 
 
-  def testSimpleMulticlassNetwork(self):
+  def testSimpleMulticlassNetworkPY(self):
     # Setup data record stream of fake data (with three categories)
     filename = _getTempFileName()
     fields = [("timestamp", "datetime", "T"),
@@ -73,7 +73,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     net = Network()
     net.addRegion("sensor", "py.RecordSensor", "{'numCategories': 3}")
     net.addRegion("classifier", "py.SDRClassifierRegion",
-                  "{steps: '0', alpha: 0.001}")
+                  "{steps: '0', alpha: 0.001, implementation: 'py'}")
     net.link("sensor", "classifier", "UniformLink", "",
              srcOutput="dataOut", destInput="bottomUpIn")
     net.link("sensor", "classifier", "UniformLink", "",
@@ -156,7 +156,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
     net = Network()
     net.addRegion("sensor", "py.RecordSensor", "{'numCategories': 3}")
     net.addRegion("classifier", "py.SDRClassifierRegion",
-                  "{steps: '0', alpha: 0.001, implementation: cpp}")
+                  "{steps: '0', alpha: 0.001, implementation: 'cpp'}")
     net.link("sensor", "classifier", "UniformLink", "",
              srcOutput="dataOut", destInput="bottomUpIn")
     net.link("sensor", "classifier", "UniformLink", "",
@@ -207,6 +207,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
       self.assertSequenceEqual(expectedCats[i], inferredCats.tolist(),
                                "Classififer did not infer expected category "
                                "for record number {}.".format(i))
+
     # Close data stream, delete file.
     dataSource.close()
     os.remove(filename)

--- a/tests/unit/nupic/algorithms/sdr_classifier_test.py
+++ b/tests/unit/nupic/algorithms/sdr_classifier_test.py
@@ -762,10 +762,9 @@ class SDRClassifierTest(unittest.TestCase):
     c2 = SDRClassifier.read(proto2)
 
     self.assertEqual(c1.steps, c2.steps)
+    self.assertEqual(c1._maxSteps, c2._maxSteps)
     self.assertAlmostEqual(c1.alpha, c2.alpha)
     self.assertAlmostEqual(c1.actValueAlpha, c2.actValueAlpha)
-    self.assertEqual(c1._learnIteration, c2._learnIteration)
-    self.assertEqual(c1._recordNumMinusLearnIteration, c2._recordNumMinusLearnIteration)
     self.assertEqual(c1._patternNZHistory, c2._patternNZHistory)
     self.assertEqual(c1._weightMatrix.keys(), c2._weightMatrix.keys())
     for step in c1._weightMatrix.keys():


### PR DESCRIPTION
Fixes #3221 et #3222, respectively by updating the SDR classifier internals to match the new serialization proto for SDR classifier, and by fixing the fact that maxSteps was not serialized.

Also:
- makes C++ the default implementation for the SDR classifier
- adds a test for the C++ implementation within a SDRClassifierRegion

@mrcslws @scottpurdy 

Note: the CI tests will break until numenta/nupic.core#1010 is merged.