### PR TITLE
Correcting spatial pooler terminology to mini column instead of cortical column

### DIFF
--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -43,7 +43,7 @@ class InvalidSPParamValueError(ValueError):
 
 
 
-class _SparseMatrixCorticalColumnAdapter(object):
+class _SparseMatrixMiniColumnAdapter(object):
   """ Many functions in SpatialPooler operate on a columnIndex but use an
   underlying storage implementation based on a Sparse Matrix in which cortical
   columns are represented as rows.  This can be confusing to someone trying to
@@ -56,13 +56,13 @@ class _SparseMatrixCorticalColumnAdapter(object):
   def __getitem__(self, columnIndex):
     """ Wraps getRow() such that instances may be indexed by columnIndex.
     """
-    return super(_SparseMatrixCorticalColumnAdapter, self).getRow(columnIndex)
+    return super(_SparseMatrixMiniColumnAdapter, self).getRow(columnIndex)
 
 
   def replace(self, columnIndex, bitmap):
     """ Wraps replaceSparseRow()
     """
-    return super(_SparseMatrixCorticalColumnAdapter, self).replaceSparseRow(
+    return super(_SparseMatrixMiniColumnAdapter, self).replaceSparseRow(
       columnIndex, bitmap
     )
 
@@ -70,14 +70,14 @@ class _SparseMatrixCorticalColumnAdapter(object):
   def update(self, columnIndex, vector):
     """ Wraps setRowFromDense()
     """
-    return super(_SparseMatrixCorticalColumnAdapter, self).setRowFromDense(
+    return super(_SparseMatrixMiniColumnAdapter, self).setRowFromDense(
       columnIndex, vector
     )
 
 
 
-class CorticalColumns(_SparseMatrixCorticalColumnAdapter, SparseMatrix):
-  """ SparseMatrix variant of _SparseMatrixCorticalColumnAdapter.  Use in cases
+class MiniColumns(_SparseMatrixMiniColumnAdapter, SparseMatrix):
+  """ SparseMatrix variant of _SparseMatrixMiniColumnAdapter.  Use in cases
   where column connections are represented as float values, such as permanence
   values
   """
@@ -85,9 +85,9 @@ class CorticalColumns(_SparseMatrixCorticalColumnAdapter, SparseMatrix):
 
 
 
