### PR TITLE
Call `brew update` before attempting to install a now outdated mysql …

### DIFF
--- a/ci/travis/before_install-osx.sh
+++ b/ci/travis/before_install-osx.sh
@@ -48,6 +48,7 @@ pip install --no-index --find-links=Users/travis/build/numenta/nupic.core/bindin
 
 # Install and start MySQL on OSX
 echo ">>> brew install mysql"
+brew update
 brew install mysql
 echo ">>> mysql.server start"
 mysql.server start


### PR DESCRIPTION
…formula

OS X Travis Builds are failing due to the homebrew mysql formula failing:

```
==> Installing mysql
==> Downloading https://downloads.sf.net/project/machomebrew/Bottles/mysql-5.6.2
curl: (56) Recv failure: Connection reset by peer
Error: Failed to download resource "mysql"
Download failed: https://downloads.sf.net/project/machomebrew/Bottles/mysql-5.6.21.mavericks.bottle.tar.gz
Warning: Bottle installation failed: building from source.
==> Downloading http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.21.tar.gz
curl: (22) The requested URL returned error: 404 Not Found
Error: Failed to download resource "mysql"
Download failed: http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.21.tar.gz
>>> mysql.server start
./ci/travis/before_install-osx.sh: line 53: mysql.server: command not found
The command "if [ ${TRAVIS_OS_NAME:-'linux'} = 'osx' ]; then . ./ci/travis/before_install-osx.sh; fi" failed and exited with 127 during .
Your build has been stopped.
```

Indeed, the url returns 404:

```
$ curl -I http://cdn.mysql.com/Downloads/MySQL-5.6/mysql-5.6.21.tar.gz
HTTP/1.1 404 Not Found
Server: Apache
Content-Length: 0
Date: Wed, 17 Aug 2016 21:27:02 GMT
Connection: keep-alive
Content-Type: application/x-tar-gz
```

This changeset attempts to update brew before installing mysql in case it's working with an old cache.