### PR TITLE
Adding an interface over TM implementations in TM Region

### DIFF
--- a/scripts/temporal_memory_performance_benchmark.py
+++ b/scripts/temporal_memory_performance_benchmark.py
@@ -251,7 +251,7 @@ def tmComputeFn(instance, encoding, activeBits):
 
 
 def backtrackingComputeFn(instance, encoding, activeBits):
-  instance.compute(encoding, enableLearn=True, computeInfOutput=True)
+  instance.compute(encoding, enableLearn=True, enableInference=True)
 
 
 if __name__ == "__main__":

--- a/src/nupic/algorithms/backtracking_tm_cpp.py
+++ b/src/nupic/algorithms/backtracking_tm_cpp.py
@@ -276,7 +276,7 @@ class BacktrackingTMCPP(BacktrackingTM):
       raise AttributeError("'TM' object has no attribute '%s'" % name)
 
 
-  def compute(self, bottomUpInput, enableLearn, computeInfOutput=None):
+  def compute(self, bottomUpInput, enableLearn, enableInference=None):
     """ Handle one compute, possibly learning.
 
     By default, we don't compute the inference output when learning because it
@@ -297,16 +297,16 @@ class BacktrackingTMCPP(BacktrackingTM):
 
     # As a speed optimization for now (until we need online learning), skip
     #  computing the inference output while learning
-    if computeInfOutput is None:
+    if enableInference is None:
       if enableLearn:
-        computeInfOutput = False
+        enableInference = False
       else:
-        computeInfOutput = True
+        enableInference = True
 
     # ====================================================================
     # Run compute and retrieve selected state and member variables
     self._setStatePointers()
-    y = self.cells4.compute(bottomUpInput, computeInfOutput, enableLearn)
+    y = self.cells4.compute(bottomUpInput, enableInference, enableLearn)
     self.currentOutput = y.reshape((self.numberOfCols, self.cellsPerColumn))
     self.avgLearnedSeqLength = self.cells4.getAvgLearnedSeqLength()
     self._copyAllocatedStates()
@@ -317,7 +317,7 @@ class BacktrackingTMCPP(BacktrackingTM):
     # Learning always includes inference
     if self.collectStats:
       activeColumns = bottomUpInput.nonzero()[0]
-      if computeInfOutput:
+      if enableInference:
         predictedState = self.infPredictedState['t-1']
       else:
         predictedState = self.lrnPredictedState['t-1']

--- a/src/nupic/algorithms/backtracking_tm_shim.py
+++ b/src/nupic/algorithms/backtracking_tm_shim.py
@@ -20,8 +20,8 @@
 # ----------------------------------------------------------------------
 
 """
-A shim for the TM class that transparently implements TemporalMemory,
-for use with OPF.
+A shim for the TM class that transparently implements TemporalMemory as a 
+:class:TemporalMemoryImplementation
 """
 
 import numpy
@@ -30,10 +30,12 @@ from nupic.bindings.algorithms import TemporalMemory as TemporalMemoryCPP
 from nupic.algorithms.monitor_mixin.temporal_memory_monitor_mixin import (
   TemporalMemoryMonitorMixin)
 from nupic.algorithms.temporal_memory import TemporalMemory
+from nupic.regions.tm_region import TemporalMemoryImplementation
 
 
 class MonitoredTemporalMemory(TemporalMemoryMonitorMixin,
-                              TemporalMemory): pass
+                              TemporalMemory):
+  pass
 
 
 
@@ -82,17 +84,13 @@ class TMShimMixin(object):
     self.infActiveState = {"t": None}
 
 
-  def compute(self, bottomUpInput, enableLearn, computeInfOutput=None):
+  def compute(self, bottomUpInput, enableLearn, enableInference=None):
     """
     (From `backtracking_tm.py`)
     Handle one compute, possibly learning.
 
     @param bottomUpInput     The bottom-up input, typically from a spatial pooler
     @param enableLearn       If true, perform learning
