### PR TITLE
Only activate cols with overlap with input vector.

### DIFF
--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1464,13 +1464,14 @@ class SpatialPooler(object):
     addToWinners = max(overlaps)/1000.0
     overlaps = numpy.array(overlaps, dtype=realDType)
     for i in xrange(self._numColumns):
-      maskNeighbors = self._getNeighborsND(i, self._columnDimensions, self._inhibitionRadius)
-      overlapSlice = overlaps[maskNeighbors]
-      numActive = int(0.5 + density * (len(maskNeighbors) + 1))
-      numBigger = numpy.count_nonzero(overlapSlice > overlaps[i])
-      if overlaps[i] > 0 and numBigger < numActive:
-        winners.append(i)
-        overlaps[i] += addToWinners
+      if overlaps[i] > 0:
+        maskNeighbors = self._getNeighborsND(i, self._columnDimensions, self._inhibitionRadius)
+        overlapSlice = overlaps[maskNeighbors]
+        numActive = int(0.5 + density * (len(maskNeighbors) + 1))
+        numBigger = numpy.count_nonzero(overlapSlice > overlaps[i])
+        if numBigger < numActive:
+          winners.append(i)
+          overlaps[i] += addToWinners
     return numpy.array(winners, dtype=uintType)
 
 

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1468,7 +1468,7 @@ class SpatialPooler(object):
       overlapSlice = overlaps[maskNeighbors]
       numActive = int(0.5 + density * (len(maskNeighbors) + 1))
       numBigger = numpy.count_nonzero(overlapSlice > overlaps[i])
-      if numBigger < numActive:
+      if overlaps[i] > 0 and numBigger < numActive:
         winners.append(i)
         overlaps[i] += addToWinners
     return numpy.array(winners, dtype=uintType)
@@ -1623,7 +1623,7 @@ class SpatialPooler(object):
       rangeND.append(numpy.unique(curRange))
 
     neighbors = numpy.ravel_multi_index(
-      numpy.array(list(itertools.product(*rangeND))).T, 
+      numpy.array(list(itertools.product(*rangeND))).T,
       dimensions).tolist()
 
     neighbors.remove(columnIndex)
@@ -1661,7 +1661,7 @@ class SpatialPooler(object):
       # the overlaps and boostedOverlaps properties were added in version 3,
       state['_overlaps'] = numpy.zeros(self._numColumns, dtype=realDType)
       state['_boostedOverlaps'] = numpy.zeros(self._numColumns, dtype=realDType)
-    
+
     # update version property to current SP version
     state['_version'] = VERSION
     self.__dict__.update(state)
@@ -1733,7 +1733,7 @@ class SpatialPooler(object):
 
     boostFactorsProto = proto.init("boostFactors", len(self._boostFactors))
     for i, v in enumerate(self._boostFactors):
-      boostFactorsProto[i] = float(v) 
+      boostFactorsProto[i] = float(v)
 
 
   @classmethod
@@ -1798,7 +1798,7 @@ class SpatialPooler(object):
     instance._minActiveDutyCycles = numpy.array(proto.minActiveDutyCycles,
                                             dtype=realDType)
     instance._boostFactors = numpy.array(proto.boostFactors, dtype=realDType)
-    
+
     return instance
 
 

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -150,11 +150,11 @@ class SpatialPoolerTest(unittest.TestCase):
       potential = sp._potentialPools[columnIndex]
       perm = sp._permanences.getRow(columnIndex)
       self.assertEqual(list(perm), list(potential))
-      
+
 
   def testOverlapsOutput(self):
     """Checks that overlaps and boostedOverlaps are correctly returned"""
-    
+
     sp = SpatialPooler(inputDimensions=[5],
     	columnDimensions=[3],
     	potentialRadius=5,
@@ -163,22 +163,22 @@ class SpatialPoolerTest(unittest.TestCase):
     	seed=1,
     	synPermActiveInc=0.1,
     	synPermInactiveDec=0.1)
-    
+
     inputVector = numpy.ones(5)
     activeArray = numpy.zeros(3)
-    
-    expOutput = numpy.array([2, 0, 0], dtype=realDType)    
-    boostFactors = 2.0 * numpy.ones(3)    
-    sp.setBoostFactors(boostFactors)    
-    sp.compute(inputVector, True, activeArray)    
-    overlaps = sp.getOverlaps()    
+
+    expOutput = numpy.array([2, 0, 0], dtype=realDType)
+    boostFactors = 2.0 * numpy.ones(3)
+    sp.setBoostFactors(boostFactors)
+    sp.compute(inputVector, True, activeArray)
+    overlaps = sp.getOverlaps()
     boostedOverlaps = sp.getBoostedOverlaps()
-    
+
     for i in range(sp.getNumColumns()):
     	self.assertEqual(overlaps[i], expOutput[i])
 
     for i in range(sp.getNumColumns()):
-    	self.assertEqual(boostedOverlaps[i], (2 * expOutput[i]))      
+    	self.assertEqual(boostedOverlaps[i], (2 * expOutput[i]))
 
 
   def testExactOutput(self):
@@ -1337,6 +1337,16 @@ class SpatialPoolerTest(unittest.TestCase):
     self.assertListEqual(trueActive, sorted(active))
 
     density = 0.5
+    sp._numColumns = 16
+    sp._columnDimensions = numpy.array([sp._numColumns])
+    sp._inhibitionRadius = 2
+    overlaps = numpy.array([1, 1, 1, 0, 1, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0], dtype=realDType)
+    active = list(sp._inhibitColumnsLocal(overlaps, density))
+    # Assert that only columns with overlap are activated
+    for index in active:
+      self.assertTrue(overlaps[index] > 0)
+
+    density = 0.5
     sp._numColumns = 10
     sp._columnDimensions = numpy.array([sp._numColumns])
     sp._inhibitionRadius = 3
@@ -1772,7 +1782,7 @@ class SpatialPoolerTest(unittest.TestCase):
 
     # Load the deserialized proto
     sp2 = SpatialPooler.read(proto2)
-    
+
     ephemeral = set(["_boostedOverlaps", "_overlaps"])
 
     # Check that the two spatial poolers have the same attributes


### PR DESCRIPTION
Fixes #3287

Depends upon https://github.com/numenta/nupic.core/pull/1054

Adds a unit test to ensure that active columns selected during the local
inhibition step have overlap with the input vector.

Added additional condition to winner column selection that ensures the
column overlaps with input vector to pass test.