### PR TITLE
SP: Walk neighbors in the same order as in C++

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ pyproj==1.9.3
 prettytable==0.7.2
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-nupic.bindings==0.4.7
+nupic.bindings==0.4.8
 numpy==1.9.2

--- a/src/nupic/math/topology.py
+++ b/src/nupic/math/topology.py
@@ -115,9 +115,8 @@ def neighborhood(centerIndex, radius, dimensions):
     right = min(dimension - 1, centerPosition[i] + radius)
     intervals.append(xrange(left, right + 1))
 
-  return numpy.ravel_multi_index(
-    numpy.array(list(itertools.product(*intervals))).T,
-    dimensions)
+  coords = numpy.array(list(itertools.product(*intervals)))
+  return numpy.ravel_multi_index(coords.T, dimensions)
 
 
 def wrappingNeighborhood(centerIndex, radius, dimensions):
@@ -149,6 +148,5 @@ def wrappingNeighborhood(centerIndex, radius, dimensions):
     interval = [v % dimension for v in xrange(left, right + 1)]
     intervals.append(interval)
 
-  return numpy.ravel_multi_index(
-    numpy.array(list(itertools.product(*intervals))).T,
-    dimensions)
+  coords = numpy.array(list(itertools.product(*intervals)))
+  return numpy.ravel_multi_index(coords.T, dimensions)

--- a/src/nupic/math/topology.py
+++ b/src/nupic/math/topology.py
@@ -1,0 +1,154 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+
+import itertools
+import numpy
+
+
+def coordinatesFromIndex(index, dimensions):
+  """
+  Translate an index into coordinates, using the given coordinate system.
+
+  Similar to numpy.unravel_index.
+
+  @param index (int)
+  The index of the point. The coordinates are expressed as a single index by
+  using the dimensions as a mixed radix definition. For example, in dimensions
+  42x10, the point [1, 4] is index 1*420 + 4*10 = 460.
+
+  @param dimensions (list of ints)
+  The coordinate system.
+
+  @returns
+  A list of coordinates of length len(dimensions).
+  """
+  coordinates = [0] * len(dimensions)
+
+  shifted = index
+  for i in xrange(len(dimensions) - 1, 0, -1):
+    coordinates[i] = shifted % dimensions[i]
+    shifted = shifted / dimensions[i]
+
+  coordinates[0] = shifted
+
+  return coordinates
+
+
+def indexFromCoordinates(coordinates, dimensions):
+  """
+  Translate coordinates into an index, using the given coordinate system.
+
+  Similar to numpy.ravel_multi_index.
+
+  @param coordinates (list of ints)
+  A list of coordinates of length dimensions.size().
+
+  @param dimensions (list of ints
+  The coordinate system.
+
+  @returns
+  The index of the point. The coordinates are expressed as a single index by
+  using the dimensions as a mixed radix definition. For example, in dimensions
+  42x10, the point [1, 4] is index 1*420 + 4*10 = 460.
+  """
+  index = 0
+  for i, dimension in enumerate(dimensions):
+    index *= dimension
+    index += coordinates[i]
+
+  return index
+
+
+def neighborhood(centerIndex, radius, dimensions):
+  """
+  Get the points in the neighborhood of a point.
+
+  A point's neighborhood is the n-dimensional hypercube with sides ranging
+  [center - radius, center + radius], inclusive. For example, if there are two
+  dimensions and the radius is 3, the neighborhood is 6x6. Neighborhoods are
+  truncated when they are near an edge.
+
+  This is designed to be fast. In C++ it's fastest to iterate through neighbors
+  one by one, calculating them on-demand rather than creating a list of them.
+  But in Python it's faster to build up the whole list in batch via a few calls
+  to C code rather than calculating them on-demand with lots of calls to Python
+  code.
+
+  @param centerIndex (int)
+  The index of the point. The coordinates are expressed as a single index by
+  using the dimensions as a mixed radix definition. For example, in dimensions
+  42x10, the point [1, 4] is index 1*420 + 4*10 = 460.
+
+  @param radius (int)
+  The radius of this neighborhood about the centerIndex.
+
+  @param dimensions (indexable sequence)
+  The dimensions of the world outside this neighborhood.
+
+  @returns (numpy array)
+  The points in the neighborhood, including centerIndex.
+  """
+  centerPosition = coordinatesFromIndex(centerIndex, dimensions)
+
+  intervals = []
+  for i, dimension in enumerate(dimensions):
+    left = max(0, centerPosition[i] - radius)
+    right = min(dimension - 1, centerPosition[i] + radius)
+    intervals.append(xrange(left, right + 1))
+
+  return numpy.ravel_multi_index(
+    numpy.array(list(itertools.product(*intervals))).T,
+    dimensions)
+
+
+def wrappingNeighborhood(centerIndex, radius, dimensions):
+  """
+  Like 'neighborhood', except that the neighborhood isn't truncated when it's
+  near an edge. It wraps around to the other side.
+
+  @param centerIndex (int)
+  The index of the point. The coordinates are expressed as a single index by
+  using the dimensions as a mixed radix definition. For example, in dimensions
+  42x10, the point [1, 4] is index 1*420 + 4*10 = 460.
+
+  @param radius (int)
+  The radius of this neighborhood about the centerIndex.
+
+  @param dimensions (indexable sequence)
+  The dimensions of the world outside this neighborhood.
+
+  @returns (numpy array)
+  The points in the neighborhood, including centerIndex.
+  """
+  centerPosition = coordinatesFromIndex(centerIndex, dimensions)
+
+  intervals = []
+  for i, dimension in enumerate(dimensions):
+    left = centerPosition[i] - radius
+    right = min(centerPosition[i] + radius,
+                left + dimensions[i] - 1)
+    interval = [v % dimension for v in xrange(left, right + 1)]
+    intervals.append(interval)
+
+  return numpy.ravel_multi_index(
+    numpy.array(list(itertools.product(*intervals))).T,
+    dimensions)

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -24,7 +24,7 @@ from nupic.bindings.math import (SM32 as SparseMatrix,
                                  SM_01_32_32 as SparseBinaryMatrix,
                                  GetNTAReal,
                                  Random as NupicRandom)
