### PR TITLE
NUP-2309 Add test to exercise network link introspection

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ pyproj==1.9.3
 prettytable==0.7.2
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-nupic.bindings==0.5.0
+nupic.bindings==0.5.1
 numpy==1.11.2

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -21,7 +21,6 @@
 
 import copy
 import sys
-from mock import Mock
 from mock import patch
 import unittest2 as unittest
 
@@ -464,6 +463,36 @@ class NetworkTest(unittest.TestCase):
 
     self.assertEqual(n.getRegionsByType(SPRegion), [])
 
+
+  def testSimpleTwoRegionNetworkIntrospection(self):
+    # Create Network instance
+    network = engine.Network()
+
+    # Add two TestNode regions to network
+    network.addRegion("region1", "TestNode", "")
+    network.addRegion("region2", "TestNode", "")
+
+    # Set dimensions on first region
+    network.regions["region1"].setDimensions(engine.Dimensions([1, 1]))
+
+    # Link region1 and region2
+    network.link("region1", "region2", "UniformLink", "")
+
+    # Initialize network
+    network.initialize()
+
+    # Get link
+    links = network.getLinks()
+    self.assertEqual(links.getCount(), 1)
+    linkPair = links.getByIndex(0)
+    link = linkPair[1]
+
+    # Compare Link API to what we know about the network
+    self.assertEqual(link.getDestRegionName(), "region2")
+    self.assertEqual(link.getSrcRegionName(), "region1")
+    self.assertEqual(link.getLinkType(), "UniformLink")
+    self.assertEqual(link.getDestInputName(), "bottomUpIn")
+    self.assertEqual(link.getSrcOutputName(), "bottomUpOut")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #3443 

Complement PR to https://github.com/numenta/nupic.core/pull/1207, note that this requires a yet-to-be released version of nupic.core, the absence of which should block the acceptance of this PR.

Please do not merge until nupic.core 0.5.1 is released.