### PR TITLE
Allow nupic.research.bindings instead of nupic.bindings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def nupicBindingsPrereleaseInstalled():
   @return: boolean
   """
   try:
-    nupicDistribution = pkg_resources.get_distribution(distributionName)
+    nupicDistribution = pkg_resources.get_distribution("nupic.bindings")
     if pkg_resources.parse_version(nupicDistribution.version).is_prerelease:
       # A pre-release dev version of nupic.bindings is installed.
       return True

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2015, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2016, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -51,7 +51,17 @@ def nupicBindingsPrereleaseInstalled():
   @return: boolean
   """
   try:
-    nupicDistribution = pkg_resources.get_distribution("nupic.bindings")
+    nupicDistribution = pkg_resources.get_distribution(distributionName)
+    if pkg_resources.parse_version(nupicDistribution.version).is_prerelease:
+      # A pre-release dev version of nupic.bindings is installed.
+      return True
+  except pkg_resources.DistributionNotFound:
+    pass  # Silently ignore.  The absence of nupic.bindings will be handled by
+    # setuptools by default
+
+  # Also check for nupic.research.bindings
+  try:
+    nupicDistribution = pkg_resources.get_distribution("nupic.research.bindings")
     if pkg_resources.parse_version(nupicDistribution.version).is_prerelease:
       # A pre-release dev version of nupic.bindings is installed.
       return True

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,7 @@ def nupicBindingsPrereleaseInstalled():
   # Also check for nupic.research.bindings
   try:
     nupicDistribution = pkg_resources.get_distribution("nupic.research.bindings")
-    if pkg_resources.parse_version(nupicDistribution.version).is_prerelease:
-      # A pre-release dev version of nupic.bindings is installed.
-      return True
+    return True
   except pkg_resources.DistributionNotFound:
     pass  # Silently ignore.  The absence of nupic.bindings will be handled by
     # setuptools by default


### PR DESCRIPTION
Enables local installation of nupic.research.bindings instead of nupic.bindings.

@mrcslws please review