-    @param computeInfOutput  If None, default behavior is to disable the inference
-                             output when enableLearn is on.
-                             If true, compute the inference output
-                             If false, do not compute the inference output
     """
     super(TMShimMixin, self).compute(set(bottomUpInput.nonzero()[0]),
                                      learn=enableLearn)
@@ -141,15 +139,25 @@ class TMShimMixin(object):
     return state
 
 
+  def saveToFile(self, filePath):
+    pass
+
+
+  def loadFromFile(self, filePath):
+    pass
+
+
 
 class TMShim(TMShimMixin, TemporalMemory):
   pass
 
+TemporalMemoryImplementation.register(TMShim)
 
 
 class TMCPPShim(TMShimMixin, TemporalMemoryCPP):
   pass
 
+TemporalMemoryImplementation.register(TMCPPShim)
 
 
 class MonitoredTMShim(MonitoredTemporalMemory):
@@ -201,18 +209,19 @@ class MonitoredTMShim(MonitoredTemporalMemory):
     self.infActiveState = {"t": None}
 
 
-  def compute(self, bottomUpInput, enableLearn, computeInfOutput=None):
+  def compute(self, bottomUpInput, enableLearn, enableInference=None):
     """
     (From `backtracking_tm.py`)
     Handle one compute, possibly learning.
 
     @param bottomUpInput     The bottom-up input, typically from a spatial pooler
     @param enableLearn       If true, perform learning
-    @param computeInfOutput  If None, default behavior is to disable the inference
+    @param enableInference  If None, default behavior is to disable the inference
                              output when enableLearn is on.
                              If true, compute the inference output
                              If false, do not compute the inference output
     """
+    # This calls compute on the the TM instance itself.
     super(MonitoredTMShim, self).compute(set(bottomUpInput.nonzero()[0]),
                                          learn=enableLearn)
     numberOfCells = self.numberOfCells()
@@ -257,5 +266,5 @@ class MonitoredTMShim(MonitoredTemporalMemory):
     state = numpy.zeros([self.numberOfColumns(), self.cellsPerColumn])
     return state
 
-
+TemporalMemoryImplementation.register(MonitoredTMShim)
 

--- a/src/nupic/algorithms/monitor_mixin/monitor_mixin_base.py
+++ b/src/nupic/algorithms/monitor_mixin/monitor_mixin_base.py
@@ -81,10 +81,10 @@ import numpy
 from prettytable import PrettyTable
 
 from nupic.algorithms.monitor_mixin.plot import Plot
+from nupic.support.console_printer import ConsolePrinterMixin
 
 
-
-class MonitorMixinBase(object):
+class MonitorMixinBase(ConsolePrinterMixin):
   """
   Base class for MonitorMixin. Each subclass will be a mixin for a particular
   algorithm.

--- a/src/nupic/algorithms/temporal_memory_shim.py
+++ b/src/nupic/algorithms/temporal_memory_shim.py
@@ -90,7 +90,7 @@ class TemporalMemoryShim(TMClass):
     bottomUpInput[list(activeColumns)] = 1
     super(TemporalMemoryShim, self).compute(bottomUpInput,
                                             enableLearn=learn,
-                                            computeInfOutput=True)
+                                            enableInference=True)
 
     predictedState = self.getPredictedState()
     self.predictiveCells = set(numpy.flatnonzero(predictedState))

--- a/src/nupic/regions/tm_region.py
+++ b/src/nupic/regions/tm_region.py
@@ -24,6 +24,7 @@ import abc
 import numpy
 
 from nupic.bindings.regions.PyRegion import PyRegion
+from nupic.algorithms import anomaly
 from nupic.support import getArgumentDescriptions
 from nupic.support.console_printer import ConsolePrinterMixin
 


### PR DESCRIPTION
Fixes #3648

I needed to register the subclasses with the super class using `abc` because they did not play nice with the mixins going on in other places unless I it that way.

When I document these, I'll be sure to point out the inheritance in the docstrings in case Sphinx does not pick them up automatically. 