### PR TITLE
git rm old docs to prevent artifacts

### DIFF
--- a/docs/bin/publish-docs.sh
+++ b/docs/bin/publish-docs.sh
@@ -115,7 +115,8 @@ git checkout gh-pages
 # Get rid of any nupic artifacts
 git clean -fd
 # Nuke any existing version of these docs
-rm -rf $VERSION
+git rm -rf $VERSION
+git commit -m "Removing old docs for $VERSION..."
 # Get the docs from the temp folder
 mv "$TMP_DIR/$VERSION" $NUPIC
 


### PR DESCRIPTION
This change just removes any old versions of docs from git. Otherwise some old artifacts and mess up the doc build because the new version is moved over top of the old one.