### PR TITLE
Disable flatline hack in anomaly likelihood

### DIFF
--- a/src/nupic/algorithms/anomaly_likelihood.py
+++ b/src/nupic/algorithms/anomaly_likelihood.py
@@ -61,6 +61,7 @@ updateAnomalyLikelihoods. The details of these are described below.
 
 import collections
 import math
+import numbers
 import numpy
 
 from nupic.utils import MovingAverage
@@ -468,12 +469,14 @@ def estimateAnomalyLikelihoods(anomalyScores,
     # detect and handle completely flat metric values by reporting them as not
     # anomalous.
     s = [r[1] for r in aggRecordList]
-    metricValues = numpy.array(s)
-    metricDistribution = estimateNormal(metricValues[skipRecords:],
-                                        performLowerBoundCheck=False)
+    # Only do this if the values are numeric
+    if all([isinstance(r[1], numbers.Number) for r in aggRecordList]):
+      metricValues = numpy.array(s)
+      metricDistribution = estimateNormal(metricValues[skipRecords:],
+                                          performLowerBoundCheck=False)
 
-    if metricDistribution["variance"] < 1.5e-5:
-      distributionParams = nullDistribution(verbosity = verbosity)
+      if metricDistribution["variance"] < 1.5e-5:
+        distributionParams = nullDistribution(verbosity = verbosity)
 
   # Estimate likelihoods based on this distribution
   likelihoods = numpy.array(dataValues, dtype=float)

--- a/tests/unit/nupic/algorithms/anomaly_likelihood_test.py
+++ b/tests/unit/nupic/algorithms/anomaly_likelihood_test.py
@@ -460,6 +460,22 @@ class AnomalyLikelihoodAlgorithmTest(TestCaseBase):
     self.assertGreaterEqual(numpy.sum(likelihoods < 0.02), 1)
 
 
+  def testEstimateAnomalyLikelihoodsCategoryValues(self):
+    start = datetime.datetime(2017, 1, 1, 0, 0, 0)
+    delta = datetime.timedelta(minutes=5)
+    dts = [start + (i * delta) for i in xrange(10)]
+    values = ["a", "b", "c", "d", "e"] * 2
+    rawScores = [0.1 * i for i in xrange(10)]
+    data = zip(dts, values, rawScores)
+
+    likelihoods, avgRecordList, estimatorParams = (
+      an.estimateAnomalyLikelihoods(data)
+    )
+    self.assertEqual(len(likelihoods), 10)
+    self.assertEqual(len(avgRecordList), 10)
+    self.assertTrue(an.isValidEstimatorParams(estimatorParams))
+
+
   def testEstimateAnomalyLikelihoodsMalformedRecords(self):
     """
     This calls estimateAnomalyLikelihoods with malformed records, which should


### PR DESCRIPTION
This disables the hack that checks for flatlined metric values if the values aren't numeric types.

fixes #3506 