### PR TITLE
Additionally support artifacts with names that can be derived from co…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -63,6 +63,19 @@ deploy:
     # Only deploy on master
     on:
       branch: master
+  - provider: s3
+    access_key_id: AKIAIGHYSEHV3WFKOWNQ
+    secret_access_key:
+      secure: "ONG00ZCPpfU/nugFiON3K2q8IMk3nB/aAUj2Ggjf1z0CJS/cvnfIexmJhe+DJCccoco2l5gpiqp7gweH5vXEcyrzTt1I3Z+iFNas2cQ/wF3LjW0NcbdGeC9NN9kGIoOvr8g6L66CUvazYoirgbJO01ktm7LVNeGS3Q1pk36Vp10="
+    bucket: artifacts.numenta.org
+    region: us-west-2
+    local-dir: "artifacts"
+    upload-dir: "numenta/nupic"
+    skip_cleanup: true
+    # Only deploy on master
+    on:
+      branch: master
+
 
 before_install:
   # Create a new virtualenv to enable upgrade of setuptools and pip;

--- a/ci/travis/before_deploy.sh
+++ b/ci/travis/before_deploy.sh
@@ -47,6 +47,10 @@ if [ "${TRAVIS_BRANCH}" = "master" ]; then
     python setup.py bdist_egg -d dist
     ls dist/wheels
 
+    # Create a tarball named according to commit sha
+    mkdir -p artifacts/travis-ci
+    tar -zcvf artifacts/travis-ci/nupic-${TRAVIS_COMMIT}.tar.gz dist/wheels/nupic-*.whl
+
     # The dist/wheels folder is expected to be deployed to S3.
 
 # If this is a tag, we're doing a release deployment, so we want to build docs


### PR DESCRIPTION
…mmit sha

This is a followup to https://github.com/numenta/nupic/pull/3564.  This makes it so that a file can be easily retrieved by commit sha alone without having to know the version or target platform.