### PR TITLE
Add support for artifacts deployed to S3 named according to sha

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -101,8 +101,13 @@ test_script:
   # Python integration tests
   - py.test tests\integration
 
+after_build:
+  - 7z a nupic-$(APPVEYOR_REPO_COMMIT).zip .\dist\nupic-*.whl
+
 artifacts:
   - path: 'dist\*.whl' # Find all wheel files in project root only (non-recusive)
+  - path: nupic-$(APPVEYOR_REPO_COMMIT).zip
+    name: appveyor
 
 deploy:
   # Amazon S3 deployment provider settings
@@ -115,5 +120,16 @@ deploy:
     set_public: true
     artifact: "nupic-$(NUPIC_VERSION)-cp27-none-win_amd64.whl"
     folder: "numenta/nupic/$(APPVEYOR_REPO_COMMIT)"
+    on:
+      branch: master
+  - provider: S3
+    access_key_id: AKIAIGHYSEHV3WFKOWNQ
+    secret_access_key:
+      secure: /8wO17Gir0XAiecJkHeE3jxOJzvyl0+uWcl7BKCuN0FC795golsL8905VmNuRl1o
+    bucket: "artifacts.numenta.org"
+    region: us-west-2
+    set_public: true
+    artifact: appveyor
+    folder: "numenta/nupic/appveyor"
     on:
       branch: master


### PR DESCRIPTION
Fixes #3572 

@rhyolight I'm not sure if this will work or not, and only executes on `master`, but it gets the appveyor config inline w/ travis.  I suggest you give me carte blanch to merge until it works, assuming you agree w/ overall approach.

![palp_trustme](https://cloud.githubusercontent.com/assets/326528/25541541/e6e7fff0-2c03-11e7-93d2-10a9a8f4cfe5.jpg)