-import nupic.math.topology as topology
+from nupic.math import topology
 
 
 

--- a/tests/integration/nupic/opf/hotgym_regression_test.py
+++ b/tests/integration/nupic/opf/hotgym_regression_test.py
@@ -63,7 +63,7 @@ class HotgymRegressionTest(unittest.TestCase):
       # Changes that affect prediction results will cause this test to fail. If
       # the change is understood and reviewers agree that there has not been a
       # regression then this value can be updated to reflect the new result.
-      self.assertAlmostEqual(float(lastRow[14]), 5.94559372885)
+      self.assertAlmostEqual(float(lastRow[14]), 5.89191585339)
 
     finally:
       shutil.rmtree(resultsDir, ignore_errors=True)

--- a/tests/integration/nupic/opf/opf_experiment_results_test.py
+++ b/tests/integration/nupic/opf/opf_experiment_results_test.py
@@ -125,7 +125,7 @@ class OPFExperimentResultsTest(unittest.TestCase):
         'results': {
           ('DefaultTask.TemporalMultiStep.predictionLog.csv',
            "multiStepBestPredictions:multiStep:errorMetric='aae':steps=1:window=200:field=field2"):
-                    (0.0, 0.56),
+                    (0.0, 0.58),
         }
       },
 

--- a/tests/unit/nupic/math/topology_test.py
+++ b/tests/unit/nupic/math/topology_test.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+
+"""Topology unit tests"""
+
+import unittest
+
+from nupic.math.topology import (coordinatesFromIndex,
+                                 indexFromCoordinates,
+                                 neighborhood,
+                                 wrappingNeighborhood)
+
+class TestTopology(unittest.TestCase):
+
+  def testIndexFromCoordinates(self):
+    self.assertEquals(0, indexFromCoordinates((0,), (100,)))
+    self.assertEquals(50, indexFromCoordinates((50,), (100,)))
+    self.assertEquals(99, indexFromCoordinates((99,), (100,)))
+
+    self.assertEquals(0, indexFromCoordinates((0, 0), (100, 80)))
+    self.assertEquals(10, indexFromCoordinates((0, 10), (100, 80)))
+    self.assertEquals(80, indexFromCoordinates((1, 0), (100, 80)))
+    self.assertEquals(90, indexFromCoordinates((1, 10), (100, 80)))
+
+    self.assertEquals(0, indexFromCoordinates((0, 0, 0), (100, 10, 8)))
+    self.assertEquals(7, indexFromCoordinates((0, 0, 7), (100, 10, 8)))
+    self.assertEquals(8, indexFromCoordinates((0, 1, 0), (100, 10, 8)))
+    self.assertEquals(80, indexFromCoordinates((1, 0, 0), (100, 10, 8)))
+    self.assertEquals(88, indexFromCoordinates((1, 1, 0), (100, 10, 8)))
+    self.assertEquals(89, indexFromCoordinates((1, 1, 1), (100, 10, 8)))
+
+
+  def testCoordinatesFromIndex(self):
+    self.assertEquals([0], coordinatesFromIndex(0, [100]));
+    self.assertEquals([50], coordinatesFromIndex(50, [100]));
+    self.assertEquals([99], coordinatesFromIndex(99, [100]));
+
+    self.assertEquals([0, 0], coordinatesFromIndex(0, [100, 80]));
+    self.assertEquals([0, 10], coordinatesFromIndex(10, [100, 80]));
+    self.assertEquals([1, 0], coordinatesFromIndex(80, [100, 80]));
+    self.assertEquals([1, 10], coordinatesFromIndex(90, [100, 80]));
+
+    self.assertEquals([0, 0, 0], coordinatesFromIndex(0, [100, 10, 8]));
+    self.assertEquals([0, 0, 7], coordinatesFromIndex(7, [100, 10, 8]));
+    self.assertEquals([0, 1, 0], coordinatesFromIndex(8, [100, 10, 8]));
+    self.assertEquals([1, 0, 0], coordinatesFromIndex(80, [100, 10, 8]));
+    self.assertEquals([1, 1, 0], coordinatesFromIndex(88, [100, 10, 8]));
+    self.assertEquals([1, 1, 1], coordinatesFromIndex(89, [100, 10, 8]));
+
+
+  # ===========================================================================
+  # NEIGHBORHOOD
+  # ===========================================================================
+
+
+  def expectNeighborhoodIndices(self, centerCoords, radius, dimensions, expected):
+    centerIndex = indexFromCoordinates(centerCoords, dimensions)
+
+    numIndices = 0
+
+    for index, expectedIndex in zip(neighborhood(centerIndex, radius,
+                                                 dimensions),
+                                    expected):
+      numIndices += 1
+      self.assertEquals(index, expectedIndex)
+
+    self.assertEquals(numIndices, len(expected))
+
+
+  def expectNeighborhoodCoords(self, centerCoords, radius, dimensions, expected):
+    centerIndex = indexFromCoordinates(centerCoords, dimensions)
+
+    numIndices = 0
+
+    for index, expectedIndex in zip(neighborhood(centerIndex, radius,
+                                                 dimensions),
+                                    expected):
+      numIndices += 1
+      self.assertEquals(index, indexFromCoordinates(expectedIndex, dimensions))
+
+    self.assertEquals(numIndices, len(expected))
+
+
+  def testNeighborhoodOfOrigin1D(self):
+    self.expectNeighborhoodIndices(
+      centerCoords = (0,),
+      dimensions = (100,),
+      radius = 2,
+      expected = (0, 1, 2))
+
+
+  def testNeighborhoodOfOrigin2D(self):
+    self.expectNeighborhoodCoords(
+      centerCoords = (0, 0),
+      dimensions = (100, 80),
+      radius = 2,
+      expected = ((0, 0), (0, 1), (0, 2),
+                  (1, 0), (1, 1), (1, 2),
+                  (2, 0), (2, 1), (2, 2)))
+
+
+  def testNeighborhoodOfOrigin3D(self):
+    self.expectNeighborhoodCoords(
+      centerCoords = (0, 0, 0),
+      dimensions = (100, 80, 60),
+      radius = 1,
+      expected = ((0, 0, 0), (0, 0, 1),
+                  (0, 1, 0), (0, 1, 1),
+                  (1, 0, 0), (1, 0, 1),
+                  (1, 1, 0), (1, 1, 1)))
+
+
+  def testNeighborhoodInMiddle1D(self):
+    self.expectNeighborhoodIndices(
+      centerCoords = (50,),
+      dimensions = (100,),
+      radius = 1,
+      expected = (49, 50, 51))
+
+
+  def testNeighborhoodOfMiddle2D(self):
+    self.expectNeighborhoodCoords(
+      centerCoords = (50, 50),
+      dimensions = (100, 80),
+      radius = 1,
+      expected = ((49, 49), (49, 50), (49, 51),
+                  (50, 49), (50, 50), (50, 51),
+                  (51, 49), (51, 50), (51, 51)))
+
+
+  def testNeighborhoodOfEnd2D(self):
+    self.expectNeighborhoodCoords(
+      centerCoords = (99, 79),
+      dimensions = (100, 80),
+      radius = 2,
+      expected = ((97, 77), (97, 78), (97, 79),
+                  (98, 77), (98, 78), (98, 79),
+                  (99, 77), (99, 78), (99, 79)))
+
+
+  def testNeighborhoodWiderThanWorld(self):
+    self.expectNeighborhoodCoords(
+      centerCoords = (0, 0),
+      dimensions = (3, 2),
+      radius = 3,
+      expected = ((0, 0), (0, 1),
+                  (1, 0), (1, 1),
+                  (2, 0), (2, 1)))
+
+
+  def testNeighborhoodRadiusZero(self):
+    self.expectNeighborhoodIndices(
+      centerCoords = (0,),
+      dimensions = (100,),
+      radius = 0,
+      expected = (0,))
+
+    self.expectNeighborhoodCoords(
+      centerCoords = (0, 0),
+      dimensions = (100, 80),
+      radius = 0,
+      expected = ((0, 0),))
+
+    self.expectNeighborhoodCoords(
+      centerCoords = (0, 0, 0),
+      dimensions = (100, 80, 60),
+      radius = 0,
+      expected = ((0, 0, 0),))
+
+
+  def testNeighborhoodDimensionOne(self):
+    self.expectNeighborhoodCoords(
+      centerCoords = (5, 0),
+      dimensions = (10, 1),
+      radius = 1,
+      expected = ((4, 0), (5, 0), (6, 0)))
+
+    self.expectNeighborhoodCoords(
+      centerCoords = (5, 0, 0),
+      dimensions = (10, 1, 1),
+      radius = 1,
+      expected = ((4, 0, 0), (5, 0, 0), (6, 0, 0)))
+
+
+  # ===========================================================================
+  # WRAPPING NEIGHBORHOOD
+  # ===========================================================================
+
+  def expectWrappingNeighborhoodIndices(self, centerCoords, radius, dimensions,
+                                        expected):
+    centerIndex = indexFromCoordinates(centerCoords, dimensions)
+
+    numIndices = 0
+
+    for index, expectedIndex in zip(wrappingNeighborhood(centerIndex, radius,
+                                                         dimensions),
+                                    expected):
+      numIndices += 1
+      self.assertEquals(index, expectedIndex)
+
+    self.assertEquals(numIndices, len(expected))
+
+
+  def expectWrappingNeighborhoodCoords(self, centerCoords, radius, dimensions,
+                                       expected):
+    centerIndex = indexFromCoordinates(centerCoords, dimensions)
+
+    numIndices = 0
+
+    for index, expectedIndex in zip(wrappingNeighborhood(centerIndex, radius,
+                                                         dimensions),
+                                    expected):
+      numIndices += 1
+      self.assertEquals(index, indexFromCoordinates(expectedIndex, dimensions))
+
+    self.assertEquals(numIndices, len(expected))
+
+
+  def testWrappingNeighborhoodOfOrigin1D(self):
+    self.expectWrappingNeighborhoodIndices(
+      centerCoords = (0,),
+      dimensions = (100,),
+      radius = 1,
+      expected = (99, 0, 1))
+
+
+  def testWrappingNeighborhoodOfOrigin2D(self):
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (0, 0),
+      dimensions = (100, 80),
+      radius = 1,
+      expected = ((99, 79), (99, 0), (99, 1),
+                  (0, 79), (0, 0), (0, 1),
+                  (1, 79), (1, 0), (1, 1)))
+
+
+  def testWrappingNeighborhoodOfOrigin3D(self):
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (0, 0, 0),
+      dimensions = (100, 80, 60),
+      radius = 1,
+      expected = ((99, 79, 59), (99, 79, 0), (99, 79, 1),
+                  (99, 0, 59), (99, 0, 0), (99, 0, 1),
+                  (99, 1, 59), (99, 1, 0), (99, 1, 1),
+                  (0, 79, 59), (0, 79, 0), (0, 79, 1),
+                  (0, 0, 59), (0, 0, 0), (0, 0, 1),
+                  (0, 1, 59), (0, 1, 0), (0, 1, 1),
+                  (1, 79, 59), (1, 79, 0), (1, 79, 1),
+                  (1, 0, 59), (1, 0, 0), (1, 0, 1),
+                  (1, 1, 59), (1, 1, 0), (1, 1, 1),))
+
+
+  def testWrappingNeighborhoodInMiddle1D(self):
+    self.expectWrappingNeighborhoodIndices(
+      centerCoords = (50,),
+      dimensions = (100,),
+      radius = 1,
+      expected = (49, 50, 51))
+
+
+  def testWrappingNeighborhoodOfMiddle2D(self):
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (50, 50),
+      dimensions = (100, 80),
+      radius = 1,
+      expected = ((49, 49), (49, 50), (49, 51),
+                  (50, 49), (50, 50), (50, 51),
+                  (51, 49), (51, 50), (51, 51)))
+
+
+  def testWrappingNeighborhoodOfEnd2D(self):
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (99, 79),
+      dimensions = (100, 80),
+      radius = 1,
+      expected = ((98, 78), (98, 79), (98, 0),
+                  (99, 78), (99, 79), (99, 0),
+                  (0, 78), (0, 79), (0, 0)))
+
+
+  def testWrappingNeighborhoodWiderThanWorld(self):
+    # The order is weird because it starts walking from {-3, -3} and avoids
+    # walking the same point twice.
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (0, 0),
+      dimensions = (3, 2),
+      radius = 3,
+      expected = ((0, 1), (0, 0),
+                  (1, 1), (1, 0),
+                  (2, 1), (2, 0)))
+
+
+  def testWrappingNeighborhoodRadiusZero(self):
+    self.expectWrappingNeighborhoodIndices(
+      centerCoords = (0,),
+      dimensions = (100,),
+      radius = 0,
+      expected = (0,))
+
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (0, 0),
+      dimensions = (100, 80),
+      radius = 0,
+      expected = ((0, 0),))
+
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (0, 0, 0),
+      dimensions = (100, 80, 60),
+      radius = 0,
+      expected = ((0, 0, 0),))
+
+
+  def testWrappingNeighborhoodDimensionOne(self):
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (5, 0),
+      dimensions = (10, 1),
+      radius = 1,
+      expected = ((4, 0), (5, 0), (6, 0)))
+
+    self.expectWrappingNeighborhoodCoords(
+      centerCoords = (5, 0, 0),
+      dimensions = (10, 1, 1),
+      radius = 1,
+      expected = ((4, 0, 0), (5, 0, 0), (6, 0, 0)))

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -426,7 +426,8 @@ class SpatialPoolerTest(unittest.TestCase):
     params.update({
       "inputDimensions": [12],
       "columnDimensions": [4],
-      "potentialRadius": 2
+      "potentialRadius": 2,
+      "wrapAround": False
     })
 
     # Test without wrapAround and potentialPct = 1
