### PR TITLE
Abolish the SegmentOverlap. Embrace references.

### DIFF
--- a/src/nupic/research/connections.py
+++ b/src/nupic/research/connections.py
@@ -53,10 +53,11 @@ class Segment(object):
     to be consistent after serialize / deserialize.
 
     """
-    return ((self.idx, self.cell, self._synapses, self._numDestroyedSynapses,
-             self._destroyed, self._lastUsedIteration) ==
-            (other.idx, other.cell, other._synapses, self._numDestroyedSynapses,
-             other._destroyed, other._lastUsedIteration))
+    return (self.idx == other.idx and
+            self.cell == other.cell and
+            self._numDestroyedSynapses == other._numDestroyedSynapses and
+            self._destroyed == other._destroyed and
+            self._lastUsedIteration == other._lastUsedIteration)
 
 
 
@@ -91,10 +92,10 @@ class Synapse(object):
     differences for synapse permanence.
 
     """
-    return ((self.segment.cell, self.segment.idx, self.idx,
-             self.presynapticCell) ==
-            (other.segment.cell, other.segment.idx, other.idx,
-             other.presynapticCell) and
+    return (self.segment.cell == other.segment.cell and
+            self.segment.idx == other.segment.idx and
+            self.idx == other.idx and
+            self.presynapticCell == other.presynapticCell and
             abs(self.permanence - other.permanence) < EPSILON)
 
 

--- a/src/nupic/research/connections.py
+++ b/src/nupic/research/connections.py
@@ -26,92 +26,87 @@ EPSILON = 0.00001 # constant error threshold to check equality of permanences to
                   # other floats
 
 
+
 class Segment(object):
   """ Class containing minimal information to identify a unique segment """
 
-  __slots__ = ['cell', 'idx', 'data']
+  __slots__ = ["cell", "idx", "flatIdx", "_synapses", "_numDestroyedSynapses",
+               "_destroyed", "_lastUsedIteration"]
 
-  def __init__(self, cell, idx, data):
+  def __init__(self, cell, idx, flatIdx):
     """
-       @param cell (int) Index of the cell that this segment is on
-       @param idx  (int) Index of the segment on the cell
+    @param cell (int) Index of the cell that this segment is on.
+    @param idx (int) Index of the segment on the cell.
+    @param flatIdx (int) The segment's flattened list index.
     """
     self.cell = cell
     self.idx = idx
-    self.data = data
+    self.flatIdx = flatIdx
+    self._synapses = []
+    self._numDestroyedSynapses = 0
+    self._destroyed = False
+    self._lastUsedIteration = -1
 
 
   def __eq__(self, other):
-    return (self.idx, self.cell) == (other.idx, other.cell)
+    """ Explicitly implement this for unit testing. The flatIdx is not designed
+    to be consistent after serialize / deserialize.
+
+    """
+    return ((self.idx, self.cell, self._synapses, self._numDestroyedSynapses,
+             self._destroyed, self._lastUsedIteration) ==
+            (other.idx, other.cell, other._synapses, self._numDestroyedSynapses,
+             other._destroyed, other._lastUsedIteration))
+
 
 
 class Synapse(object):
   """ Class containing minimal information to identify a unique synapse """
 
-  __slots__ = ['idx', 'segment', 'data']
+  __slots__ = ["segment", "idx", "presynapticCell", "permanence", "_destroyed"]
 
-  def __init__(self, idx, segment, synapseData):
+  def __init__(self, segment, idx, presynapticCell, permanence):
     """
-       @param idx     (int)    Index of the synapse on the segment
-       @param segment (Object) Segment Object that the synapse is synapsed to
+    @param segment
+    (Object) Segment object that the synapse is synapsed to.
+
+    @param idx (int)
+    Index of the synapse on the segment.
+
+    @param presynapticCell (int)
+    The index of the presynaptic cell of the synapse.
+
+    @param permanence (float)
+    Permanence of the synapse from 0.0 to 1.0.
     """
-    self.idx = idx
     self.segment = segment
-    self.data = synapseData
-
-
-  def __eq__(self, other):
-    return ((self.idx, self.segment, self.data) ==
-            (other.idx, other.segment, other.data))
-
-
-class SynapseData(object):
-  """ Class containing other important synapse information """
-
-  __slots__ = ['presynapticCell', 'permanence', 'destroyed']
-
-  def __init__(self, presynapticCell, permanence):
-    """
-       @param presynapticCell (int)   The index of the presynaptic cell of the
-                                      synapse
-       @param permanence      (float) permanence of the synapse from 0.0 to 1.0
-    """
+    self.idx = idx
     self.presynapticCell = presynapticCell
     self.permanence = permanence
-    self.destroyed = False  # boolean destroyed flag so object can be reused
+    self._destroyed = False
 
 
   def __eq__(self, other):
-    return (self.segment == other.segment and
-            self.presynapticCell == other.presynapticCell and
+    """ Explicitly implement this for unit testing. Allow floating point
+    differences for synapse permanence.
+
+    """
+    return ((self.segment.cell, self.segment.idx, self.idx,
+             self.presynapticCell) ==
+            (other.segment.cell, other.segment.idx, other.idx,
+             other.presynapticCell) and
             abs(self.permanence - other.permanence) < EPSILON)
 
 
-class SegmentData(object):
-  """ Class containing other important segment information """
-
-  __slots__ = ['synapses', 'numDestroyedSynapses', 'destroyed',
-               'lastUsedIteration', 'flatIdx']
-
-  def __init__(self, flatIdx):
-    """
-       @param flatIdx (int) global index of the segment
-    """
-    self.synapses = []
-    self.numDestroyedSynapses = 0
-    self.destroyed = False
-    self.lastUsedIteration = -1
-    self.flatIdx = flatIdx
-
 
 class CellData(object):
-  """ Class containing cell information """
+  """ Class containing cell information. Internal to the Connections. """
 
-  __slots__ = ['segments', 'numDestroyedSegments']
+  __slots__ = ["_segments", "_numDestroyedSegments"]
 
   def __init__(self):
-    self.segments = []   # list of segments on the cell
-    self.numDestroyedSegments = 0
+    self._segments = []
+    self._numDestroyedSegments = 0
 
 
 
@@ -152,8 +147,6 @@ class Connections(object):
     self._synapsesForPresynapticCell = defaultdict(list)
     self._segmentForFlatIdx = []
 
-    self._synapsesForSegment = defaultdict(list)
-
     self._numSegments = 0
     self._numSynapses = 0
     self._nextFlatIdx = 0
@@ -165,15 +158,13 @@ class Connections(object):
 
     @param cell (int) Cell index
 
-    @return (list) Segment objects representing segments on the given cell
+    @return (generator)
+    Segment objects representing segments on the given cell.
     """
 
-    segmentsList = self._cells[cell].segments
-
-
-    return [Segment(cell, i, segmentsList[i])
-            for i in xrange(len(segmentsList))
-            if not segmentsList[i].destroyed]
+    return (segment
+            for segment in self._cells[cell]._segments
+            if not segment._destroyed)
 
 
   def synapsesForSegment(self, segment):
@@ -181,38 +172,42 @@ class Connections(object):
 
     @param segment (int) Segment index
 
-    @return (list) Synapse objects representing synapses on the given segment
+    @return (generator)
+    Synapse objects representing synapses on the given segment.
     """
 
-    segmentData = segment.data
-    if segmentData.destroyed:
+    if segment._destroyed:
       raise ValueError("Attempting to access destroyed segment's synapses")
 
-    return [synapse
-            for synapse in self._synapsesForSegment[segmentData.flatIdx]
-            if not synapse.data.destroyed]
+    return (synapse
+            for synapse in segment._synapses
+            if not synapse._destroyed)
 
 
   def dataForSynapse(self, synapse):
     """ Returns the data for a synapse.
 
+    This method exists to match the interface of the C++ Connections. This
+    allows tests and tools to inspect the connections using a common interface.
+
     @param synapse (Object) Synapse object
 
-    @return (SynapseData) Synapse data
+    @return Synapse data
     """
-
-    return synapse.data
+    return synapse
 
 
   def dataForSegment(self, segment):
     """ Returns the data for a segment.
 
-    @param segment (Object) Segment object
+    This method exists to match the interface of the C++ Connections. This
+    allows tests and tools to inspect the connections using a common interface.
 
-    @return (SegmentData) Segment data
+    @param synapse (Object) Segment object
+
+    @return segment data
     """
-
-    return segment.data
+    return segment
 
 
   def getSegment(self, cell, idx):
@@ -226,54 +221,33 @@ class Connections(object):
 
     """
 
-    return Segment(cell, idx, self._cells[cell].segments[idx])
-
-
-  def _leastRecentlyUsedSegment(self, cell):
-    """ Internal method for finding the least recently activated segment on a
-        cell
-
-    @param cell (int) cell index to search for segments on
-
-    @return (Object) Segment object of the segment that was least recently
-                     created/activated.
-    """
-    segments = self._cells[cell].segments
-    minIdx = float("inf")
-    minIteration = float("inf")
-
-    for i in xrange(len(segments)):
-      segment = segments[i]
-      if (not segment.destroyed and
-          segment.lastUsedIteration < minIteration):
-        minIdx = i
-        minIteration = segment.lastUsedIteration
-
-    return Segment(cell, minIdx, segments[minIdx])
+    return self._cells[cell]._segments[idx]
 
 
   def _minPermanenceSynapse(self, segment):
-    """ Internal method for finding the synapse with the smallest permanence
-    on the given segment.
+    """ Find this segment's synapse with the smallest permanence.
 
-    @param segment (Object) Segment object to search for synapses on
+    This method is NOT equivalent to a simple min() call. It uses an EPSILON to
+    account for floating point differences between C++ and Python.
 
-    @return (Object) Synapse object on the segment of the minimal permanence
+    @param segment (Object) Segment to query.
 
-    Note: On ties it will chose the first occurrence of the minimum permanence
+    @return (Object) Synapse with the minimal permanence
+
+    Note: On ties it will choose the first occurrence of the minimum permanence.
+
     """
-    synapses = self._synapsesForSegment[segment.data.flatIdx]
-    minIdx = float("inf")
+    minSynapse = None
     minPermanence = float("inf")
 
-    for i in xrange(len(synapses)):
-      synapseData = synapses[i].data
-      if (not synapseData.destroyed) and (synapseData.permanence
-                                          < minPermanence - EPSILON):
-        minIdx = i
-        minPermanence = synapseData.permanence
+    for synapse in self.synapsesForSegment(segment):
+      if synapse.permanence < minPermanence - EPSILON:
+        minSynapse = synapse
+        minPermanence = synapse.permanence
 
-    return synapses[minIdx]
+    assert minSynapse is not None
+
+    return minSynapse
 
 
   def segmentForFlatIdx(self, flatIdx):
@@ -313,32 +287,24 @@ class Connections(object):
     @return (int) New segment index
     """
     while self.numSegments(cell) >= self.maxSegmentsPerCell:
-      self.destroySegment(self._leastRecentlyUsedSegment(cell))
+      leastRecentlyUsed = min(self.segmentsForCell(cell),
+                              key=lambda s: s._lastUsedIteration)
+      self.destroySegment(leastRecentlyUsed)
 
     cellData = self._cells[cell]
-    segment = Segment(cell, -1, None) # New segment with some default values
 
-    if cellData.numDestroyedSegments > 0:
-      found = False
-      for i in xrange(len(cellData.segments)):
-        if cellData.segments[i].destroyed:
-          segment.idx = i
-          found = True
-
-      if not found:
-        raise AssertionError("Failed to find a destroyed segment.")
-
-      cellData.segments[segment.idx].destroyed = False
-      cellData.numDestroyedSegments -= 1
+    if cellData._numDestroyedSegments > 0:
+      segment = next(s for s in cellData._segments if s._destroyed)
+      segment._destroyed = False
+      cellData._numDestroyedSegments -= 1
     else:
-      segment.idx = len(cellData.segments)
-      cellData.segments.append(SegmentData(self._nextFlatIdx))
+      idx = len(cellData._segments)
+      segment = Segment(cell, idx, self._nextFlatIdx)
+      cellData._segments.append(segment)
       self._segmentForFlatIdx.append(segment)
       self._nextFlatIdx += 1
 
-    segmentData = cellData.segments[segment.idx]
-    segmentData.lastUsedIteration = self._iteration
-    segment.data = segmentData
+    segment._lastUsedIteration = self._iteration
     self._numSegments += 1
 
     return segment
@@ -350,32 +316,16 @@ class Connections(object):
     @param segment (Object) Segment object representing the segment to be
                             destroyed
     """
-    segmentData = segment.data
-    if not segmentData.destroyed:
-      for i in xrange(len(segmentData.synapses)):
-        synapse = Synapse(i, segment, segmentData.synapses[i])
-        synapseData = synapse.data
+    assert not segment._destroyed
 
-        if not synapseData.destroyed:
-          cell = synapseData.presynapticCell
-          presynapticSynapses = self._synapsesForPresynapticCell[cell]
+    for synapse in self.synapsesForSegment(segment):
+      self.destroySynapse(synapse)
 
-          for i in xrange(len(presynapticSynapses)):
-            if presynapticSynapses[i] == synapse:
-              del presynapticSynapses[i]
-
-              if len(presynapticSynapses) == 0:
-                del self._synapsesForPresynapticCell[cell]
-              self._numSynapses -= 1
-              break
-
-      segmentData.synapses = []
-      self._synapsesForSegment[segmentData.flatIdx] = []
-      segmentData.numDestroyedSynapses = 0
-      segmentData.destroyed = True
-      self._cells[segment.cell].numDestroyedSegments += 1
-      self._numSegments -= 1
-
+    segment._synapses = []
+    segment._numDestroyedSynapses = 0
+    segment._destroyed = True
+    self._numSegments -= 1
+    self._cells[segment.cell]._numDestroyedSegments += 1
 
 
   def createSynapse(self, segment, presynapticCell, permanence):
@@ -391,37 +341,21 @@ class Connections(object):
     while self.numSynapses(segment) >= self.maxSynapsesPerSegment:
       self.destroySynapse(self._minPermanenceSynapse(segment))
 
-    segmentData = segment.data
-    synapseIdx = -1
-    found = False
-    if segmentData.numDestroyedSynapses > 0:
-      for i in xrange(len(segmentData.synapses)):
-        if segmentData.synapses[i].destroyed:
-          synapseIdx = i
-          found = True
-          break
+    if segment._numDestroyedSynapses > 0:
+      synapse = next(s for s in segment._synapses if s._destroyed)
 
-      if not found:
-        raise AssertionError("Failed to find a destroyed synapse.")
+      synapse._destroyed = False
+      segment._numDestroyedSynapses -= 1
 
-      synapseData = segmentData.synapses[synapseIdx]
-      synapseData.destroyed = False
-      segmentData.numDestroyedSynapses -= 1
-
-      synapseData.presynapticCell = presynapticCell
-      synapseData.permanence = permanence
-      self._synapsesForSegment[segmentData.flatIdx][synapseIdx].data =\
-        synapseData
+      synapse.presynapticCell = presynapticCell
+      synapse.permanence = permanence
 
     else:
-      synapseIdx = len(segmentData.synapses)
-      synapseData = SynapseData(presynapticCell, permanence)
-      segmentData.synapses.append(synapseData)
+      idx = len(segment._synapses)
+      synapse = Synapse(segment, idx, presynapticCell, permanence)
+      segment._synapses.append(synapse)
 
-    synapse = Synapse(synapseIdx, segment, synapseData)
     self._synapsesForPresynapticCell[presynapticCell].append(synapse)
-    if not found:
-      self._synapsesForSegment[segmentData.flatIdx].append(synapse)
     self._numSynapses += 1
 
     return synapse
@@ -432,38 +366,37 @@ class Connections(object):
 
     @param synapse (Object) Synapse object to destroy
     """
-    synapseData = synapse.data
-    if not synapseData.destroyed:
-      presynapticSynapses = \
-        self._synapsesForPresynapticCell[synapseData.presynapticCell]
+    assert not synapse._destroyed
 
-      for i in xrange(len(presynapticSynapses)):
-        if presynapticSynapses[i] == synapse:
-          del presynapticSynapses[i]
+    synapse._destroyed = True
+    synapse.segment._numDestroyedSynapses += 1
+    self._numSynapses -= 1
 
-          if len(presynapticSynapses) == 0:
-            del self._synapsesForPresynapticCell[synapseData.presynapticCell]
+    presynapticSynapses = \
+      self._synapsesForPresynapticCell[synapse.presynapticCell]
 
-          synapseData.destroyed = True
-          synapse.segment.data.numDestroyedSynapses += 1
-          self._numSynapses -= 1
-          break
+    i = next(i
+             for i, syn in enumerate(presynapticSynapses)
+             if syn is synapse)
+    del presynapticSynapses[i]
+
+    if len(presynapticSynapses) == 0:
+      del self._synapsesForPresynapticCell[synapse.presynapticCell]
 
 
   def updateSynapsePermanence(self, synapse, permanence):
     """ Updates the permanence for a synapse.
-
     @param synapse    (Object) Synapse object to be updated
     @param permanence (float)  New permanence
     """
 
-    synapse.data.permanence = permanence
+    synapse.permanence = permanence
 
 
   def computeActivity(self, activePresynapticCells, connectedPermanence):
     """ Compute each segment's number of active synapses for a given input.
     In the returned lists, a segment's active synapse count is stored at index
-    `segment.data.flatIdx`.
+    `segment.flatIdx`.
 
     @param activePresynapticCells (iter)  active cells
     @param connectedPermanence    (float) permanence threshold for a synapse
@@ -481,11 +414,9 @@ class Connections(object):
 
     for cell in activePresynapticCells:
       for synapse in self._synapsesForPresynapticCell[cell]:
-        synapseData = synapse.data
-        segment = synapse.segment
-        flatIdx = segment.data.flatIdx
+        flatIdx = synapse.segment.flatIdx
         numActivePotentialSynapsesForSegment[flatIdx] += 1
-        if synapseData.permanence > threshold:
+        if synapse.permanence > threshold:
           numActiveConnectedSynapsesForSegment[flatIdx] += 1
 
     return (numActiveConnectedSynapsesForSegment,
@@ -498,7 +429,7 @@ class Connections(object):
 
         @param segment The segment that had some activity.
     """
-    segment.data.lastUsedIteration = self._iteration
+    segment._lastUsedIteration = self._iteration
 
 
   def startNewIteration(self):
@@ -518,7 +449,7 @@ class Connections(object):
     """
     if cell is not None:
       cellData = self._cells[cell]
-      return len(cellData.segments) - cellData.numDestroyedSegments
+      return len(cellData._segments) - cellData._numDestroyedSegments
 
     return self._numSegments
 
@@ -533,8 +464,7 @@ class Connections(object):
                   specified, or on a specified segment
     """
     if segment is not None:
-      segmentData = self._cells[segment.cell].segments[segment.idx]
-      return len(segmentData.synapses) - segmentData.numDestroyedSynapses
+      return len(segment._synapses) - segment._numDestroyedSynapses
     return self._numSynapses
 
 
@@ -546,24 +476,23 @@ class Connections(object):
     protoCells = proto.init('cells', self.numCells)
 
     for i in xrange(self.numCells):
-      segments = self._cells[i].segments
+      segments = self._cells[i]._segments
       protoSegments = protoCells[i].init('segments', len(segments))
 
       for j in xrange(len(segments)):
-        synapses = segments[j].synapses
+        synapses = segments[j]._synapses
         protoSynapses = protoSegments[j].init('synapses', len(synapses))
-        protoSegments[j].destroyed = segments[j].destroyed
-        protoSegments[j].lastUsedIteration = segments[j].lastUsedIteration
+        protoSegments[j].destroyed = segments[j]._destroyed
+        protoSegments[j].lastUsedIteration = segments[j]._lastUsedIteration
 
         for k in xrange(len(synapses)):
           protoSynapses[k].presynapticCell = synapses[k].presynapticCell
           protoSynapses[k].permanence = synapses[k].permanence
-          protoSynapses[k].destroyed = synapses[k].destroyed
+          protoSynapses[k].destroyed = synapses[k]._destroyed
 
     proto.maxSegmentsPerCell = self.maxSegmentsPerCell
     proto.maxSynapsesPerSegment = self.maxSynapsesPerSegment
     proto.iteration = self._iteration
-
 
 
   @classmethod
@@ -580,44 +509,40 @@ class Connections(object):
                       proto.maxSegmentsPerCell,
                       proto.maxSynapsesPerSegment)
 
-    for i in xrange(len(protoCells)):
-      protoCell = protoCells[i]
+    for cellIdx, protoCell in enumerate(protoCells):
+      protoCell = protoCells[cellIdx]
       protoSegments = protoCell.segments
-      connections._cells[i] = CellData()
-      segments = connections._cells[i].segments
+      connections._cells[cellIdx] = CellData()
+      segments = connections._cells[cellIdx]._segments
 
-      for j in xrange(len(protoSegments)):
-        segmentData = SegmentData(connections._nextFlatIdx)
-        segmentData.destroyed = protoSegments[j].destroyed
-        segmentData.lastUsedIteration = protoSegments[j].lastUsedIteration
-        connections._nextFlatIdx += 1
-        segments.append(segmentData)
+      for segmentIdx, protoSegment in enumerate(protoSegments):
+        segment = Segment(cellIdx, segmentIdx, connections._nextFlatIdx)
+        segment._destroyed = protoSegment.destroyed
+        segment._lastUsedIteration = protoSegment.lastUsedIteration
 
-        segment = Segment(i, j, segmentData)
+        segments.append(segment)
         connections._segmentForFlatIdx.append(segment)
+        connections._nextFlatIdx += 1
 
-        protoSynapses = protoSegments[j].synapses
-        synapses = segments[j].synapses
+        synapses = segment._synapses
+        protoSynapses = protoSegment.synapses
 
-        for k in xrange(len(protoSynapses)):
-          presynapticCell = protoSynapses[k].presynapticCell
-          synapseData = SynapseData(presynapticCell,
-                                    protoSynapses[k].permanence)
-          synapseData.destroyed = protoSynapses[k].destroyed
-          synapses.append(synapseData)
-
-          synapse = Synapse(k, segment, synapseData)
+        for synapseIdx, protoSynapse in enumerate(protoSynapses):
+          presynapticCell = protoSynapse.presynapticCell
+          synapse = Synapse(segment, synapseIdx, presynapticCell,
+                            protoSynapse.permanence)
+          synapse._destroyed = protoSynapse.destroyed
+          synapses.append(synapse)
           connections._synapsesForPresynapticCell[presynapticCell].append(
             synapse)
-          connections._synapsesForSegment[segmentData.flatIdx].append(synapse)
 
-          if synapseData.destroyed:
-            segments[j].numDestroyedSynapses += 1
+          if synapse._destroyed:
+            segment._numDestroyedSynapses += 1
           else:
             connections._numSynapses += 1
 
-        if segmentData.destroyed:
-          connections._cells[i].numDestroyedSegments += 1
+        if segment._destroyed:
+          connections._cells[cellIdx]._numDestroyedSegments += 1
         else:
           connections._numSegments += 1
 
@@ -639,8 +564,8 @@ class Connections(object):
       return False
 
     for i in xrange(self.numCells):
-      segments = self._cells[i].segments
-      otherSegments = other._cells[i].segments
+      segments = self._cells[i]._segments
+      otherSegments = other._cells[i]._segments
 
       if len(segments) != len(otherSegments):
         return False
@@ -648,12 +573,12 @@ class Connections(object):
       for j in xrange(len(segments)):
         segment = segments[j]
         otherSegment = otherSegments[j]
-        synapses = segment.synapses
-        otherSynapses = otherSegment.synapses
+        synapses = segment._synapses
+        otherSynapses = otherSegment._synapses
 
-        if segment.destroyed != otherSegment.destroyed:
+        if segment._destroyed != otherSegment._destroyed:
           return False
-        if segment.lastUsedIteration != otherSegment.lastUsedIteration:
+        if segment._lastUsedIteration != otherSegment._lastUsedIteration:
           return False
         if len(synapses) != len(otherSynapses):
           return False
@@ -666,7 +591,7 @@ class Connections(object):
             return False
           if (synapse.permanence - otherSynapse.permanence) > EPSILON :
             return False
-          if synapse.destroyed != otherSynapse.destroyed:
+          if synapse._destroyed != otherSynapse._destroyed:
             return False
 
     if (len(self._synapsesForPresynapticCell) !=
@@ -703,7 +628,6 @@ class Connections(object):
 
     #pylint: enable=W0212
     return True
-
 
 
   def __ne__(self, other):

--- a/src/nupic/research/temporal_memory.py
+++ b/src/nupic/research/temporal_memory.py
@@ -21,6 +21,14 @@
 
 """
 Temporal Memory implementation in Python.
+
+The static methods in this file use the following parameter ordering convention:
+
+1. Output / mutated params
+2. Traditional parameters to the function, i.e. the ones that would still exist
+   if this function were a method on a class
+3. Model state (not mutated)
+4. Model parameters (including "learn")
 """
 
 from collections import defaultdict
@@ -28,7 +36,7 @@ from operator import mul
 
 
 from nupic.bindings.math import Random
-from nupic.research.connections import Connections, SegmentOverlap, binSearch
+from nupic.research.connections import Connections, binSearch
 from nupic.support.group_by import groupby2
 
 EPSILON = 0.00001 # constant error threshold to check equality of permanences to
@@ -55,35 +63,43 @@ class TemporalMemory(object):
                seed=42,
                **kwargs):
     """
-    @param columnDimensions          (list)  Dimensions of the column space
-    @param cellsPerColumn            (int)   Number of cells per column
-    @param activationThreshold       (int)   If the number of active connected
-                                             synapses on a segment is at least
-                                             this threshold, the segment is said
-                                             to be active.
-    @param initialPermanence         (float) Initial permanence of a new synapse
-    @param connectedPermanence       (float) If the permanence value for a
-                                             synapse is greater than this value,
-                                             it is said to be connected.
-    @param minThreshold              (int)   If the number of synapses active on
-                                             a segment is at least this
-                                             threshold, it is selected as the
-                                             best matching cell in a bursting
-                                             column
-    @param maxNewSynapseCount        (int)   The maximum number of synapses
-                                             added to a segment during learning
-    @param permanenceIncrement       (float) Amount by which permanences of
-                                             synapses are incremented during
-                                             learning.
-    @param permanenceDecrement       (float) Amount by which permanences of
-                                             synapses are decremented during
-                                             learning.
-    @param predictedSegmentDecrement (float) Amount by which active permanences
-                                             of synapses of previously predicted
-                                             but inactive segments are
-                                             decremented.
-    @param seed                      (int)   Seed for the random number
-                                             generator
+    @param columnDimensions (list)
+    Dimensions of the column space
+
+    @param cellsPerColumn (int)
+    Number of cells per column
+
+    @param activationThreshold (int)
+    If the number of active connected synapses on a segment is at least this
+    threshold, the segment is said to be active.
+
+    @param initialPermanence (float)
+    Initial permanence of a new synapse
+
+    @param connectedPermanence (float)
+    If the permanence value for a synapse is greater than this value, it is said
+    to be connected.
+
+    @param minThreshold (int)
+    If the number of potential synapses active on a segment is at least this
+    threshold, it is said to be "matching" and is eligible for learning.
+
+    @param maxNewSynapseCount (int)
+    The maximum number of synapses added to a segment during learning.
+
+    @param permanenceIncrement (float)
+    Amount by which permanences of synapses are incremented during learning.
+
+    @param permanenceDecrement (float)
+    Amount by which permanences of synapses are decremented during learning.
+
+    @param predictedSegmentDecrement (float)
+    Amount by which segments are punished for incorrect predictions.
+
+    @param seed (int)
+    Seed for the random number generator
+
+
     Notes:
 
     predictedSegmentDecrement: A good value is just a bit larger than
@@ -126,6 +142,9 @@ class TemporalMemory(object):
     self.activeSegments = []
     self.matchingSegments = []
 
+    self.numActiveConnectedSynapsesForSegment = []
+    self.numActivePotentialSynapsesForSegment = []
+
   # ==============================
   # Main functions
   # ==============================
@@ -133,8 +152,12 @@ class TemporalMemory(object):
   def compute(self, activeColumns, learn=True):
     """ Feeds input record through TM, performing inference and learning.
 
-    @param activeColumns (set)  Indices of active columns
-    @param learn         (bool) Whether or not learning is enabled
+    @param activeColumns (iter)
+    Indices of active columns
+
+    @param learn (bool)
+    Whether or not learning is enabled
+
     """
     self.activateCells(sorted(activeColumns), learn)
     self.activateDendrites(learn)
@@ -144,8 +167,11 @@ class TemporalMemory(object):
     """ Calculate the active cells, using the current active columns and
     dendrite segments. Grow and reinforce synapses.
 
-    @param activeColumns (list) A sorted list of active column indices.
-    @param learn (bool) If true, reinforce / punish / grow synapses.
+    @param activeColumns (iter)
+    A sorted list of active column indices.
+
+    @param learn (bool)
+    If true, reinforce / punish / grow synapses.
 
     Pseudocode:
     for each column
@@ -161,7 +187,7 @@ class TemporalMemory(object):
     self.activeCells = []
     self.winnerCells = []
 
-    segToCol = lambda segment: int(segment.segment.cell / self.cellsPerColumn)
+    segToCol = lambda segment: int(segment.cell / self.cellsPerColumn)
     identity = lambda x: x
 
     for columnData in groupby2(activeColumns, identity,
@@ -177,9 +203,9 @@ class TemporalMemory(object):
             self.connections,
             self._random,
             activeSegmentsOnCol,
-            matchingSegmentsOnCol,
             prevActiveCells,
             prevWinnerCells,
+            self.numActivePotentialSynapsesForSegment,
             self.maxNewSynapseCount,
             self.initialPermanence,
             self.permanenceIncrement,
@@ -190,18 +216,20 @@ class TemporalMemory(object):
           self.winnerCells += cellsToAdd
         else:
           (cellsToAdd,
-           winnerCell) = TemporalMemory.burstColumn(self.connections,
-                                                    self._random,
-                                                    column,
-                                                    matchingSegmentsOnCol,
-                                                    prevActiveCells,
-                                                    prevWinnerCells,
-                                                    self.cellsPerColumn,
-                                                    self.maxNewSynapseCount,
-                                                    self.initialPermanence,
-                                                    self.permanenceIncrement,
-                                                    self.permanenceDecrement,
-                                                    learn)
+           winnerCell) = TemporalMemory.burstColumn(
+             self.connections,
+             self._random,
+             column,
+             matchingSegmentsOnCol,
+             prevActiveCells,
+             prevWinnerCells,
+             self.numActivePotentialSynapsesForSegment,
+             self.cellsPerColumn,
+             self.maxNewSynapseCount,
+             self.initialPermanence,
+             self.permanenceIncrement,
+             self.permanenceDecrement,
+             learn)
 
           self.activeCells += cellsToAdd
           self.winnerCells.append(winnerCell)
@@ -226,17 +254,35 @@ class TemporalMemory(object):
     for each distal dendrite segment with unconnected activity >= minThreshold
       mark the segment as matching
     """
-    (activeSegments,
-     matchingSegments) = self.connections.computeActivity(
+    (numActiveConnected,
+     numActivePotential) = self.connections.computeActivity(
        self.activeCells,
-       self.connectedPermanence,
-       self.activationThreshold,
-       0.0,
-       self.minThreshold,
-       learn)
+       self.connectedPermanence)
 
-    self.activeSegments = activeSegments
-    self.matchingSegments = matchingSegments
+    activeSegments = (
+      self.connections.segmentForFlatIdx(i)
+      for i in xrange(len(numActiveConnected))
+      if numActiveConnected[i] >= self.activationThreshold
+    )
+
+    matchingSegments = (
+      self.connections.segmentForFlatIdx(i)
+      for i in xrange(len(numActivePotential))
+      if numActivePotential[i] >= self.minThreshold
+    )
+
+    maxSegmentsPerCell = self.connections.maxSegmentsPerCell
+    segmentKey = lambda segment: (segment.cell * maxSegmentsPerCell
+                                  + segment.idx)
+    self.activeSegments = sorted(activeSegments, key = segmentKey)
+    self.matchingSegments = sorted(matchingSegments, key = segmentKey)
+    self.numActiveConnectedSynapsesForSegment = numActiveConnected
+    self.numActivePotentialSynapsesForSegment = numActivePotential
+
+    if learn:
+      for segment in self.activeSegments:
+        self.connections.recordSegmentActivity(segment)
+      self.connections.startNewIteration()
 
 
   def reset(self):
@@ -249,35 +295,52 @@ class TemporalMemory(object):
 
 
   @staticmethod
-  def activatePredictedColumn(connections, random, activeSegments,
-                              matchingSegments, prevActiveCells,
-                              prevWinnerCells, maxNewSynapseCount,
+  def activatePredictedColumn(connections, random, columnActiveSegments,
+                              prevActiveCells, prevWinnerCells,
+                              numActivePotentialSynapsesForSegment,
+                              maxNewSynapseCount,
                               initialPermanence, permanenceIncrement,
                               permanenceDecrement, learn):
     """ Determines which cells in a predicted column should be added to winner
     cells list, and learns on the segments that correctly predicted this column.
 
-    @param connections     (Object) Connections for the TM. Gets mutated.
-    @param random          (Object) Random number generator. Gets mutated.
-    @param activeSegments  (iter)   An iterable of SegmentOverlap objects.
-                                    Active segments for this column, and
-                                    an overlap for each segment.
-    @param matchingSegments (iter)  An iterable of SegmentOverlap objects.
-                                    Matching segments for this column, and
-                                    an overlap for each segment.
-    @param prevActiveCells (list)   Active cells in `t-1`.
-    @param prevWinnerCells     (list)   Winner cells in `t-1`.
-    @param maxNewSynapseCount  (int)    The maximum number of synapses added to
-                                        a segment during learning.
-    @param initialPermanence   (float)  Initial permanence of a new synapse.
-    @permanenceIncrement   (float)  Amount by which permanences of synapses are
-                                    incremented during learning.
-    @permanenceDecrement   (float)  Amount by which permanences of synapses are
-                                    decremented during learning.
-    @param learn           (bool)   Determines if permanences are adjusted.
+    @param connections (Object)
+    Connections for the TM. Gets mutated.
 
-    @return cellsToAdd (list) A list of predicted cells that will be added to
-                              active cells and winner cells.
+    @param random (Object)
+    Random number generator. Gets mutated.
+
+    @param columnActiveSegments (iter)
+    Active segments in this column.
+
+    @param prevActiveCells (list)
+    Active cells in `t-1`.
+
+    @param prevWinnerCells (list)
+    Winner cells in `t-1`.
+
+    @param numActivePotentialSynapsesForSegment (list)
+    Number of active potential synapses per segment, indexed by the segment's
+    flatIdx.
+
+    @param maxNewSynapseCount (int)
+    The maximum number of synapses added to a segment during learning
+
+    @param initialPermanence (float)
+    Initial permanence of a new synapse.
+
+    @permanenceIncrement (float)
+    Amount by which permanences of synapses are incremented during learning.
+
+    @permanenceDecrement (float)
+    Amount by which permanences of synapses are decremented during learning.
+
+    @param learn (bool)
+    If true, grow and reinforce synapses.
+
+    @return cellsToAdd (list)
+    A list of predicted cells that will be added to active cells and winner
+    cells.
 
     Pseudocode:
     for each cell in the column that has an active distal dendrite segment
@@ -290,75 +353,76 @@ class TemporalMemory(object):
     """
 
     cellsToAdd = []
+    previousCell = None
+    for segment in columnActiveSegments:
+      if segment.cell != previousCell:
+        cellsToAdd.append(segment.cell)
+        previousCell = segment.cell
 
-    byCell = lambda x: x.segment.cell
-    for cellData in groupby2(activeSegments, byCell,
-                             matchingSegments, byCell):
-      (cell,
-       activeSegmentsOnCell,
-       matchingSegmentsOnCell) = cellData
+      if learn:
+        TemporalMemory.adaptSegment(connections, segment, prevActiveCells,
+                                    permanenceIncrement, permanenceDecrement)
 
-      if activeSegmentsOnCell is not None:
-        cellsToAdd.append(cell)
+        active = numActivePotentialSynapsesForSegment[segment.data.flatIdx]
+        nGrowDesired = maxNewSynapseCount - active
 
-        if learn:
-          # Learn on every active segment.
-          #
-          # For each active segment, get its corresponding matching
-          # segment so that we can use its overlap to compute the
-          # number of synapses to grow.
-          bySegment = lambda x: x.segment
-          for segmentData in groupby2(activeSegmentsOnCell, bySegment,
-                                      matchingSegmentsOnCell, bySegment):
-            (segment,
-             activeOverlaps,
-             matchingOverlaps) = segmentData
-
-            if activeOverlaps is not None:
-              # Active segments are a superset of matching segments,
-              # so this iterator must contain a segment (and overlap).
-              matching = matchingOverlaps.next()
-
-              TemporalMemory.adaptSegment(connections, segment, prevActiveCells,
-                                          permanenceIncrement,
-                                          permanenceDecrement)
-
-
-              nGrowDesired = maxNewSynapseCount - matching.overlap
-              if nGrowDesired > 0:
-                TemporalMemory.growSynapses(connections, random, segment,
-                                            nGrowDesired, prevWinnerCells,
-                                            initialPermanence)
+        if nGrowDesired > 0:
+          TemporalMemory.growSynapses(connections, random, segment,
+                                      nGrowDesired, prevWinnerCells,
+                                      initialPermanence)
 
     return cellsToAdd
 
 
   @staticmethod
-  def burstColumn(connections, random, column, matchingSegments,
-                  prevActiveCells, prevWinnerCells, cellsPerColumn,
+  def burstColumn(connections, random, column, columnMatchingSegments,
+                  prevActiveCells, prevWinnerCells,
+                  numActivePotentialSynapsesForSegment, cellsPerColumn,
                   maxNewSynapseCount, initialPermanence, permanenceIncrement,
                   permanenceDecrement, learn):
     """ Activates all of the cells in an unpredicted active column, chooses a
     winner cell, and, if learning is turned on, learns on one segment, growing a
     new segment if necessary.
 
-    @param connections         (Object) Connections for the TM. Gets mutated.
-    @param random              (Object) Random number generator. Gets mutated.
-    @param column              (int)    Index of bursting column.
-    @param matchingSegments    (iter)   An iterable of SegmentOverlap objects.
-                                        Matching segments for this column, and
-                                        an overlap for each segment.
-    @param prevActiveCells     (list)   Active cells in `t-1`.
-    @param prevWinnerCells     (list)   Winner cells in `t-1`.
-    @param cellsPerColumn      (int)    Number of cells per column.
-    @param maxNewSynapseCount  (int)    The maximum number of synapses added to
-                                        a segment during learning.
-    @param initialPermanence   (float)  Initial permanence of a new synapse.
-    @param permanenceIncrement (float)  Amount by which permanences of synapses
-                                        are incremented during learning.
-    @param permanenceDecrement (float)  Amount by which permanences of synapses
-                                        are decremented during learning.
-    @param learn               (bool)   Whether or not learning is enabled.
+    @param connections (Object)
+    Connections for the TM. Gets mutated.
+
+    @param random (Object)
+    Random number generator. Gets mutated.
+
+    @param column (int)
+    Index of bursting column.
+
+    @param columnMatchingSegments (iter)
+    Matching segments in this column.
+
+    @param prevActiveCells (list)
+    Active cells in `t-1`.
+
+    @param prevWinnerCells (list)
+    Winner cells in `t-1`.
+
+    @param numActivePotentialSynapsesForSegment (list)
+    Number of active potential synapses per segment, indexed by the segment's
+    flatIdx.
+
+    @param cellsPerColumn (int)
+    Number of cells per column.
+
+    @param maxNewSynapseCount (int)
+    The maximum number of synapses added to a segment during learning.
+
+    @param initialPermanence (float)
+    Initial permanence of a new synapse.
+
+    @param permanenceIncrement (float)
+    Amount by which permanences of synapses are incremented during learning.
+
+    @param permanenceDecrement (float)
+    Amount by which permanences of synapses are decremented during learning.
+
+    @param learn (bool)
+    Whether or not learning is enabled.
 
     @return (tuple) Contains:
                       `cells`         (iter),
@@ -381,22 +445,24 @@ class TemporalMemory(object):
     start = cellsPerColumn * column
     cells = xrange(start, start + cellsPerColumn)
 
-    if matchingSegments is not None:
-      bestMatching = max(matchingSegments, key=lambda seg: seg.overlap)
-      winnerCell = bestMatching.segment.cell
+    if columnMatchingSegments is not None:
+      numActive = lambda s: numActivePotentialSynapsesForSegment[s.data.flatIdx]
+      bestMatchingSegment = max(columnMatchingSegments, key=numActive)
+      winnerCell = bestMatchingSegment.cell
+
       if learn:
-        TemporalMemory.adaptSegment(connections, bestMatching.segment,
+        TemporalMemory.adaptSegment(connections, bestMatchingSegment,
                                     prevActiveCells, permanenceIncrement,
                                     permanenceDecrement)
 
-        nGrowDesired = maxNewSynapseCount - bestMatching.overlap
+        nGrowDesired = maxNewSynapseCount - numActive(bestMatchingSegment)
 
         if nGrowDesired > 0:
-          TemporalMemory.growSynapses(connections, random, bestMatching.segment,
+          TemporalMemory.growSynapses(connections, random, bestMatchingSegment,
                                       nGrowDesired, prevWinnerCells,
                                       initialPermanence)
     else:
-      winnerCell = TemporalMemory.leastUsedCell(cells, connections, random)
+      winnerCell = TemporalMemory.leastUsedCell(random, cells, connections)
       if learn:
         nGrowExact = min(maxNewSynapseCount, len(prevWinnerCells))
         if nGrowExact > 0:
@@ -409,25 +475,29 @@ class TemporalMemory(object):
 
 
   @staticmethod
-  def punishPredictedColumn(connections, matchingSegments,
+  def punishPredictedColumn(connections, columnMatchingSegments,
                             predictedSegmentDecrement, prevActiveCells):
     """Punishes the Segments that incorrectly predicted a column to be active.
 
-    @param connections         (Object) Connections for the TM. Gets mutated.
-    @param matchingSegments    (iter)   An iterable of SegmentOverlap objects.
-                                        Matching segments for this column, and
-                                        an overlap for each segment.
-    @param permanenceDecrement (float)  Amount by which permanences of synapses
-                                        are decremented during learning.
-    @param prevActiveCells     (list)   Active cells in `t-1`
+    @param connections (Object)
+    Connections for the TM. Gets mutated.
+
+    @param columnMatchingSegments (iter)
+    Matching segments for this column.
+
+    @param predictedSegmentDecrement (float)
+    Amount by which segments are punished for incorrect predictions.
+
+    @param prevActiveCells (list)
+    Active cells in `t-1`.
 
     Pseudocode:
     for each matching segment in the column
       weaken active synapses
     """
-    if predictedSegmentDecrement > 0.0 and matchingSegments is not None:
-      for matching in matchingSegments:
-        TemporalMemory.adaptSegment(connections, matching.segment,
+    if predictedSegmentDecrement > 0.0 and columnMatchingSegments is not None:
+      for segment in columnMatchingSegments:
+        TemporalMemory.adaptSegment(connections, segment,
                                     prevActiveCells,
                                     -predictedSegmentDecrement, 0.0)
 
@@ -437,15 +507,20 @@ class TemporalMemory(object):
 
 
   @staticmethod
-  def leastUsedCell(cells, connections, random):
+  def leastUsedCell(random, cells, connections):
     """ Gets the cell with the smallest number of segments.
     Break ties randomly.
 
-    @param cells       (list)   Indices of cells
-    @param connections (Object) Connections instance for the tm
-    @param random      (Object) Random number generator
+    @param random (Object)
+    Random number generator. Gets mutated.
 
-    @return (int) Cell index
+    @param cells (list)
+    Indices of cells.
+
+    @param connections (Object)
+    Connections instance for the TM.
+
+    @return (int) Cell index.
     """
     leastUsedCells = []
     minNumSegments = float("inf")
@@ -611,13 +686,14 @@ class TemporalMemory(object):
 
     @return (list) Indices of predictive cells.
     """
-    predictiveCells = set()
-    for activeSegment in self.activeSegments:
-      cell = activeSegment.segment.cell
-      if not cell in predictiveCells:
-        predictiveCells.add(cell)
+    previousCell = None
+    predictiveCells = []
+    for segment in self.activeSegments:
+      if segment.cell != previousCell:
+        predictiveCells.append(segment.cell)
+        previousCell = segment.cell
 
-    return sorted(predictiveCells)
+    return predictiveCells
 
 
   def getWinnerCells(self):
@@ -795,17 +871,21 @@ class TemporalMemory(object):
     proto.winnerCells = list(self.winnerCells)
     activeSegmentOverlaps = \
         proto.init('activeSegmentOverlaps', len(self.activeSegments))
-    for i, active in enumerate(self.activeSegments):
-      activeSegmentOverlaps[i].cell = active.segment.cell
-      activeSegmentOverlaps[i].segment = active.segment.idx
-      activeSegmentOverlaps[i].overlap = active.overlap
+    for i, segment in enumerate(self.activeSegments):
+      activeSegmentOverlaps[i].cell = segment.cell
+      activeSegmentOverlaps[i].segment = segment.idx
+      activeSegmentOverlaps[i].overlap = (
+        self.numActiveConnectedSynapsesForSegment[segment.data.flatIdx]
+      )
 
     matchingSegmentOverlaps = \
         proto.init('matchingSegmentOverlaps', len(self.matchingSegments))
-    for i, matching in enumerate(self.matchingSegments):
-      matchingSegmentOverlaps[i].cell = matching.segment.cell
-      matchingSegmentOverlaps[i].segment = matching.segment.idx
-      matchingSegmentOverlaps[i].overlap = matching.overlap
+    for i, segment in enumerate(self.matchingSegments):
+      matchingSegmentOverlaps[i].cell = segment.cell
+      matchingSegmentOverlaps[i].segment = segment.idx
+      matchingSegmentOverlaps[i].overlap = (
+        self.numActivePotentialSynapsesForSegment[segment.data.flatIdx]
+      )
 
 
 
@@ -839,22 +919,32 @@ class TemporalMemory(object):
     tm.activeCells = [int(x) for x in proto.activeCells]
     tm.winnerCells = [int(x) for x in proto.winnerCells]
 
+    flatListLength = tm.connections.segmentFlatListLength()
+    tm.numActiveConnectedSynapsesForSegment = [0] * flatListLength
+    tm.numActivePotentialSynapsesForSegment = [0] * flatListLength
+
     tm.activeSegments = []
     tm.matchingSegments = []
 
     for i in xrange(len(proto.activeSegmentOverlaps)):
       protoSegmentOverlap = proto.activeSegmentOverlaps[i]
-      segment = tm.connections.getSegment(protoSegmentOverlap.segment,
-                                          protoSegmentOverlap.cell)
-      segmentOverlap = SegmentOverlap(segment, protoSegmentOverlap.overlap)
-      tm.activeSegments.append(segmentOverlap)
+
+      segment = tm.connections.getSegment(protoSegmentOverlap.cell,
+                                          protoSegmentOverlap.segment)
+      tm.activeSegments.append(segment)
+
+      overlap = protoSegmentOverlap.overlap
+      tm.numActiveConnectedSynapsesForSegment[segment.data.flatIdx] = overlap
 
     for i in xrange(len(proto.matchingSegmentOverlaps)):
       protoSegmentOverlap = proto.matchingSegmentOverlaps[i]
-      segment = tm.connections.getSegment(protoSegmentOverlap.segment,
-                                          protoSegmentOverlap.cell)
-      segmentOverlap = SegmentOverlap(segment, protoSegmentOverlap.overlap)
-      tm.matchingSegments.append(segmentOverlap)
+
+      segment = tm.connections.getSegment(protoSegmentOverlap.cell,
+                                          protoSegmentOverlap.segment)
+      tm.matchingSegments.append(segment)
+
+      overlap = protoSegmentOverlap.overlap
+      tm.numActivePotentialSynapsesForSegment[segment.data.flatIdx] = overlap
 
     return tm
 

--- a/tests/unit/nupic/research/connections_test.py
+++ b/tests/unit/nupic/research/connections_test.py
@@ -45,7 +45,8 @@ class ConnectionsTest(unittest.TestCase):
     self.assertEqual(segment2.idx, 1)
     self.assertEqual(segment2.cell, 10)
 
-    self.assertEqual(connections.segmentsForCell(10), [segment1, segment2])
+    self.assertEqual([segment1, segment2],
+                     list(connections.segmentsForCell(10)))
 
 
   def testCreateSegmentReuse(self):
@@ -81,7 +82,7 @@ class ConnectionsTest(unittest.TestCase):
     synapse1 = connections.createSynapse(segment, 50, .34)
     synapse2 = connections.createSynapse(segment, 51, .34)
 
-    synapses = connections.synapsesForSegment(segment)
+    synapses = list(connections.synapsesForSegment(segment))
     self.assertEqual(synapses, [synapse1, synapse2])
 
     #Add an additional synapse to force it over the limit of num synapses
@@ -90,7 +91,7 @@ class ConnectionsTest(unittest.TestCase):
     self.assertEqual(0, synapse3.idx)
 
     #ensure lower permanence synapse was removed
-    synapses = connections.synapsesForSegment(segment)
+    synapses = list(connections.synapsesForSegment(segment))
     self.assertEqual(synapses, [synapse3, synapse2])
 
 
@@ -123,8 +124,8 @@ class ConnectionsTest(unittest.TestCase):
     (numActiveConnected,
      numActivePotential) = connections.computeActivity([80, 81, 82], 0.5)
 
-    self.assertEqual(0, numActiveConnected[segment2.data.flatIdx])
-    self.assertEqual(0, numActivePotential[segment2.data.flatIdx])
+    self.assertEqual(0, numActiveConnected[segment2.flatIdx])
+    self.assertEqual(0, numActivePotential[segment2.flatIdx])
 
 
   def testDestroySynapse(self):
@@ -143,13 +144,13 @@ class ConnectionsTest(unittest.TestCase):
     connections.destroySynapse(synapse2)
 
     self.assertEqual(2, connections.numSynapses())
-    self.assertEqual(connections.synapsesForSegment(segment), [synapse1,
-                                                               synapse3])
+    self.assertEqual([synapse1, synapse3],
+                     list(connections.synapsesForSegment(segment)))
     (numActiveConnected,
      numActivePotential) = connections.computeActivity([80, 81, 82], .5)
 
-    self.assertEqual(1, numActiveConnected[segment.data.flatIdx])
-    self.assertEqual(2, numActivePotential[segment.data.flatIdx])
+    self.assertEqual(1, numActiveConnected[segment.flatIdx])
+    self.assertEqual(2, numActivePotential[segment.flatIdx])
 
 
   def testPathsNotInvalidatedByOtherDestroys(self):
@@ -170,19 +171,19 @@ class ConnectionsTest(unittest.TestCase):
     synapse4 = connections.createSynapse(segment3, 204, .85)
     synapse5 = connections.createSynapse(segment3, 205, .85)
 
-    self.assertEqual(203, connections.dataForSynapse(synapse3).presynapticCell)
+    self.assertEqual(203, synapse3.presynapticCell)
     connections.destroySynapse(synapse1)
-    self.assertEqual(203, connections.dataForSynapse(synapse3).presynapticCell)
+    self.assertEqual(203, synapse3.presynapticCell)
     connections.destroySynapse(synapse5)
-    self.assertEqual(203, connections.dataForSynapse(synapse3).presynapticCell)
+    self.assertEqual(203, synapse3.presynapticCell)
 
     connections.destroySegment(segment1)
-    self.assertEqual(connections.synapsesForSegment(segment3),
-                     [synapse2, synapse3, synapse4])
+    self.assertEqual([synapse2, synapse3, synapse4],
+                     list(connections.synapsesForSegment(segment3)))
     connections.destroySegment(segment5)
-    self.assertEqual(connections.synapsesForSegment(segment3),
-                     [synapse2, synapse3, synapse4])
-    self.assertEqual(203, connections.dataForSynapse(synapse3).presynapticCell)
+    self.assertEqual([synapse2, synapse3, synapse4],
+                     list(connections.synapsesForSegment(segment3)))
+    self.assertEqual(203, synapse3.presynapticCell)
 
 
   def testDestroySegmentWithDestroyedSynapses(self):
@@ -232,7 +233,7 @@ class ConnectionsTest(unittest.TestCase):
     reincarnated = connections.createSegment(11)
 
     self.assertEqual(0, connections.numSynapses(reincarnated))
-    self.assertEqual(0, len(connections.synapsesForSegment(reincarnated)))
+    self.assertEqual(0, len(list(connections.synapsesForSegment(reincarnated))))
 
 
   def testDestroySegmentsThenReachLimit(self):
@@ -344,11 +345,11 @@ class ConnectionsTest(unittest.TestCase):
     (numActiveConnected,
      numActivePotential) = connections.computeActivity(inputVec, .5)
 
-    self.assertEqual(1, numActiveConnected[segment1a.data.flatIdx])
-    self.assertEqual(2, numActivePotential[segment1a.data.flatIdx])
+    self.assertEqual(1, numActiveConnected[segment1a.flatIdx])
+    self.assertEqual(2, numActivePotential[segment1a.flatIdx])
 
-    self.assertEqual(2, numActiveConnected[segment2a.data.flatIdx])
-    self.assertEqual(3, numActivePotential[segment2a.data.flatIdx])
+    self.assertEqual(2, numActiveConnected[segment2a.flatIdx])
+    self.assertEqual(3, numActivePotential[segment2a.flatIdx])
 
 
   @unittest.skipUnless(

--- a/tests/unit/nupic/research/temporal_memory_test.py
+++ b/tests/unit/nupic/research/temporal_memory_test.py
@@ -210,36 +210,6 @@ class TemporalMemoryTest(unittest.TestCase):
     self.assertAlmostEqual(.42, tm.connections.dataForSynapse(is1).permanence)
 
 
-  def testNoGrowthOnCorrectlyActiveSegments(self):
-    tm = TemporalMemory(
-      columnDimensions=[32],
-      cellsPerColumn=4,
-      activationThreshold=3,
-      initialPermanence=.2,
-      connectedPermanence=.50,
-      minThreshold=2,
-      maxNewSynapseCount=3,
-      permanenceIncrement=.10,
-      permanenceDecrement=.10,
-      predictedSegmentDecrement=0.02,
-      seed=42)
-
-    previousActiveColumns = [0]
-    previousActiveCells = [0,1,2,3]
-    activeColumns = [1]
-    activeCell = 5
-
-    activeSegment = tm.connections.createSegment(activeCell)
-    tm.connections.createSynapse(activeSegment, previousActiveCells[0], .5)
-    tm.connections.createSynapse(activeSegment, previousActiveCells[1], .5)
-    tm.connections.createSynapse(activeSegment, previousActiveCells[2], .5)
-
-    tm.compute(previousActiveColumns, True)
-    tm.compute(activeColumns, True)
-
-    self.assertEqual(3, len(tm.connections.synapsesForSegment(activeSegment)))
-
-
   def testReinforceSelectedMatchingSegmentInBurstingColumn(self):
     tm = TemporalMemory(
       columnDimensions=[32],

--- a/tests/unit/nupic/research/temporal_memory_test.py
+++ b/tests/unit/nupic/research/temporal_memory_test.py
@@ -397,9 +397,9 @@ class TemporalMemoryTest(unittest.TestCase):
 
     winnerCells = tm.getWinnerCells() #[18]
     self.assertEqual(1, len(winnerCells))
-    segments = tm.connections.segmentsForCell(winnerCells[0])
+    segments = list(tm.connections.segmentsForCell(winnerCells[0]))
     self.assertEqual(1, len(segments))
-    synapses = tm.connections.synapsesForSegment(segments[0])
+    synapses = list(tm.connections.synapsesForSegment(segments[0]))
     self.assertEqual(2, len(synapses))
 
     for synapse in synapses:
@@ -435,7 +435,7 @@ class TemporalMemoryTest(unittest.TestCase):
     self.assertEqual(1, len(winnerCells))
     segments = list(tm.connections.segmentsForCell(winnerCells[0]))
     self.assertEqual(1, len(segments))
-    synapses = tm.connections.synapsesForSegment(segments[0])
+    synapses = list(tm.connections.synapsesForSegment(segments[0]))
     self.assertEqual(3, len(synapses))
 
     presynapticCells = []
@@ -473,7 +473,7 @@ class TemporalMemoryTest(unittest.TestCase):
     self.assertEqual(prevWinnerCells, tm.getWinnerCells())
     tm.compute(activeColumns, True)
 
-    synapses = tm.connections.synapsesForSegment(matchingSegment)
+    synapses = list(tm.connections.synapsesForSegment(matchingSegment))
     self.assertEqual(3, len(synapses))
 
     synapses = synapses[1:] # only test the synapses added by compute
@@ -511,7 +511,7 @@ class TemporalMemoryTest(unittest.TestCase):
 
     tm.compute(activeColumns)
 
-    synapses = tm.connections.synapsesForSegment(matchingSegment)
+    synapses = list(tm.connections.synapsesForSegment(matchingSegment))
     self.assertEqual(2, len(synapses))
 
     synapseData = tm.connections.dataForSynapse(synapses[1])
@@ -553,7 +553,7 @@ class TemporalMemoryTest(unittest.TestCase):
     self.assertEqual(prevWinnerCells, tm.getWinnerCells())
     tm.compute(activeColumns, True)
 
-    synapses = tm.connections.synapsesForSegment(activeSegment)
+    synapses = list(tm.connections.synapsesForSegment(activeSegment))
     self.assertEqual(4, len(synapses))
 
     synapse = synapses[3];
@@ -593,7 +593,7 @@ class TemporalMemoryTest(unittest.TestCase):
     tm.compute(previousActiveColumns, True)
     tm.compute(activeColumns, True)
 
-    self.assertTrue(tm.connections.dataForSynapse(weakActiveSynapse).destroyed)
+    self.assertTrue(weakActiveSynapse._destroyed)
 
 
   def testDestroyWeakSynapseOnActiveReinforce(self):
@@ -626,7 +626,7 @@ class TemporalMemoryTest(unittest.TestCase):
     tm.compute(previousActiveColumns, True)
     tm.compute(activeColumns, True)
 
-    self.assertTrue(tm.connections.dataForSynapse(weakInactSynapse).destroyed)
+    self.assertTrue(weakInactSynapse._destroyed)
 
 
   def testRecycleWeakestSynapseToMakeRoomForNewSynapse(self):
@@ -660,7 +660,7 @@ class TemporalMemoryTest(unittest.TestCase):
     synapseData = tm.connections.dataForSynapse(weakestSynapse)
     self.assertNotEqual(0, synapseData.presynapticCell)
 
-    self.assertFalse(synapseData.destroyed)
+    self.assertFalse(synapseData._destroyed)
 
     self.assertAlmostEqual(.21, synapseData.permanence)
 
@@ -688,26 +688,25 @@ class TemporalMemoryTest(unittest.TestCase):
     tm.compute(prevActiveColumns1)
     tm.compute(activeColumns)
 
-    self.assertEqual(1, len(tm.connections.segmentsForCell(9)))
-    oldestSegment = tm.connections.segmentsForCell(9)[0]
+    self.assertEqual(1, tm.connections.numSegments(9))
+    oldestSegment = list(tm.connections.segmentsForCell(9))[0]
     tm.reset()
     tm.compute(prevActiveColumns2)
     tm.compute(activeColumns)
 
-    self.assertEqual(2, len(tm.connections.segmentsForCell(9)))
+    self.assertEqual(2, tm.connections.numSegments(9))
 
     tm.reset()
     tm.compute(prevActiveColumns3)
     tm.compute(activeColumns)
-    self.assertEqual(2, len(tm.connections.segmentsForCell(9)))
+    self.assertEqual(2, tm.connections.numSegments(9))
 
 
-    synapses = tm.connections.synapsesForSegment(oldestSegment)
-    self.assertEqual(3, len(synapses))
-    presynapticCells = set()
+    self.assertEqual(3, tm.connections.numSynapses(oldestSegment))
 
-    for synapseData in tm.connections.dataForSegment(oldestSegment).synapses:
-      presynapticCells.add(synapseData.presynapticCell)
+    presynapticCells = \
+      set(synapse.presynapticCell
+          for synapse in tm.connections.synapsesForSegment(oldestSegment))
 
     expected = set([6,7,8])
     self.assertEqual(expected, presynapticCells)
@@ -742,8 +741,8 @@ class TemporalMemoryTest(unittest.TestCase):
     tm.compute(activeColumns, True)
 
 
-    self.assertTrue(tm.connections.dataForSegment(matchingSegment))
-    self.assertEqual(0, len(tm.connections.segmentsForCell(expectedActiveCell)))
+    self.assertTrue(matchingSegment._destroyed)
+    self.assertEqual(0, tm.connections.numSegments(expectedActiveCell))
 
 
   def testPunishMatchingSegmentsInInactiveColumns(self):
@@ -829,14 +828,14 @@ class TemporalMemoryTest(unittest.TestCase):
       self.assertEqual(activeCells, tm.getActiveCells())
 
       self.assertEqual(3, tm.connections.numSegments())
-      self.assertEqual(1, len(tm.connections.segmentsForCell(0)))
-      self.assertEqual(1, len(tm.connections.segmentsForCell(3)))
-      self.assertEqual(1, len(tm.connections.synapsesForSegment(segment1)))
-      self.assertEqual(1, len(tm.connections.synapsesForSegment(segment2)))
+      self.assertEqual(1, tm.connections.numSegments(0))
+      self.assertEqual(1, tm.connections.numSegments(3))
+      self.assertEqual(1, tm.connections.numSynapses(segment1))
+      self.assertEqual(1, tm.connections.numSynapses(segment2))
 
-      segments = tm.connections.segmentsForCell(1)
+      segments = list(tm.connections.segmentsForCell(1))
       if len(segments) == 0:
-        segments2 = tm.connections.segmentsForCell(2)
+        segments2 = list(tm.connections.segmentsForCell(2))
         self.assertFalse(len(segments2) == 0)
         grewOnCell2 = True
         segments.append(segments2[0])
@@ -844,7 +843,7 @@ class TemporalMemoryTest(unittest.TestCase):
         grewOnCell1 = True
 
       self.assertEqual(1, len(segments))
-      synapses = tm.connections.synapsesForSegment(segments[0])
+      synapses = list(tm.connections.synapsesForSegment(segments[0]))
       self.assertEqual(4, len(synapses))
 
       columnChecklist = set(prevActiveColumns)


### PR DESCRIPTION
Fixes #3306

This makes two changes to the Connections and TemporalMemory.

### Change 1: Abolish the SegmentOverlap

This problem is described in #3306 

The solution is to keep the `numActivePotentialSynapsesForSegment` list that was already being created inside of `computeActivity`. Now the TM can look up the "overlap" for any segment by simply doing `numActivePotentialSynapsesForSegment[segment.flatIdx]`.

This makes the code simpler and faster. Part of the reason it's faster is because we're not instantiating a `SegmentOverlap` class for every single active / matching segment.

Now the `activeSegments` and `matchingSegments` are just simple lists of segments.

### Change 2: Use `Segment` and `Synapse` instances for both data storage and identity

This gets rid of the `SegmentData` and the `SynapseData`. Now a `Segment` is both the type used inside of the Connections for data storage and the type used to refer to a segment. Same for the `Synapse`.

The separation between a `Segment` and a `SegmentData` makes sense in C++, where structs are passed around by value. In C++ there's an incentive to keep the Segment struct small, and it also wouldn't make sense to include large amounts of data on the `Segment` struct because changing it won't have any effect on the Connection instance's internal copy.

In Python, we pass around references (because that's what you do in all garbage-collected languages). When you pass around references, it doesn't matter how big the data structure is, and the reference always points to the most up-to-date information. Also in Python, every time you create a new instance of any class, you create something that has to be garbage-collected later, so there's a lot more overhead than in C++ where a struct is just a blob of bits, no different from any other value.

With this change, we only instantiate a `Segment` or `Synapse` when creating a new segment or synapse. Afterward we just stop instantiating stuff. When you call `segmentsForCell`, it returns existing Segment instances.

### Perf results

Before:

~~~
> python scripts/temporal_memory_performance_benchmark.py -i tm_py -t hotgym
Test: hotgym

tm_py: 24.044563s
~~~

After:

~~~
> python scripts/temporal_memory_performance_benchmark.py -i tm_py -t hotgym
Test: hotgym

tm_py: 14.601669s
~~~

Measuring in timesteps-per-second, this is ~60% faster.

## TM algorithm results

This does not affect results. It's the same TemporalMemory algorithm.