### PR TITLE
Use IterableCollection from engine_internal

### DIFF
--- a/src/nupic/engine/__init__.py
+++ b/src/nupic/engine/__init__.py
@@ -1,7 +1,6 @@
-
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-2017, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -21,7 +20,6 @@
 # ----------------------------------------------------------------------
 
 import os
-import sys
 import nupic.bindings.engine_internal as engine
 from nupic.support.lockattributes import LockAttributesMixin
 import functools
@@ -226,20 +224,6 @@ def ArrayRef(dtype):
   return Array(dtype, None, True)
 
 
-class CollectionIterator(object):
-
-  def __init__(self, collection):
-    self.collection = collection
-    self.index = 0
-
-  def next(self):
-    index = self.index
-    if index == self.collection.getCount():
-      raise StopIteration
-    self.index += 1
-    return self.collection.getByIndex(index)[0]
-
-
 class CollectionWrapper(object):
   """Wrap an nupic::Collection with a dict-like interface
   
@@ -259,7 +243,7 @@ class CollectionWrapper(object):
     self.__class__.__doc__ == collection.__class__.__doc__
 
   def __iter__(self):
-    return CollectionIterator(self.collection)
+    return engine.IterableCollection(self.collection)
 
   def __str__(self):
     return str(self.collection)

--- a/tests/unit/nupic/engine/network_test.py
+++ b/tests/unit/nupic/engine/network_test.py
@@ -287,9 +287,7 @@ class NetworkTest(unittest.TestCase):
     region1 = n.addRegion("region1", "TestNode", "")
     region2 = n.addRegion("region2", "TestNode", "")
 
-    names = []
-    for name in n.regions:
-      names.append(name)
+    names = [region[0] for region in n.regions]
     self.assertEqual(names, ['region1', 'region2'])
     print n.getPhases('region1')
     self.assertEqual(n.getPhases('region1'), (0,))

--- a/tests/unit/nupic/engine/syntactic_sugar_test.py
+++ b/tests/unit/nupic/engine/syntactic_sugar_test.py
@@ -85,9 +85,9 @@ class NetworkSugarTest(unittest.TestCase):
     # for iteration
     for i, r in enumerate(regions):
       if i == 0:
-        self.assertEqual(r, 'r1')
+        self.assertEqual(r[0], 'r1')
       elif i == 1:
-        self.assertEqual(r, 'r2')
+        self.assertEqual(r[0], 'r2')
       else:
         self.fail("Expected i == 0 or i == 1")
 


### PR DESCRIPTION
This removes `CollectionIterator` in favor of the recently-added `nupic.bindings.engine_internal.IterableCollection`.  There is one important difference between the two implementations, however.  `CollectionIterator` (removed here) iterates over the names only whereas `IterableCollection` iterates over the key-value pairs.  As a result, some of the tests needed to be updated to reflect this change in api and as such requires careful consideration.

Looking into this exposed some flaws in `CollectionWrapper` with respect to its `dict`-like interface documented at https://github.com/numenta/nupic/issues/3446.  Fixing those flaws are not in scope of this change.  A future change to `nupic.bindings.engine_internal` may obviate `CollectionWrapper` entirely, shifting focus there.  In the meantime, this change is meant only to remove some duplicated code.

cc @scottpurdy @rhyolight 