@@ -434,23 +435,24 @@ class SpatialPoolerTest(unittest.TestCase):
     sp = SpatialPooler(**params)
 
     expectedMask = [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0]
-    mask = sp._mapPotential(0, wrapAround=False)
+    mask = sp._mapPotential(0)
     self.assertListEqual(mask.tolist(), expectedMask)
 
     expectedMask = [0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 0, 0]
-    mask = sp._mapPotential(2, wrapAround=False)
+    mask = sp._mapPotential(2)
     self.assertListEqual(mask.tolist(), expectedMask)
 
     # Test with wrapAround and potentialPct = 1
     params["potentialPct"] = 1
+    params["wrapAround"] = True
     sp = SpatialPooler(**params)
 
     expectedMask = [1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1]
-    mask = sp._mapPotential(0, wrapAround=True)
+    mask = sp._mapPotential(0)
     self.assertListEqual(mask.tolist(), expectedMask)
 
     expectedMask = [1, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1]
-    mask = sp._mapPotential(3, wrapAround=True)
+    mask = sp._mapPotential(3)
     self.assertListEqual(mask.tolist(), expectedMask)
 
     # Test with potentialPct < 1
@@ -458,7 +460,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp = SpatialPooler(**params)
 
     supersetMask = numpy.array([1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 1])
