### PR TITLE
NUP-2306 Integrate with the new delayed link feature from nupic.core.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ pyproj==1.9.3
 prettytable==0.7.2
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-nupic.bindings==0.4.16
+nupic.bindings==0.5.0
 numpy==1.11.2


### PR DESCRIPTION
Fixes #3439

DO NOT MERGE until https://github.com/numenta/nupic.core/pull/1182 has been merged and released to PyPi along with nupic.bindings version update in this PR. The integration tests will continue to fail until then.

* Call Region.purgeInputLinkBufferHeads after compute() calls in CLAModel to integrate with the new delayed link implementation from nupic.core
* Implemented Delayed Link test in nupic
* Switched version of nupic.bindings in requirements.txt to 0.5.0 to match the new nupic.bindings release on PyPi with the new supporting functionality for delayed links.