### PR TITLE
Give better message for bad dtype to SparsePassThroughEncoder

### DIFF
--- a/src/nupic/encoders/sparse_pass_through_encoder.py
+++ b/src/nupic/encoders/sparse_pass_through_encoder.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013-2014, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-2017, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -48,8 +48,15 @@ class SparsePassThroughEncoder(pass_through_encoder.PassThroughEncoder):
         n, w, name, forced, verbosity)
 
 
-  def encodeIntoArray(self, input, output):
+  def encodeIntoArray(self, value, output):
     """ See method description in base.py """
     denseInput = numpy.zeros(output.shape)
-    denseInput[input] = 1
+    try:
+      denseInput[value] = 1
+    except IndexError:
+      if isinstance(value, numpy.ndarray):
+        raise TypeError(
+            "Numpy array must have integer dtype but got {}".format(
+                value.dtype))
+      raise
     super(SparsePassThroughEncoder, self).encodeIntoArray(denseInput, output)

--- a/src/nupic/encoders/sparse_pass_through_encoder.py
+++ b/src/nupic/encoders/sparse_pass_through_encoder.py
@@ -55,7 +55,7 @@ class SparsePassThroughEncoder(pass_through_encoder.PassThroughEncoder):
       denseInput[value] = 1
     except IndexError:
       if isinstance(value, numpy.ndarray):
-        raise TypeError(
+        raise ValueError(
             "Numpy array must have integer dtype but got {}".format(
                 value.dtype))
       raise

--- a/tests/unit/nupic/encoders/sparse_pass_through_encoder_test.py
+++ b/tests/unit/nupic/encoders/sparse_pass_through_encoder_test.py
@@ -67,7 +67,7 @@ class SparsePassThroughEncoderTest(unittest.TestCase):
     e = self._encoder(self.n, 1)
     v = numpy.zeros(self.n)
     v[0] = 12
-    with self.assertRaises(TypeError):
+    with self.assertRaises(ValueError):
       e.encode(v)
 
 

--- a/tests/unit/nupic/encoders/sparse_pass_through_encoder_test.py
+++ b/tests/unit/nupic/encoders/sparse_pass_through_encoder_test.py
@@ -1,6 +1,6 @@
 # ----------------------------------------------------------------------
 # Numenta Platform for Intelligent Computing (NuPIC)
-# Copyright (C) 2013, Numenta, Inc.  Unless you have an agreement
+# Copyright (C) 2013-2017, Numenta, Inc.  Unless you have an agreement
 # with Numenta, Inc., for a separate license for this software code, the
 # following terms and conditions apply:
 #
@@ -61,6 +61,14 @@ class SparsePassThroughEncoderTest(unittest.TestCase):
     x = e.decode(out)
     self.assertIsInstance(x[0], dict)
     self.assertTrue(self.name in x[0])
+
+
+  def testEncodeArrayInvalidType(self):
+    e = self._encoder(self.n, 1)
+    v = numpy.zeros(self.n)
+    v[0] = 12
+    with self.assertRaises(TypeError):
+      e.encode(v)
 
 
   def testEncodeArrayInvalidW(self):


### PR DESCRIPTION
Using the default numpy array dtype previously would cause the following error message:

```
IndexError: arrays used as indices must be of integer (or boolean) type
```

And now it will raise a ValueError with the message:

```
Numpy array must have integer dtype but got float64
```

fixes #1950