### PR TITLE
NUP-2396: Allow SensorRegion to pass actValue and bucketIdx to SDRClassifierRegion

### DIFF
--- a/src/nupic/regions/RecordSensor.py
+++ b/src/nupic/regions/RecordSensor.py
@@ -108,6 +108,25 @@ class RecordSensor(PyRegion):
       singleNodeOnly=True,
       description="Sensor that reads data records and encodes them for an HTM",
       outputs=dict(
+        actValueOut=dict(
+          description="Actual value of the field to predict. The index of the "
+                      "field to predict must be specified via the parameter "
+                      "predictedFieldIdx. If this parameter is not set, then "
+                      "actValueOut won't be populated.",
+          dataType="Real32",
+          count=0,
+          regionLevel=True,
+          isDefaultOutput=False),
+        bucketIdxOut=dict(
+          description="Active index of the encoder bucket for the "
+                      "actual value of the field to predict. The index of the "
+                      "field to predict must be specified via the parameter "
+                      "predictedFieldIdx. If this parameter is not set, then "
+                      "actValueOut won't be populated.",
+          dataType="UInt64",
+          count=0,
+          regionLevel=True,
+          isDefaultOutput=False),
         dataOut=dict(
           description="Encoded data",
           dataType="Real32",  # inefficient for bits, but that's what we use now
@@ -139,15 +158,15 @@ class RecordSensor(PyRegion):
           regionLevel=True,
           isDefaultOutput=False),
         spatialTopDownOut=dict(
-          description="""The top-down output signal, generated from
-                        feedback from SP""",
+          description="The top-down output signal, generated from "
+                      "feedback from SP",
           dataType='Real32',
           count=0,
           regionLevel=True,
           isDefaultOutput=False),
         temporalTopDownOut=dict(
-          description="""The top-down output signal, generated from
-                        feedback from TP through SP""",
+          description="The top-down output signal, generated from "
+                      "feedback from TP through SP",
           dataType='Real32',
           count=0,
           regionLevel=True,
@@ -155,8 +174,8 @@ class RecordSensor(PyRegion):
       ),
       inputs=dict(
         spatialTopDownIn=dict(
-          description="""The top-down input signal, generated from
-                        feedback from SP""",
+          description="The top-down input signal, generated from "
+                      "feedback from SP",
           dataType='Real32',
           count=0,
           required=False,
@@ -164,8 +183,8 @@ class RecordSensor(PyRegion):
           isDefaultInput=False,
           requireSplitterMap=False),
         temporalTopDownIn=dict(
-          description="""The top-down input signal, generated from
-                        feedback from TP through SP""",
+          description="The top-down input signal, generated from "
+                      "feedback from TP through SP",
           dataType='Real32',
           count=0,
           required=False,
@@ -181,19 +200,30 @@ class RecordSensor(PyRegion):
           count=1,
           constraints=""),
         numCategories=dict(
-          description=("Total number of categories to expect from the "
-                       "FileRecordStream"),
+          description="Total number of categories to expect from the "
+                      "FileRecordStream",
           dataType="UInt32",
           accessMode="ReadWrite",
           count=1,
           constraints=""),
-        topDownMode=dict(
-          description='1 if the node should do top down compute on the next '
-                      'call to compute into topDownOut (default 0).',
-          accessMode='ReadWrite',
-          dataType='UInt32',
+        predictedFieldIdx=dict(
+          description="Index of the field to be predicted. Needs to be "
+                      "consistent with the data source indexing. "
+                      "Default value is < 0 which means that no particular "
+                      "field is selected. This will result in the outputs "
+                      "actValueOut and bucketIdxOut not being populated.",
+          dataType="UInt32",
+          accessMode="ReadWrite",
           count=1,
-          constraints='bool'),
+          defaultValue=-1,
+          constraints=""),
+        topDownMode=dict(
+          description="1 if the node should do top down compute on the next "
+                      "call to compute into topDownOut (default 0).",
+          accessMode="ReadWrite",
+          dataType="UInt32",
+          count=1,
+          constraints="bool"),
       ),
       commands=dict())
 
@@ -215,6 +245,11 @@ class RecordSensor(PyRegion):
     self.verbosity = verbosity
     self.numCategories = numCategories
     self._iterNum = 0