-class BinaryCorticalColumns(_SparseMatrixCorticalColumnAdapter,
+class BinaryMiniColumns(_SparseMatrixMiniColumnAdapter,
                             SparseBinaryMatrix):
-  """ SparseBinaryMatrix variant of _SparseMatrixCorticalColumnAdapter.  Use in
+  """ SparseBinaryMatrix variant of _SparseMatrixMiniColumnAdapter.  Use in
   cases where column connections are represented as bitmaps.
   """
   pass
@@ -304,12 +304,12 @@ class SpatialPooler(object):
     # single adjacency matrix such that matrix rows map to cortical columns,
     # and matrix columns map to input buts.  If potentialPools[i][j] == 1,
     # then input bit 'j' is in column 'i's potential pool. A column can only be
-    # connected to inputs in its potential pool.  Here, BinaryCorticalColumns
+    # connected to inputs in its potential pool.  Here, BinaryMiniColumns
     # is used to provide cortical column-centric semantics for what is
     # otherwise a sparse binary matrix implementation.  Sparse binary matrix is
     # used as an optimization since a column will only be connected to a small
     # fraction of input bits.
-    self._potentialPools = BinaryCorticalColumns(numInputs)
+    self._potentialPools = BinaryMiniColumns(numInputs)
     self._potentialPools.resize(numColumns, numInputs)
 
     # Initialize the permanences for each column. Similar to the
@@ -317,13 +317,13 @@ class SpatialPooler(object):
     # represent the cortical columns, and whose columns represent the input
     # bits. If self._permanences[i][j] = 0.2, then the synapse connecting
     # cortical column 'i' to input bit 'j'  has a permanence of 0.2. Here,
-    # CorticalColumns is used to provide cortical column-centric semantics for
+    # MiniColumns is used to provide cortical column-centric semantics for
     # what is otherwise a sparse matrix implementation.  Sparse matrix is used
     # as an optimization to improve computation time of alforithms that
     # require iterating over the data  structure. This permanence matrix is
     # only allowed to have non-zero elements where the potential pool is
     # non-zero.
-    self._permanences = CorticalColumns(numColumns, numInputs)
+    self._permanences = MiniColumns(numColumns, numInputs)
 
     # Initialize a tiny random tie breaker. This is used to determine winning
     # columns where the overlaps are identical.
@@ -337,7 +337,7 @@ class SpatialPooler(object):
     # bit, i.e. its permanence value is greater than 'synPermConnected'. While
     # this information is readily available from the 'self._permanence' matrix,
     # it is stored separately for efficiency purposes.
-    self._connectedSynapses = BinaryCorticalColumns(numInputs)
+    self._connectedSynapses = BinaryMiniColumns(numInputs)
     self._connectedSynapses.resize(numColumns, numInputs)
 
     # Stores the number of connected synapses for each column. This is simply
@@ -1780,7 +1780,7 @@ class SpatialPooler(object):
     instance._permanences.read(proto.permanences)
     # Initialize ephemerals and make sure they get updated
     instance._connectedCounts = numpy.zeros(numColumns, dtype=realDType)
-    instance._connectedSynapses = BinaryCorticalColumns(numInputs)
+    instance._connectedSynapses = BinaryMiniColumns(numInputs)
     instance._connectedSynapses.resize(numColumns, numInputs)
     for columnIndex in xrange(proto.numColumns):
       instance._updatePermanencesForColumn(

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -45,9 +45,9 @@ class InvalidSPParamValueError(ValueError):
 
 class _SparseMatrixMiniColumnAdapter(object):
   """ Many functions in SpatialPooler operate on a columnIndex but use an
-  underlying storage implementation based on a Sparse Matrix in which cortical
+  underlying storage implementation based on a Sparse Matrix in which mini
   columns are represented as rows.  This can be confusing to someone trying to
-  follow the algorithm, confusing terminology between matrix math and cortical
+  follow the algorithm, confusing terminology between matrix math and mini
   columns.  This class is provided to abstract away some of the details of the
   underlying implementation, providing a cleaner API that isn't specific to
   sparse matrices.
@@ -301,11 +301,11 @@ class SpatialPooler(object):
     self._iterationLearnNum = 0
 
     # Store the set of all inputs within each columns potential pool as a
-    # single adjacency matrix such that matrix rows map to cortical columns,
+    # single adjacency matrix such that matrix rows map to mini columns,
     # and matrix columns map to input buts.  If potentialPools[i][j] == 1,
     # then input bit 'j' is in column 'i's potential pool. A column can only be
     # connected to inputs in its potential pool.  Here, BinaryMiniColumns
-    # is used to provide cortical column-centric semantics for what is
+    # is used to provide mini column-centric semantics for what is
     # otherwise a sparse binary matrix implementation.  Sparse binary matrix is
     # used as an optimization since a column will only be connected to a small
     # fraction of input bits.
@@ -314,10 +314,10 @@ class SpatialPooler(object):
 
     # Initialize the permanences for each column. Similar to the
     # 'self._potentialPools', the permanences are stored in a matrix whose rows
-    # represent the cortical columns, and whose columns represent the input
+    # represent the mini columns, and whose columns represent the input
     # bits. If self._permanences[i][j] = 0.2, then the synapse connecting
-    # cortical column 'i' to input bit 'j'  has a permanence of 0.2. Here,
-    # MiniColumns is used to provide cortical column-centric semantics for
+    # mini column 'i' to input bit 'j'  has a permanence of 0.2. Here,
+    # MiniColumns is used to provide mini column-centric semantics for
     # what is otherwise a sparse matrix implementation.  Sparse matrix is used
     # as an optimization to improve computation time of alforithms that
     # require iterating over the data  structure. This permanence matrix is
@@ -332,8 +332,8 @@ class SpatialPooler(object):
                                     dtype=realDType)
 
     # 'self._connectedSynapses' is a similar matrix to 'self._permanences'
-    # (rows represent cortical columns, columns represent input bits) whose
-    # entries represent whether the cortical column is connected to the input
+    # (rows represent mini columns, columns represent input bits) whose
+    # entries represent whether the mini column is connected to the input
     # bit, i.e. its permanence value is greater than 'synPermConnected'. While
     # this information is readily available from the 'self._permanence' matrix,
     # it is stored separately for efficiency purposes.
@@ -364,7 +364,7 @@ class SpatialPooler(object):
     self._boostFactors = numpy.ones(numColumns, dtype=realDType)
 
     # The inhibition radius determines the size of a column's local
-    # neighborhood.  A cortical column must overcome the overlap score of
+    # neighborhood.  A mini column must overcome the overlap score of
     # columns in its neighborhood in order to become active. This radius is
     # updated every learning round. It grows and shrinks with the average
     # number of connected synapses per column.

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -34,8 +34,8 @@ import numpy
 from nupic.support.unittesthelpers.algorithm_test_helpers import (
   getNumpyRandomGenerator, getSeed)
 from nupic.bindings.math import GetNTAReal, Random
