### PR TITLE
NUP-2389 Remove calls to Region::purgeInputLinkBufferHeads

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ prettytable==0.7.2
 
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-nupic.bindings==0.6.0
+nupic.bindings==0.6.1
 numpy==1.11.2

--- a/src/nupic/frameworks/opf/clamodel.py
+++ b/src/nupic/frameworks/opf/clamodel.py
@@ -474,8 +474,6 @@ class CLAModel(Model):
     except StopIteration as e:
       raise Exception("Unexpected StopIteration", e,
                       "ACTUAL TRACEBACK: %s" % traceback.format_exc())
-    finally:
-      sensor.purgeInputLinkBufferHeads()
 
 
   def _spCompute(self):
@@ -488,7 +486,6 @@ class CLAModel(Model):
     sp.setParameter('learningMode', self.isLearningEnabled())
     sp.prepareInputs()
     sp.compute()
-    sp.purgeInputLinkBufferHeads()
 
 
 
@@ -509,7 +506,6 @@ class CLAModel(Model):
     tp.setParameter('learningMode', self.isLearningEnabled())
     tp.prepareInputs()
     tp.compute()
-    tp.purgeInputLinkBufferHeads()
 
 
   def _isReconstructionModel(self):
@@ -567,7 +563,6 @@ class CLAModel(Model):
     classifier.setParameter('learningMode', self.isLearningEnabled())
     classifier.prepareInputs()
     classifier.compute()
-    classifier.purgeInputLinkBufferHeads()
 
     # What we get out is the score for each category. The argmax is
     # then the index of the winning category
@@ -595,14 +590,12 @@ class CLAModel(Model):
     sp.setParameter('topDownMode', True)
     sp.prepareInputs()
     sp.compute()
-    sp.purgeInputLinkBufferHeads()
 
     #--------------------------------------------------
     # Sensor Top-down flow
     sensor.setParameter('topDownMode', True)
     sensor.prepareInputs()
     sensor.compute()
-    sensor.purgeInputLinkBufferHeads()
 
     # Need to call getOutputValues() instead of going through getOutputData()
     # because the return values may contain strings, which cannot be passed
@@ -660,7 +653,6 @@ class CLAModel(Model):
             "activeColumnCount", len(activeColumns))
         self._getAnomalyClassifier().prepareInputs()
         self._getAnomalyClassifier().compute()
-        self._getAnomalyClassifier().purgeInputLinkBufferHeads()
 
         labels = self._getAnomalyClassifier().getSelf().getLabelResults()
         inferences[InferenceElement.anomalyLabel] = "%s" % labels


### PR DESCRIPTION
Fixes #3509.

NOTE: this won't pass until a version of nupic.core containing https://github.com/numenta/nupic.core/pull/1264 is deployed to PyPi and nupic's dependency on nupic.bindings is updated to that deployed version.

Since we only support delay=0 in CLA models, we no longer need `purgeInputLinkBufferHeads`,
because the new Link::compute logic in nupic.core now performs direct copy
from src to dest for links with delay of 0. See https://github.com/numenta/nupic.core/pull/1264.