+
+    # Optional index of the field for which we want to populate bucketIdxOut
+    # and actValueOut. If predictedFieldIdx < 0, then bucketIdxOut and
+    # actValueOut won't be populated.
+    self.predictedFieldIdx = -1
 
     # lastRecord is the last record returned. Used for debugging only
     self.lastRecord = None
@@ -344,6 +379,28 @@ class RecordSensor(PyRegion):
       # Encode the processed records; populate outputs["dataOut"] in place
       self.encoder.encodeIntoArray(data, outputs["dataOut"])
 
+      # If there is a field to predict, set bucketIdxOut and actValueOut.
+      if self.predictedFieldIdx > 0:
+        fields = self.dataSource.getFieldNames()
+        if self.predictedFieldIdx >= len(fields):
+          raise ValueError("predictedFieldIdx (%s) must be strictly inferior "
+                           "to the number of fields (%s). Fields: %s."
+                           % (self.predictedFieldIdx, len(fields), fields))
+        predictedField = fields[self.predictedFieldIdx]
+        encoders = [e for e in self.encoder.encoders if e[0] == predictedField]
+        if len(encoders) == 0:
+          raise ValueError("There is no encoder for set for the predicted "
+                           "field: %s" % predictedField)
+        elif len(encoders) > 1:
+          raise ValueError("There cant' be more than 1 encoder for the "
+                           "predicted field: %s" % predictedField)
+        else:
+          encoder = encoders[0][1]
+
+        actualValue = data[predictedField]
+        outputs["bucketIdxOut"][:] = encoder.getBucketIndices(actualValue)
+        outputs["actValueOut"][:] = actualValue
+
       # Write out the scalar values obtained from they data source.
       outputs["sourceOut"][:] = self.encoder.getScalars(data)
       self._outputValues["sourceOut"] = self.encoder.getEncodedValues(data)
@@ -430,7 +487,7 @@ class RecordSensor(PyRegion):
       temporalTopDownOut = self.encoder.topDownCompute(temporalTopDownIn)
 
       # -----------------------------------------------------------------------
-      # Split topDownOutput into seperate outputs
+      # Split topDownOutput into separate outputs
 
       values = [elem.value for elem in temporalTopDownOut]
       scalars = [elem.scalar for elem in temporalTopDownOut]
@@ -510,6 +567,12 @@ class RecordSensor(PyRegion):
                         "but the encoder has not been set")
       return len(self.encoder.getDescription())
 
+    elif name == "bucketIdxOut":
+      return 1
+
+    elif name == "actValueOut":
+      return 1
+
     elif name == "categoryOut":
       return self.numCategories
 