-    mask = sp._mapPotential(0, wrapAround=True)
+    mask = sp._mapPotential(0)
     self.assertEqual(numpy.sum(mask), 3)
     unionMask = supersetMask | mask.astype(int)
     self.assertListEqual(unionMask.tolist(), supersetMask.tolist())
@@ -470,7 +472,8 @@ class SpatialPoolerTest(unittest.TestCase):
       "columnDimensions": [2, 4],
       "inputDimensions": [6, 12],
       "potentialRadius": 1,
-      "potentialPct": 1
+      "potentialPct": 1,
+      "wrapAround": False,
     })
 
     # Test without wrapAround
@@ -479,18 +482,19 @@ class SpatialPoolerTest(unittest.TestCase):
     trueIndicies = [0, 12, 24,
                     1, 13, 25,
                     2, 14, 26]
-    mask = sp._mapPotential(0, wrapAround=False)
+    mask = sp._mapPotential(0)
     self.assertSetEqual(set(numpy.flatnonzero(mask).tolist()), set(trueIndicies))
 
     trueIndicies = [6, 18, 30,
                     7, 19, 31,
                     8, 20, 32]
-    mask = sp._mapPotential(2, wrapAround=False)
+    mask = sp._mapPotential(2)
     self.assertSetEqual(set(numpy.flatnonzero(mask).tolist()), set(trueIndicies))
 
     # Test with wrapAround
     params.update({
       "potentialRadius": 2,
+      "wrapAround": True,
     })
     sp = SpatialPooler(**params)
 