-from nupic.research.spatial_pooler import (BinaryCorticalColumns,
-                                           CorticalColumns,
+from nupic.research.spatial_pooler import (BinaryMiniColumns,
+                                           MiniColumns,
                                            SpatialPooler)
 
 try:
@@ -102,7 +102,7 @@ class SpatialPoolerTest(unittest.TestCase):
         seed=getSeed(),
         spVerbosity=0)
 
-    sp._potentialPools = BinaryCorticalColumns(numpy.ones([sp._numColumns,
+    sp._potentialPools = BinaryMiniColumns(numpy.ones([sp._numColumns,
                                                            sp._numInputs]))
     sp._inhibitColumns = Mock(return_value = numpy.array(range(5)))
 
@@ -630,7 +630,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([9])
     sp._inputDimensions = numpy.array([12])
     sp._connectedSynapses = (
-      BinaryCorticalColumns([[0, 1, 0, 1, 0, 1, 0, 1],
+      BinaryMiniColumns([[0, 1, 0, 1, 0, 1, 0, 1],
                              [0, 0, 0, 1, 0, 0, 0, 1],
                              [0, 0, 0, 0, 0, 0, 1, 0],
                              [0, 0, 1, 0, 0, 0, 1, 0],
@@ -653,7 +653,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._numInpts = 8
     sp._inputDimensions = numpy.array([8])
     sp._connectedSynapses = (
-      BinaryCorticalColumns([[0, 1, 0, 1, 0, 1, 0, 1],
+      BinaryMiniColumns([[0, 1, 0, 1, 0, 1, 0, 1],
                              [0, 0, 0, 1, 0, 0, 0, 1],
                              [0, 0, 0, 0, 0, 0, 1, 0],
                              [0, 0, 1, 0, 0, 0, 1, 0],
@@ -672,7 +672,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([7])
     sp._numInputs = 20
     sp._inputDimensions = numpy.array([5, 4])
-    sp._connectedSynapses = BinaryCorticalColumns(sp._numInputs)
+    sp._connectedSynapses = BinaryMiniColumns(sp._numInputs)
     sp._connectedSynapses.resize(sp._numColumns, sp._numInputs)
 
     connected = numpy.array([
@@ -744,7 +744,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._numInputs = numpy.prod(sp._inputDimensions)
     sp._numColumns = 5
     sp._columnDimensions = numpy.array([5])
-    sp._connectedSynapses = BinaryCorticalColumns(sp._numInputs)
+    sp._connectedSynapses = BinaryMiniColumns(sp._numInputs)
     sp._connectedSynapses.resize(sp._numColumns, sp._numInputs)
 
     connected = numpy.zeros(sp._numInputs).reshape(sp._inputDimensions)
@@ -801,14 +801,14 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._overlapDutyCycles = numpy.array([0, 0.009, 0.1, 0.001, 0.002])
     sp._minOverlapDutyCycles = numpy.array(5*[0.01])
 
-    sp._potentialPools = BinaryCorticalColumns(
+    sp._potentialPools = BinaryMiniColumns(
        [[1, 1, 1, 1, 0, 0, 0, 0],
         [1, 0, 0, 0, 1, 1, 0, 1],
         [0, 0, 1, 0, 1, 1, 1, 0],
         [1, 1, 1, 0, 0, 0, 1, 0],
         [1, 1, 1, 1, 1, 1, 1, 1]])
 
-    sp._permanences = CorticalColumns(
+    sp._permanences = MiniColumns(
       [[0.200, 0.120, 0.090, 0.040, 0.000, 0.000, 0.000, 0.000],
        [0.150, 0.000, 0.000, 0.000, 0.180, 0.120, 0.000, 0.450],
        [0.000, 0.000, 0.014, 0.000, 0.032, 0.044, 0.110, 0.000],
@@ -969,7 +969,7 @@ class SpatialPoolerTest(unittest.TestCase):
                        synPermActiveInc=0.1)
     sp._synPermTrimThreshold = 0.05
 
-    sp._potentialPools = BinaryCorticalColumns(
+    sp._potentialPools = BinaryMiniColumns(
         [[1, 1, 1, 1, 0, 0, 0, 0],
          [1, 0, 0, 0, 1, 1, 0, 1],
          [0, 0, 1, 0, 0, 0, 1, 0],
@@ -978,7 +978,7 @@ class SpatialPoolerTest(unittest.TestCase):
     inputVector = numpy.array([1, 0, 0, 1, 1, 0, 1, 0])
     activeColumns = numpy.array([0, 1, 2])
 
-    sp._permanences = CorticalColumns(
+    sp._permanences = MiniColumns(
         [[0.200, 0.120, 0.090, 0.040, 0.000, 0.000, 0.000, 0.000],
          [0.150, 0.000, 0.000, 0.000, 0.180, 0.120, 0.000, 0.450],
          [0.000, 0.000, 0.014, 0.000, 0.000, 0.000, 0.110, 0.000],
@@ -1000,7 +1000,7 @@ class SpatialPoolerTest(unittest.TestCase):
       for j in xrange(sp._numInputs):
         self.assertAlmostEqual(truePermanences[i][j], perm[j])
 
-    sp._potentialPools = BinaryCorticalColumns(
+    sp._potentialPools = BinaryMiniColumns(
         [[1, 1, 1, 0, 0, 0, 0, 0],
          [0, 1, 1, 1, 0, 0, 0, 0],
          [0, 0, 1, 1, 1, 0, 0, 0],
@@ -1009,7 +1009,7 @@ class SpatialPoolerTest(unittest.TestCase):
     inputVector = numpy.array([1, 0, 0, 1, 1, 0, 1, 0])
     activeColumns = numpy.array([0, 1, 2])
 
-    sp._permanences = CorticalColumns(
+    sp._permanences = MiniColumns(
         [[0.200, 0.120, 0.090, 0.000, 0.000, 0.000, 0.000, 0.000],
          [0.000, 0.017, 0.232, 0.400, 0.000, 0.000, 0.000, 0.000],
          [0.000, 0.000, 0.014, 0.051, 0.730, 0.000, 0.000, 0.000],
@@ -1039,14 +1039,14 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._synPermConnected=0.1
     sp._stimulusThreshold=3
     sp._synPermBelowStimulusInc = 0.01
-    sp._permanences = CorticalColumns(
+    sp._permanences = MiniColumns(
         [[0.0, 0.11, 0.095, 0.092, 0.01],
          [0.12, 0.15, 0.02, 0.12, 0.09],
          [0.51, 0.081, 0.025, 0.089, 0.31],
          [0.18, 0.0601, 0.11, 0.011, 0.03],
          [0.011, 0.011, 0.011, 0.011, 0.011]])
 
-    sp._connectedSynapses = BinaryCorticalColumns([[0, 1, 0, 0, 0],
+    sp._connectedSynapses = BinaryMiniColumns([[0, 1, 0, 0, 0],
                                                    [1, 1, 0, 1, 0],
                                                    [1, 0, 0, 0, 1],
                                                    [1, 0, 1, 0, 0],
@@ -1118,7 +1118,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp = SpatialPooler(inputDimensions = [10],
                        columnDimensions = [5])
     sp._connectedSynapses = (
-      BinaryCorticalColumns([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      BinaryMiniColumns([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                              [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
                              [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                              [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
@@ -1133,7 +1133,7 @@ class SpatialPoolerTest(unittest.TestCase):
     self.assertListEqual(list(overlapsPct), trueOverlapsPct)
 
     sp._connectedSynapses = (
-      BinaryCorticalColumns([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      BinaryMiniColumns([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                              [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
                              [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                              [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
@@ -1148,7 +1148,7 @@ class SpatialPoolerTest(unittest.TestCase):
     self.assertListEqual(list(overlapsPct), trueOverlapsPct)
 
     sp._connectedSynapses = (
-      BinaryCorticalColumns([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+      BinaryMiniColumns([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
                              [0, 0, 1, 1, 1, 1, 1, 1, 1, 1],
                              [0, 0, 0, 0, 1, 1, 1, 1, 1, 1],
                              [0, 0, 0, 0, 0, 0, 1, 1, 1, 1],
@@ -1165,7 +1165,7 @@ class SpatialPoolerTest(unittest.TestCase):
 
     # Zig-zag
     sp._connectedSynapses = (
-      BinaryCorticalColumns([[1, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+      BinaryMiniColumns([[1, 0, 0, 0, 0, 1, 0, 0, 0, 0],
                              [0, 1, 0, 0, 0, 0, 1, 0, 0, 0],
                              [0, 0, 1, 0, 0, 0, 0, 1, 0, 0],
                              [0, 0, 0, 1, 0, 0, 0, 0, 1, 0],
@@ -1786,7 +1786,7 @@ class SpatialPoolerTest(unittest.TestCase):
                          "Key %s has differing dtypes: %s vs %s" % (
                              k, v1.dtype, v2.dtype))
         self.assertTrue(numpy.isclose(v1, v2).all(), k)
-      elif isinstance(v1, Random) or isinstance(v1, BinaryCorticalColumns):
+      elif isinstance(v1, Random) or isinstance(v1, BinaryMiniColumns):
         pass
       elif isinstance(v1, float):
         self.assertAlmostEqual(v1, v2)


### PR DESCRIPTION
Incorporated changes to the spatial terminology as mentioned which Fixes #3259.