@@ -531,7 +594,8 @@ class RecordSensor(PyRegion):
     """
     if parameterName == 'topDownMode':
       self.topDownMode = parameterValue
-
+    elif parameterName == 'predictedFieldIdx':
+      self.predictedFieldIdx = parameterValue
     else:
       raise Exception('Unknown parameter: ' + parameterName)
 

--- a/src/nupic/regions/RecordSensor.py
+++ b/src/nupic/regions/RecordSensor.py
@@ -383,8 +383,8 @@ class RecordSensor(PyRegion):
       if self.predictedFieldIdx > 0:
         fields = self.dataSource.getFieldNames()
         if self.predictedFieldIdx >= len(fields):
-          raise ValueError("predictedFieldIdx (%s) must be strictly inferior "
-                           "to the number of fields (%s). Fields: %s."
+          raise ValueError("predictedFieldIdx (%s) must be strictly less than "
+                           "the number of fields (%s). Fields: %s."
                            % (self.predictedFieldIdx, len(fields), fields))
         predictedField = fields[self.predictedFieldIdx]
         encoders = [e for e in self.encoder.encoders if e[0] == predictedField]

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -407,7 +407,7 @@ class SDRClassifierRegion(PyRegion):
       if len(categories) == 0:
         if "bucketIdxIn" not in inputs:
           raise KeyError("Network link missing: bucketIdxOut -> bucketIdxIn")
-        if "actValue" not in inputs:
+        if "actValueIn" not in inputs:
           raise KeyError("Network link missing: actValueOut -> actValueIn")
 
         classificationIn = {"bucketIdx": int(inputs["bucketIdxIn"]),

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -73,6 +73,27 @@ class SDRClassifierRegion(PyRegion):
       singleNodeOnly=True,
 
       inputs=dict(
+        actValueIn=dict(
+          description="Actual value of the field to predict. Only taken "
+                      "into account if the input has no category field.",
+          dataType="Real32",
+          count=0,
+          required=False,
+          regionLevel=False,
+          isDefaultInput=False,
+          requireSplitterMap=False),
+
+        bucketIdxIn=dict(
+          description="Active index of the encoder bucket for the "
+                      "actual value of the field to predict. Only taken "
+                      "into account if the input has no category field.",
+          dataType="UInt64",
+          count=0,
+          required=False,
+          regionLevel=False,
+          isDefaultInput=False,
+          requireSplitterMap=False),
+
         categoryIn=dict(
           description='Vector of categories of the input sample',
           dataType='Real32',
@@ -163,7 +184,7 @@ class SDRClassifierRegion(PyRegion):
           count=1,
           constraints='',
           # arbitrarily large value
-          defaultValue=100,
+          defaultValue=2000,
           accessMode='Create'),
 
         steps=dict(
@@ -375,6 +396,22 @@ class SDRClassifierRegion(PyRegion):
         classificationIn = {"bucketIdx": int(category),
                             "actValue": int(category)}
 
+        self._sdrClassifier.compute(recordNum=self.recordNum,
+                                    patternNZ=patternNZ,
+                                    classification=classificationIn,
+                                    learn=self.learningMode,
+                                    infer=False)
+
+      # If the input does not belong to a category, i.e. len(categories) == 0,
+      # then look for bucketIdx and ActValueIn.
+      if len(categories) == 0:
+        if "bucketIdxIn" not in inputs:
+          raise KeyError("Network link missing: bucketIdxOut -> bucketIdxIn")
+        if "actValue" not in inputs:
+          raise KeyError("Network link missing: actValueOut -> actValueIn")
+
+        classificationIn = {"bucketIdx": int(inputs["bucketIdxIn"]),
+                            "actValue": float(inputs["actValueIn"])}
         self._sdrClassifier.compute(recordNum=self.recordNum,
                                     patternNZ=patternNZ,
                                     classification=classificationIn,

--- a/src/nupic/regions/SDRClassifierRegion.py
+++ b/src/nupic/regions/SDRClassifierRegion.py
@@ -403,7 +403,7 @@ class SDRClassifierRegion(PyRegion):
                                     infer=False)
 
       # If the input does not belong to a category, i.e. len(categories) == 0,
-      # then look for bucketIdx and ActValueIn.
+      # then look for bucketIdx and actValueIn.
       if len(categories) == 0:
         if "bucketIdxIn" not in inputs:
           raise KeyError("Network link missing: bucketIdxOut -> bucketIdxIn")

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -109,7 +109,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
                      "Inference mode is not turned on.")
 
     # make sure we can access all the parameters with getParameter
-    self.assertEqual(classifier.getParameter("maxCategoryCount"), 100)
+    self.assertEqual(classifier.getParameter("maxCategoryCount"), 2000)
     self.assertAlmostEqual(float(classifier.getParameter("alpha")), 0.001)
     self.assertEqual(int(classifier.getParameter("steps")), 0)
     self.assertTrue(classifier.getParameter("implementation") == "py")

--- a/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
+++ b/tests/integration/nupic/regions/single_step_sdr_classifier_test.py
@@ -192,7 +192,7 @@ class SingleStepSDRClassifierTest(unittest.TestCase):
                      "Inference mode is not turned on.")
 
     # make sure we can access all the parameters with getParameter
-    self.assertEqual(classifier.getParameter("maxCategoryCount"), 100)
+    self.assertEqual(classifier.getParameter("maxCategoryCount"), 2000)
     self.assertAlmostEqual(float(classifier.getParameter("alpha")), 0.001)
     self.assertEqual(int(classifier.getParameter("steps")), 0)
     self.assertTrue(classifier.getParameter("implementation") == "cpp")

--- a/tests/unit/nupic/regions/fixtures/gymdata-test.csv
+++ b/tests/unit/nupic/regions/fixtures/gymdata-test.csv
@@ -1,0 +1,4 @@
+timestamp,consumption
+datetime,float
+T,
+7/2/10 0:00,21.2

--- a/tests/unit/nupic/regions/record_sensor_region_test.py
+++ b/tests/unit/nupic/regions/record_sensor_region_test.py
@@ -21,21 +21,55 @@
 """Unit tests for the RecordSensor region."""
 
 import numpy
+import os
 import unittest2 as unittest
 
 from nupic.engine import Network
-from nupic.regions.RecordSensor import RecordSensor
+from nupic.encoders import MultiEncoder
+from nupic.data.file_record_stream import FileRecordStream
+
+
+
+def _createNetwork():
+  """Create network with one RecordSensor region."""
+  network = Network()
+  network.addRegion('sensor', 'py.RecordSensor', '{}')
+  sensorRegion = network.regions['sensor'].getSelf()
+
+  # Add an encoder.
+  encoderParams = {'consumption': {'fieldname': 'consumption',
+                                   'resolution': 0.88,
+                                   'seed': 1,
+                                   'name': 'consumption',
+                                   'type': 'RandomDistributedScalarEncoder'}}
+
+  encoder = MultiEncoder()
+  encoder.addMultipleEncoders(encoderParams)
+  sensorRegion.encoder = encoder
+
+  # Add a data source.
+  testDir = os.path.dirname(os.path.abspath(__file__))
+  inputFile = os.path.join(testDir, 'fixtures', 'gymdata-test.csv')
+  dataSource = FileRecordStream(streamID=inputFile)
+  sensorRegion.dataSource = dataSource
+
+  # Get and set what field index we want to predict.
+  predictedIdx = dataSource.getFieldNames().index('consumption')
+  network.regions['sensor'].setParameter('predictedFieldIdx', predictedIdx)
+
+  return network
 
 
 
 class RecordSensorRegionTest(unittest.TestCase):
   """RecordSensor region unit tests."""
 
+
   def testVaryingNumberOfCategories(self):
     # Setup network with sensor; max number of categories = 2
     net = Network()
     sensorRegion = net.addRegion(
-        "sensor", "py.RecordSensor", "{'numCategories': 2}")
+      "sensor", "py.RecordSensor", "{'numCategories': 2}")
     sensor = sensorRegion.getSelf()
 
     # Test for # of output categories = max
@@ -44,33 +78,48 @@ class RecordSensorRegionTest(unittest.TestCase):
             "_timestampRecordIdx": None, "_reset": 0}
     sensorOutput = numpy.array([0, 0], dtype="int32")
     sensor.populateCategoriesOut(data["_category"], sensorOutput)
-    
+
     self.assertSequenceEqual([0, 1], sensorOutput.tolist(),
-        "Sensor failed to populate the array with record of two categories.")
+                             "Sensor failed to populate the array with record of two categories.")
 
     # Test for # of output categories > max
     data["_category"] = [1, 2, 3]
     sensorOutput = numpy.array([0, 0], dtype="int32")
     sensor.populateCategoriesOut(data["_category"], sensorOutput)
-    
+
     self.assertSequenceEqual([1, 2], sensorOutput.tolist(),
-        "Sensor failed to populate the array w/ record of three categories.")
-    
+                             "Sensor failed to populate the array w/ record of three categories.")
+
     # Test for # of output categories < max
     data["_category"] = [3]
     sensorOutput = numpy.array([0, 0], dtype="int32")
     sensor.populateCategoriesOut(data["_category"], sensorOutput)
-    
+
     self.assertSequenceEqual([3, -1], sensorOutput.tolist(),
-        "Sensor failed to populate the array w/ record of one category.")
-    
+                             "Sensor failed to populate the array w/ record of one category.")
+
     # Test for no output categories
     data["_category"] = [None]
     sensorOutput = numpy.array([0, 0], dtype="int32")
     sensor.populateCategoriesOut(data["_category"], sensorOutput)
 
     self.assertSequenceEqual([-1, -1], sensorOutput.tolist(),
-        "Sensor failed to populate the array w/ record of zero categories.")
+                             "Sensor failed to populate the array w/ record of zero categories.")
+
+
+  def testBucketIdxOut(self):
+    network = _createNetwork()
+    network.run(1)  # Process 1 row of data
+    bucketIdxOut = network.regions['sensor'].getOutputData('bucketIdxOut')[0]
+    self.assertEquals(bucketIdxOut, 500)
+
+
+  def testActValueOut(self):
+    network = _createNetwork()
+    network.run(1)  # Process 1 row of data
+    actValueOut = network.regions['sensor'].getOutputData('actValueOut')[0]
+    self.assertEquals(round(actValueOut, 1), 21.2)  # only 1 precision digit
+
 
 
 if __name__ == "__main__":

--- a/tests/unit/nupic/regions/sdr_classifier_region_test.py
+++ b/tests/unit/nupic/regions/sdr_classifier_region_test.py
@@ -1,0 +1,103 @@
+# ----------------------------------------------------------------------
+# Numenta Platform for Intelligent Computing (NuPIC)
+# Copyright (C) 2017, Numenta, Inc.  Unless you have an agreement
+# with Numenta, Inc., for a separate license for this software code, the
+# following terms and conditions apply:
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero Public License version 3 as
+# published by the Free Software Foundation.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero Public License for more details.
+#
+# You should have received a copy of the GNU Affero Public License
+# along with this program.  If not, see http://www.gnu.org/licenses.
+#
+# http://numenta.org/licenses/
+# ----------------------------------------------------------------------
+"""Unit tests for the SDRClassifier region."""
+
+import os
+import unittest2 as unittest
+
+from nupic.engine import Network
+from nupic.encoders import MultiEncoder
+from nupic.data.file_record_stream import FileRecordStream
+
+
+
+def _createNetwork():
+  """Create a network with a RecordSensor region and a SDRClassifier region"""
+
+  network = Network()
+  network.addRegion('sensor', 'py.RecordSensor', '{}')
+  network.addRegion('classifier', 'py.SDRClassifierRegion', '{}')
+  _createSensorToClassifierLinks(network, 'sensor', 'classifier')
+
+  # Add encoder to sensor region.
+  sensorRegion = network.regions['sensor'].getSelf()
+  encoderParams = {'consumption': {'fieldname': 'consumption',
+                                   'resolution': 0.88,
+                                   'seed': 1,
+                                   'name': 'consumption',
+                                   'type': 'RandomDistributedScalarEncoder'}}
+
+  encoder = MultiEncoder()
+  encoder.addMultipleEncoders(encoderParams)
+  sensorRegion.encoder = encoder
+
+  # Add data source.
+  testDir = os.path.dirname(os.path.abspath(__file__))
+  inputFile = os.path.join(testDir, 'fixtures', 'gymdata-test.csv')
+  dataSource = FileRecordStream(streamID=inputFile)
+  sensorRegion.dataSource = dataSource
+
+  # Get and set what field index we want to predict.
+  predictedIdx = dataSource.getFieldNames().index('consumption')
+  network.regions['sensor'].setParameter('predictedFieldIdx', predictedIdx)
+
+  return network
+
+
+
+def _createSensorToClassifierLinks(network, sensorRegionName,
+                                   classifierRegionName):
+  """Create links from sensor region to classifier region."""
+  network.link(sensorRegionName, classifierRegionName, 'UniformLink', '',
+               srcOutput='bucketIdxOut', destInput='bucketIdxIn')
+  network.link(sensorRegionName, classifierRegionName, 'UniformLink', '',
+               srcOutput='actValueOut', destInput='actValueIn')
+  network.link(sensorRegionName, classifierRegionName, 'UniformLink', '',
+               srcOutput='categoryOut', destInput='categoryIn')
+  network.link(sensorRegionName, classifierRegionName, 'UniformLink', '',
+               srcOutput='dataOut', destInput='bottomUpIn')
+
+
+
+class SDRClassifierRegionTest(unittest.TestCase):
+  """ SDRClassifier region unit tests."""
+
+
+  def setUp(self):
+    self.network = _createNetwork()
+    self.classifierRegion = self.network.regions['classifier']
+
+
+  def testActValueIn(self):
+    self.network.run(1)  # Process 1 row of data
+    actValueIn = self.classifierRegion.getInputData('actValueIn')[0]
+    self.assertEquals(round(actValueIn, 1), 21.2)  # only 1 precision digit
+
+
+  def testBucketIdxIn(self):
+    self.network.run(1)  # Process 1 row of data
+    bucketIdxIn = self.classifierRegion.getInputData('bucketIdxIn')[0]
+    self.assertEquals(bucketIdxIn, 500)
+
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
This PR blocks #3520.

The network API does not support continuous inference at the moment. The workaround has been to call `customCompute()` on the classifier region to do inference.

This PR fixes the issue: the change enables the creation of new links between sensor and classifier regions so that the `SensorRegion` can pass `bucketIdx` and `actValue` to the `SDRClassifierRegion`. This way inference can happen within the network, without having to call `customCompute()` in an outer loop.