@@ -499,7 +503,7 @@ class SpatialPoolerTest(unittest.TestCase):
                     61,  1, 13, 25, 37,
                     62,  2, 14, 26, 38,
                     63,  3, 15, 27, 39]
-    mask = sp._mapPotential(0, wrapAround=True)
+    mask = sp._mapPotential(0)
     self.assertSetEqual(set(numpy.flatnonzero(mask).tolist()), set(trueIndicies))
 
     trueIndicies = [68,  8, 20, 32, 44,
@@ -507,7 +511,7 @@ class SpatialPoolerTest(unittest.TestCase):
                     70, 10, 22, 34, 46,
                     71, 11, 23, 35, 47,
                     60,  0, 12, 24, 36]
-    mask = sp._mapPotential(3, wrapAround=True)
+    mask = sp._mapPotential(3)
     self.assertSetEqual(set(numpy.flatnonzero(mask).tolist()), set(trueIndicies))
 
 
@@ -516,7 +520,8 @@ class SpatialPoolerTest(unittest.TestCase):
     params.update({
       "inputDimensions": [1],
       "columnDimensions": [1],
-      "potentialRadius": 2
+      "potentialRadius": 2,
+      "wrapAround": False,
     })
 
     # Test without wrapAround and potentialPct = 1
@@ -524,7 +529,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp = SpatialPooler(**params)
 
     expectedMask = [1]
-    mask = sp._mapPotential(0, wrapAround=False)
+    mask = sp._mapPotential(0)
     self.assertListEqual(mask.tolist(), expectedMask)
 
 

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -408,6 +408,18 @@ class SpatialPoolerTest(unittest.TestCase):
     self.assertEqual(sp._mapColumn(7), 58)
     self.assertEqual(sp._mapColumn(47), 418)
 
+    # Test 2D with some input dimensions smaller than column dimensions.
+    params.update({
+      "columnDimensions": [4, 4],
+      "inputDimensions": [3, 5]
+    })
+
+    sp = SpatialPooler(**params)
+
+    self.assertEqual(sp._mapColumn(0), 0)
+    self.assertEqual(sp._mapColumn(3), 4)
+    self.assertEqual(sp._mapColumn(15), 14)
+
 
   def testMapPotential1D(self):
     params = self._params.copy()
@@ -917,61 +929,28 @@ class SpatialPoolerTest(unittest.TestCase):
 
 
   def testUpdateMinDutyCycleLocal(self):
-    sp = self._sp
+    sp = SpatialPooler(inputDimensions=(5,),
+                       columnDimensions=(8,),
+                       globalInhibition=False)
 
-    # Replace the get neighbors function with a mock to know exactly
-    # the neighbors of each column.
-    sp._numColumns = 5
-    sp._getNeighborsND = Mock(side_effect=[[0, 1, 2],
-                                           [1, 2, 3],
-                                           [2, 3, 4],
-                                           [0, 2, 4],
-                                           [0, 1, 3]])
-
-    sp._minPctOverlapDutyCycles = 0.04
-    sp._overlapDutyCycles = numpy.array([1.4, 0.5, 1.2, 0.8, 0.1])
-    trueMinOverlapDutyCycles = [0.04*1.4, 0.04*1.2, 0.04*1.2, 0.04*1.4,
-                                0.04*1.4]
-
-    sp._minPctActiveDutyCycles = 0.02
-    sp._activeDutyCycles = numpy.array([0.4, 0.5, 0.2, 0.18, 0.1])
-    trueMinActiveDutyCycles = [0.02*0.5, 0.02*0.5, 0.02*0.2, 0.02*0.4,
-                               0.02*0.5]
-
-    sp._minOverlapDutyCycles = numpy.zeros(sp._numColumns)
-    sp._minActiveDutyCycles = numpy.zeros(sp._numColumns)
+    sp.setInhibitionRadius(1)
+    sp.setOverlapDutyCycles([0.7, 0.1, 0.5, 0.01, 0.78, 0.55, 0.1, 0.001])
+    sp.setActiveDutyCycles([0.9, 0.3, 0.5, 0.7, 0.1, 0.01, 0.08, 0.12])
+    sp.setMinPctActiveDutyCycles(0.1);
+    sp.setMinPctOverlapDutyCycles(0.2);
     sp._updateMinDutyCyclesLocal()
