### PR TITLE
NUP-2324 Fix hotgym_regression_test.py to make it work with nupic.core PR 1236

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ pyproj==1.9.3
 prettytable==0.7.2
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-nupic.bindings==0.5.1
+nupic.bindings==0.5.3
 numpy==1.11.2

--- a/tests/integration/nupic/opf/hotgym_regression_test.py
+++ b/tests/integration/nupic/opf/hotgym_regression_test.py
@@ -63,7 +63,7 @@ class HotgymRegressionTest(unittest.TestCase):
       # Changes that affect prediction results will cause this test to fail. If
       # the change is understood and reviewers agree that there has not been a
       # regression then this value can be updated to reflect the new result.
-      self.assertAlmostEqual(float(lastRow[14]), 5.84456654247)
+      self.assertAlmostEqual(float(lastRow[14]), 5.85504058885)
 
     finally:
       shutil.rmtree(resultsDir, ignore_errors=True)


### PR DESCRIPTION
Fixes #3477

This PR fixes `tests/integration/nupic/opf/hotgym_regression_test.py` to be compatible with the changes in https://github.com/numenta/nupic.core/pull/1236.
NOTE: This PR will fail in `tests/integration/nupic/opf/hotgym_regression_test.py`until the changes in https://github.com/numenta/nupic.core/pull/1236 are released to PyPi and nupic's dependency on nupic.bindings is updated to that release version. 

NOTE: This requires PR #3476 that switches nupic's nupic.bindings requirement to 0.5.3. Once #3476 is merged, merge master into this PR and wait for a green build.