### PR TITLE
Fix logic in getColumnNeighborhood

### DIFF
--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1157,6 +1157,7 @@ class SpatialPooler(object):
     p = int(p*100000) / 100000.0
     return p
 
+
   def _initPermanence(self, potential, connectedPct):
     """
     Initializes the permanences of a column. The method
@@ -1505,9 +1506,15 @@ class SpatialPooler(object):
     @returns (1D numpy array of integers)
     The columns in the neighborhood.
     """
-    return topology.neighborhood(centerColumn,
-                                 self._inhibitionRadius,
-                                 self._columnDimensions)
+    if self._wrapAround:
+      return topology.wrappingNeighborhood(centerColumn,
+                                           self._inhibitionRadius,
+                                           self._columnDimensions)
+
+    else:
+      return topology.neighborhood(centerColumn,
+                                   self._inhibitionRadius,
+                                   self._columnDimensions)
 
 
 

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1496,7 +1496,7 @@ class SpatialPooler(object):
     """
     Gets a neighborhood of columns.
 
-    Simply calls topology.neighborhood.
+    Simply calls topology.neighborhood or topology.wrappingNeighborhood
 
     A subclass can insert different topology behavior by overriding this method.
 

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -1398,8 +1398,8 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([sp._numColumns])
     sp._inhibitionRadius = 2
     overlaps = numpy.array([1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7], dtype=realDType)
-                        #   L  W  W  L  L  W  W   L   L    W
-    trueActive = [1, 2, 5, 6, 9]
+                        #   L  W  W  L  L  W  W   L   W    W
+    trueActive = [1, 2, 5, 6, 8, 9]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
     self.assertListEqual(trueActive, sorted(active))
 
@@ -1408,10 +1408,10 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([sp._numColumns])
     sp._inhibitionRadius = 3
     overlaps = numpy.array([1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7], dtype=realDType)
-                        #   L  W  W  L  L  W  W   L   L    L
-    trueActive = [1, 2, 5, 6]
+                        #   L  W  W  L  W  W  W   L   L    W
+    trueActive = [1, 2, 4, 5, 6, 9]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
-    # self.assertListEqual(trueActive, active) #FIXME see issue #2639
+    self.assertListEqual(trueActive, active)
 
     # Test add to winners
     density = 0.3333
@@ -1420,7 +1420,7 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._inhibitionRadius = 3
     overlaps = numpy.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=realDType)
                         #   W  W  L  L  W  W  L  L  L  W
-    trueActive = [0, 1, 4, 5, 8]
+    trueActive = [0, 1, 4, 5]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
     self.assertListEqual(trueActive, sorted(active))
 

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -934,9 +934,11 @@ class SpatialPoolerTest(unittest.TestCase):
 
 
   def testUpdateMinDutyCycleLocal(self):
+    # wrapAround=False
     sp = SpatialPooler(inputDimensions=(5,),
                        columnDimensions=(8,),
-                       globalInhibition=False)
+                       globalInhibition=False,
+                       wrapAround=False)
 
     sp.setInhibitionRadius(1)
     sp.setOverlapDutyCycles([0.7, 0.1, 0.5, 0.01, 0.78, 0.55, 0.1, 0.001])
@@ -957,6 +959,30 @@ class SpatialPoolerTest(unittest.TestCase):
                                 [0.14, 0.14, 0.1, 0.156, 0.156, 0.156, 0.11, 0.02]):
       self.assertAlmostEqual(actual, expected)
 
+    # wrapAround=True
+    sp = SpatialPooler(inputDimensions=(5,),
+                       columnDimensions=(8,),
+                       globalInhibition=False,
+                       wrapAround=True)
+
+    sp.setInhibitionRadius(1)
+    sp.setOverlapDutyCycles([0.7, 0.1, 0.5, 0.01, 0.78, 0.55, 0.1, 0.001])
+    sp.setActiveDutyCycles([0.9, 0.3, 0.5, 0.7, 0.1, 0.01, 0.08, 0.12])
+    sp.setMinPctActiveDutyCycles(0.1);
+    sp.setMinPctOverlapDutyCycles(0.2);
+    sp._updateMinDutyCyclesLocal()
+
+    resultMinActiveDutyCycles = numpy.zeros(sp.getNumColumns())
+    sp.getMinActiveDutyCycles(resultMinActiveDutyCycles)
+    for actual, expected in zip(resultMinActiveDutyCycles,
+                                [0.09, 0.09, 0.07, 0.07, 0.07, 0.01, 0.012, 0.09]):
+      self.assertAlmostEqual(actual, expected)
+
+    resultMinOverlapDutyCycles = numpy.zeros(sp.getNumColumns())
+    sp.getMinOverlapDutyCycles(resultMinOverlapDutyCycles)
+    for actual, expected in zip(resultMinOverlapDutyCycles,
+                                [0.14, 0.14, 0.1, 0.156, 0.156, 0.156, 0.11, 0.14]):
+      self.assertAlmostEqual(actual, expected)
 
   def testUpdateMinDutyCyclesGlobal(self):
     sp = self._sp
@@ -1398,8 +1424,16 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([sp._numColumns])
     sp._inhibitionRadius = 2
     overlaps = numpy.array([1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7], dtype=realDType)
-                        #   L  W  W  L  L  W  W   L   W    W
+                        #   L  W  W  L  L  W  W   L   W    W (wrapAround=True)
+                        #   L  W  W  L  L  W  W   L   L    W (wrapAround=False)
+
+    sp._wrapAround = True
     trueActive = [1, 2, 5, 6, 8, 9]
+    active = list(sp._inhibitColumnsLocal(overlaps, density))
+    self.assertListEqual(trueActive, sorted(active))
+
+    sp._wrapAround = False
+    trueActive = [1, 2, 5, 6, 9]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
     self.assertListEqual(trueActive, sorted(active))
 
@@ -1408,7 +1442,14 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([sp._numColumns])
     sp._inhibitionRadius = 3
     overlaps = numpy.array([1, 2, 7, 0, 3, 4, 16, 1, 1.5, 1.7], dtype=realDType)
-                        #   L  W  W  L  W  W  W   L   L    W
+                        #   L  W  W  L  W  W  W   L   L    W (wrapAround=True)
+                        #   L  W  W  L  W  W  W   L   L    L (wrapAround=False)
+    sp._wrapAround = True
+    trueActive = [1, 2, 4, 5, 6, 9]
+    active = list(sp._inhibitColumnsLocal(overlaps, density))
+    self.assertListEqual(trueActive, active)
+
+    sp._wrapAround = False
     trueActive = [1, 2, 4, 5, 6, 9]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
     self.assertListEqual(trueActive, active)
@@ -1419,8 +1460,16 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._columnDimensions = numpy.array([sp._numColumns])
     sp._inhibitionRadius = 3
     overlaps = numpy.array([1, 1, 1, 1, 1, 1, 1, 1, 1, 1], dtype=realDType)
-                        #   W  W  L  L  W  W  L  L  L  W
+                        #   W  W  L  L  W  W  L  L  L  L (wrapAround=True)
+                        #   W  W  L  L  W  W  L  L  W  L (wrapAround=False)
+
+    sp._wrapAround = True
     trueActive = [0, 1, 4, 5]
+    active = list(sp._inhibitColumnsLocal(overlaps, density))
+    self.assertListEqual(trueActive, sorted(active))
+
+    sp._wrapAround = False
+    trueActive = [0, 1, 4, 5, 8]
     active = list(sp._inhibitColumnsLocal(overlaps, density))
     self.assertListEqual(trueActive, sorted(active))
 


### PR DESCRIPTION
Fixes https://github.com/numenta/nupic/issues/3358
Also fixes https://github.com/numenta/nupic/issues/2639

The change has an impact on the testInhibitColumnsLocal. I have verified that the new result makes sense given periodic neighborhood conditions.

@mrcslws Could you make the same change in nupic.core? I am less familiar with the C++ code there. The compatibility test will break until the logic is updated in nupic.core.