-    self.assertListEqual(trueMinOverlapDutyCycles,
-                         list(sp._minOverlapDutyCycles))
-    self.assertListEqual(trueMinActiveDutyCycles, list(sp._minActiveDutyCycles))
 
-    sp._numColumns = 8
-    sp._getNeighborsND = Mock(side_effect= [[0, 1, 2, 3, 4],
-                                            [1, 2, 3, 4, 5],
-                                            [2, 3, 4, 6, 7],
-                                            [0, 2, 4, 6],
-                                            [1, 6],
-                                            [3, 5, 7],
-                                            [1, 4, 5, 6],
-                                            [2, 3, 6, 7]])
+    resultMinActiveDutyCycles = numpy.zeros(sp.getNumColumns())
+    sp.getMinActiveDutyCycles(resultMinActiveDutyCycles)
+    for actual, expected in zip(resultMinActiveDutyCycles,
+                                [0.09, 0.09, 0.07, 0.07, 0.07, 0.01, 0.012, 0.012]):
+      self.assertAlmostEqual(actual, expected)
 
-    sp._minPctOverlapDutyCycles = 0.01
-    sp._overlapDutyCycles = numpy.array(
-        [1.2, 2.7, 0.9, 1.1, 4.3, 7.1, 2.3, 0.0])
-    trueMinOverlapDutyCycles = [0.01*4.3, 0.01*7.1, 0.01*4.3, 0.01*4.3,
-                                0.01*4.3, 0.01*7.1, 0.01*7.1, 0.01*2.3]
-
-    sp._minPctActiveDutyCycles = 0.03
-    sp._activeDutyCycles = numpy.array(
-        [0.14, 0.25, 0.125, 0.33, 0.27, 0.11, 0.76, 0.31])
-    trueMinActiveDutyCycles = [0.03*0.33, 0.03*0.33, 0.03*0.76, 0.03*0.76,
-                               0.03*0.76, 0.03*0.33, 0.03*0.76, 0.03*0.76]
-    sp._minOverlapDutyCycles = numpy.zeros(sp._numColumns)
-    sp._minActiveDutyCycles = numpy.zeros(sp._numColumns)
-    sp._updateMinDutyCyclesLocal()
-    self.assertListEqual(trueMinOverlapDutyCycles,
-                         list(sp._minOverlapDutyCycles))
-    self.assertListEqual(trueMinActiveDutyCycles, list(sp._minActiveDutyCycles))
+    resultMinOverlapDutyCycles = numpy.zeros(sp.getNumColumns())
+    sp.getMinOverlapDutyCycles(resultMinOverlapDutyCycles)
+    for actual, expected in zip(resultMinOverlapDutyCycles,
+                                [0.14, 0.14, 0.1, 0.156, 0.156, 0.156, 0.11, 0.02]):
+      self.assertAlmostEqual(actual, expected)
 
 
   def testUpdateMinDutyCyclesGlobal(self):
@@ -1439,382 +1418,6 @@ class SpatialPoolerTest(unittest.TestCase):
     trueActive = [0, 1, 4, 5, 8]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
     self.assertListEqual(trueActive, sorted(active))
