### PR TITLE
Removing utils.py from docs (internal)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -127,7 +127,6 @@ nupic
 │   └─── unimportable_node.py [TODO]
 ├── serializable.py [TODO]
 ├── support [OK]
-├── swarming [DEFER]
-└── utils.py [TODO]
+└── swarming [DEFER]
 
 ```


### PR DESCRIPTION
This file is an internal resource and doesn't look like it should be exposed to the public.