-
-
-  def testGetNeighbors1D(self):
-    """
-    Test that _getNeighbors static method correctly computes
-    the neighbors of a column
-    """
-    sp = self._sp
-
-    layout = numpy.array([0, 0, 1, 0, 1, 0, 0,  0])
-    layout1D = layout.reshape(-1)
-    columnIndex = 3
-    dimensions = numpy.array([8])
-    radius = 1
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-
-    layout = numpy.array([0, 1, 1, 0, 1, 1, 0,  0])
-    layout1D = layout.reshape(-1)
-    columnIndex = 3
-    dimensions = numpy.array([8])
-    radius = 2
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array([0, 1, 1, 0, 0, 0, 1,  1])
-    layout1D = layout.reshape(-1)
-    columnIndex = 0
-    dimensions = numpy.array([8])
-    radius = 2
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array([0, 1, 1, 0, 0, 0, 0,  0])
-    layout1D = layout.reshape(-1)
-    columnIndex = 0
-    dimensions = numpy.array([8])
-    radius = 2
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Radius to big
-    layout = numpy.array([1, 1, 1, 1, 1, 1, 0, 1])
-    layout1D = layout.reshape(-1)
-    columnIndex = 6
-    dimensions = numpy.array([8])
-    radius = 20
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array([1, 1, 1, 1, 1, 1, 0,  1])
-    layout1D = layout.reshape(-1)
-    columnIndex = 6
-    dimensions = numpy.array([8])
-    radius = 20
-    mask = sp._getNeighbors1D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-
-  def testGetNeighbors2D(self):
-    """
-    Test that _getNeighbors static method correctly computes
-    the neighbors of a column and maps them from 2D back to 1D
-    """
-    sp = self._sp
-    layout = numpy.array([
-      [0, 0, 0, 0, 0],
-      [0, 0, 0, 0, 0],
-      [0, 1, 1, 1, 0],
-      [0, 1, 0, 1, 0],
-      [0, 1, 1, 1, 0],
-      [0, 0, 0, 0, 0]])
-
-    layout1D = layout.reshape(-1)
-    columnIndex = 3*5+ 2
-    dimensions = numpy.array([6, 5])
-    radius = 1
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array(
-      [[0, 0, 0, 0, 0],
-       [1, 1, 1, 1, 1],
-       [1, 1, 1, 1, 1],
-       [1, 1, 0, 1, 1],
-       [1, 1, 1, 1, 1],
-       [1, 1, 1, 1, 1]])
-
-    layout1D = layout.reshape(-1)
-    columnIndex = 3*5+ 2
-    dimensions = numpy.array([6, 5])
-    radius = 2
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Radius too big
-    layout = numpy.array(
-      [[1, 1, 1, 1, 1],
-       [1, 1, 1, 1, 1],
-       [1, 1, 1, 1, 1],
-       [1, 1, 0, 1, 1],
-       [1, 1, 1, 1, 1],
-       [1, 1, 1, 1, 1]])
-
-    layout1D = layout.reshape(-1)
-    columnIndex = 3*5+ 2
-    dimensions = numpy.array([6, 5])
-    radius = 7
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Wrap-around
-    layout = numpy.array(
-      [[1, 0, 0, 1, 1],
-       [0, 0, 0, 0, 0],
-       [0, 0, 0, 0, 0],
-       [0, 0, 0, 0, 0],
-       [1, 0, 0, 1, 1],
-       [1, 0, 0, 1, 0]])
-
-    layout1D = layout.reshape(-1)
-    dimensions = numpy.array([6, 5])
-    columnIndex = dimensions.prod() -1
-    radius = 1
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array(
-      [[0, 0, 0, 0, 0],
-       [0, 0, 0, 0, 0],
-       [0, 0, 0, 0, 0],
-       [0, 0, 0, 0, 0],
-       [0, 0, 0, 1, 1],
-       [0, 0, 0, 1, 0]])
-
-    layout1D = layout.reshape(-1)
-    dimensions = numpy.array([6, 5])
-    columnIndex = dimensions.prod() -1
-    radius = 1
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=False)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-
-  def testGetNeighborsND(self):
-    sp = self._sp
-
-    dimensions = numpy.array([5, 7, 2])
-    layout1D = numpy.array(range(numpy.prod(dimensions)))
-    layout = numpy.reshape(layout1D, dimensions)
-    radius = 1
-    x = 1
-    y = 3
-    z = 2
-    columnIndex = layout[z][y][x]
-    neighbors = sp._getNeighborsND(columnIndex, dimensions, radius,
-                                   wrapAround=True)
-    trueNeighbors = set()
-    for i in range(-radius, radius+1):
-      for j in range(-radius, radius+1):
-        for k in range(-radius, radius+1):
-          zprime = (z + i) % dimensions[0]
-          yprime = (y + j) % dimensions[1]
-          xprime = (x + k) % dimensions[2]
-          trueNeighbors.add(
-            layout[zprime][yprime][xprime]
-          )
-    trueNeighbors.remove(columnIndex)
-    self.assertListEqual(sorted(list(trueNeighbors)),
-                         sorted(list(neighbors)))
-
-    dimensions = numpy.array([5, 7, 9])
-    layout1D = numpy.array(range(numpy.prod(dimensions)))
-    layout = numpy.reshape(layout1D, dimensions)
-    radius = 3
-    x = 0
-    y = 0
-    z = 3
-    columnIndex = layout[z][y][x]
-    neighbors = sp._getNeighborsND(columnIndex, dimensions, radius,
-                                   wrapAround=True)
-    trueNeighbors = set()
-    for i in range(-radius, radius+1):
-      for j in range(-radius, radius+1):
-        for k in range(-radius, radius+1):
-          zprime = (z + i) % dimensions[0]
-          yprime = (y + j) % dimensions[1]
-          xprime = (x + k) % dimensions[2]
-          trueNeighbors.add(
-            layout[zprime][yprime][xprime]
-          )
-    trueNeighbors.remove(columnIndex)
-    self.assertListEqual(sorted(list(trueNeighbors)),
-                         sorted(list(neighbors)))
-
-    dimensions = numpy.array([5, 10, 7, 6])
-    layout1D = numpy.array(range(numpy.prod(dimensions)))
-    layout = numpy.reshape(layout1D, dimensions)
-    radius = 4
-    w = 2
-    x = 5
-    y = 6
-    z = 2
-    columnIndex = layout[z][y][x][w]
-    neighbors = sp._getNeighborsND(columnIndex, dimensions, radius,
-                                   wrapAround=True)
-    trueNeighbors = set()
-    for i in range(-radius, radius+1):
-      for j in range(-radius, radius+1):
-        for k in range(-radius, radius+1):
-          for m in range(-radius, radius+1):
-            zprime = (z + i) % dimensions[0]
-            yprime = (y + j) % dimensions[1]
-            xprime = (x + k) % dimensions[2]
-            wprime = (w + m) % dimensions[3]
-            trueNeighbors.add(layout[zprime][yprime][xprime][wprime])
-    trueNeighbors.remove(columnIndex)
-    self.assertListEqual(sorted(list(trueNeighbors)), sorted(list(neighbors)))
-
-    # These are all the same tests from 1D
-    layout = numpy.array([0, 0, 1, 0, 1, 0, 0,  0])
-    layout1D = layout.reshape(-1)
-    columnIndex = 3
-    dimensions = numpy.array([8])
-    radius = 1
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array([0, 1, 1, 0, 1, 1, 0,  0])
-    layout1D = layout.reshape(-1)
-    columnIndex = 3
-    dimensions = numpy.array([8])
-    radius = 2
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Wrap around
-    layout = numpy.array([0, 1, 1, 0, 0, 0, 1,  1])
-    layout1D = layout.reshape(-1)
-    columnIndex = 0
-    dimensions = numpy.array([8])
-    radius = 2
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Radius too big
-    layout = numpy.array([1, 1, 1, 1, 1, 1, 0,  1])
-    layout1D = layout.reshape(-1)
-    columnIndex = 6
-    dimensions = numpy.array([8])
-    radius = 20
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-
-    # These are all the same tests from 2D
-    layout = numpy.array([[0, 0, 0, 0, 0],
-                    [0, 0, 0, 0, 0],
-                    [0, 1, 1, 1, 0],
-                    [0, 1, 0, 1, 0],
-                    [0, 1, 1, 1, 0],
-                    [0, 0, 0, 0, 0]])
-
-    layout1D = layout.reshape(-1)
-    columnIndex = 3*5 + 2
-    dimensions = numpy.array([6, 5])
-    radius = 1
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    layout = numpy.array([[0, 0, 0, 0, 0],
-                          [1, 1, 1, 1, 1],
-                          [1, 1, 1, 1, 1],
-                          [1, 1, 0, 1, 1],
-                          [1, 1, 1, 1, 1],
-                          [1, 1, 1, 1, 1]])
-
-    layout1D = layout.reshape(-1)
-    columnIndex = 3*5+ 2
-    dimensions = numpy.array([6, 5])
-    radius = 2
-    mask = sp._getNeighbors2D(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Radius too big
-    layout = numpy.array([[1, 1, 1, 1, 1],
-                          [1, 1, 1, 1, 1],
-                          [1, 1, 1, 1, 1],
-                          [1, 1, 0, 1, 1],
-                          [1, 1, 1, 1, 1],
-                          [1, 1, 1, 1, 1]])
-
-    layout1D = layout.reshape(-1)
-    columnIndex = 3*5+ 2
-    dimensions = numpy.array([6, 5])
-    radius = 7
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
-
-    # Wrap-around
-    layout = numpy.array([[1, 0, 0, 1, 1],
-                          [0, 0, 0, 0, 0],
-                          [0, 0, 0, 0, 0],
-                          [0, 0, 0, 0, 0],
-                          [1, 0, 0, 1, 1],
-                          [1, 0, 0, 1, 0]])
-
-    layout1D = layout.reshape(-1)
-    dimensions = numpy.array([6, 5])
-    columnIndex = dimensions.prod() -1
-    radius = 1
-    mask = sp._getNeighborsND(columnIndex, dimensions, radius, wrapAround=True)
-    negative = set(range(dimensions.prod())) - set(mask)
-    self.assertEqual(layout1D[mask].all(), True)
-    self.assertEqual(layout1D[list(negative)].any(), False)
 
 
   @unittest.skipUnless(


### PR DESCRIPTION
Fixes #3343

This is the matching Python change for https://github.com/numenta/nupic.core/pull/1081. It will fail the compatibility tests until we have a released nupic.bindings with that change.

Originally I used the same approach as in C++, walking the neighbors without creating lists of them. But this approach is slow in Python, sadly. It's better for the Python to batch process big lists in C (via itertools and numpy) than for Python to try to do the processing in Python.

Here's what this change accomplishes:

- Builds a common interface for handling neighbors (matching the C++) `topology.py`
- Walks the neighbors in the same order as in the C++. The SP compatibility tests pass.
- Removes the need to sort neighbors. https://github.com/numenta/nupic.core/issues/128. So for the first time, the neighbors code is compatible.
- Adds to the `_mapColumn` unit test to cover inputs that were previously broken in C++ https://github.com/numenta/nupic.core/issues/1079
- Updates `testUpdateMinDutyCycleLocal` to do the same thing as the C++, because its mocking strategy no longer works with these changes.
- It's slightly faster. About ~32%, according to the test below.

## Perf Results

### Note it's only 10 epochs. The [C++ results](https://github.com/numenta/nupic.core/pull/1081) did 100 epochs.

Before

~~~
> time python nupic.research/projects/sp_paper/train_sp_topology_simple.py --spatialImp py --numEpochs 10

real	0m32.865s
user	0m32.688s
sys	0m0.152s
~~~

After

~~~
> time python nupic.research/projects/sp_paper/train_sp_topology_simple.py --spatialImp py --numEpochs 10

real	0m24.733s
user	0m24.565s
sys	0m0.150s
~~~
