### PR TITLE
Implement capnp serialization for BacktrackingTM

### DIFF
--- a/src/nupic/algorithms/backtracking_tm.capnp
+++ b/src/nupic/algorithms/backtracking_tm.capnp
@@ -1,0 +1,122 @@
+@0xff2c4ed09fa84975;
+
+using import "/nupic/proto/RandomProto.capnp".RandomProto;
+
+struct SegmentProto {
+  # Segment.tm must be set after constructing Segment from serialization
+
+  segID @0 :UInt32;
+  isSequenceSeg @1 :Bool;
+  lastActiveIteration @2 :UInt32;
+  positiveActivations @3 :UInt32;
+  totalActivations @4 :UInt32;
+  lastPosDutyCycle @5 :Float64;
+  lastPosDutyCycleIteration @6 :UInt32;
+
+  struct SegmentSynapse {
+    srcCellCol @0 :UInt32;
+    srcCellIdx @1 :UInt32;
+    permanence @1 :Float64;
+  }
+  synapses @7 :List(SegmentSynapse);
+}
+
+struct SegmentUpdateProto {
+  columnIdx @0 :UInt32;
+  cellIdx @1 :UInt32;
+  lrnIterationIdx @2 :UInt32;
+  segment @3 :SegmentProto;
+  activeSynapses @4 :List(UInt32);
+  sequenceSegment @5 :Bool;
+  phase1Flag @6 :Bool;
+  weaklyPredicting @7 :Bool;
+}
+
+struct BacktrackingTMProto {
+  version @0 :UInt16;
+  random @1 :RandomProto;
+  numberOfCols @2 :UInt32;
+  cellsPerColumn @3 :UInt32;
+  #numberOfCells
+  initialPerm @4 :Float32;
+  connectedPerm @5 :Float32;
+  minThreshold @6 :Float64;
+  newSynapseCount @7 :UInt32;
+  permanenceInc @8 :Float32;
+  permanenceDec @9 :Float32;
+  permanenceMax @10 :Float32;
+  globalDecay @11 :Float32;
+  activationThreshold @12 :UInt32;
+  doPooling @13 :Bool;
+  segUpdateValidDuration @14 :UInt32;
+  burnIn @15 :UInt32;
+  collectStats @16 :Bool;
+  verbosity @17 :UInt8;
+  pamLength @18 :UInt32;
+  maxAge @19 :UInt32;
+  maxInfBacktrack @20 :UInt32;
+  maxLrnBacktrack @21 :UInt32;
+  maxSeqLength @22 :UInt32;
+  maxSegmentsPerCell @23 :UInt32;
+  maxSynapsesPerSegment @24 :UInt32;
+  outputType @25 :Text;
+
+  activeColumns @26 :List(UInt32);
+
+  # First list indexed by column, inner list indexed by cell in the column
+  cells @27 :List(List(SegmentProto));
+
+  lrnIterationIdx @28 :UInt32;
+  iterationIdx @29 :UInt32;
+  segID @30 :UInt32;
+  currentOutput @31 :List(Float32);
+
+  pamCounter @32 :UInt32;
+  collectSequenceStats @33 :Bool;
+  resetCalled @34 :Bool;
+  avgInputDensity @35 :Float64;
+  learnedSeqLength @36 :UInt32;
+  avgLearnedSeqLength @37 :Float64;
+
+  # List of past inputs, where each input is a list of active indices
+  prevLrnPatterns @38 :List(List(UInt32));
+  prevInfPatterns @39 :List(List(UInt32));
+
+  struct _SegmentUpdateWrapperProto {
+    lrnIterationIdx @0 :UInt32;
+    segmentUpdate @1 :SegmentUpdateProto;
+  }
+  struct _CellSegmentUpdatesProto {
+    columnIdx @0 :UInt32;
+    cellIdx @1 :UInt32;
+    segmentUpdates @2 :List(SegmentUpdateWrapperProto);
+  }
+  segmentUpdates @40 :List(_CellSegmentUpdatesProto);
+
+  cellConfidenceT @41 :List(Float32);
+  cellConfidenceT1 @42 :List(Float32);
+  cellConfidenceCandidate @43 :List(Float32);
+
+  colConfidenceT @44 :List(Float32);
+  colConfidenceT1 @45 :List(Float32);
+  colConfidenceCandidate @46 :List(Float32);
+
+  lrnActiveStateT @47 :List(Int8);
+  lrnActiveStateT1 @48 :List(Int8);
+
+  infActiveStateT @49 :List(Int8);
+  infActiveStateT1 @50 :List(Int8);
+  infActiveStateBackup @51 :List(Int8);
+  infActiveStateCandidate @52 :List(Int8);
+
+  lrnPredictedStateT @53 :List(Int8);
+  lrnPredictedStateT1 @54 :List(Int8);
+
+  infPredictedStateT @55 :List(Int8);
+  infPredictedStateT1 @56 :List(Int8);
+  infPredictedStateBackup @57 :List(Int8);
+  infPredictedStateCandidate @58 :List(Int8);
+
+  # From mixin class
+  consolePrinterVerbosity @59 :UInt8;
+}

--- a/src/nupic/algorithms/backtracking_tm.capnp
+++ b/src/nupic/algorithms/backtracking_tm.capnp
@@ -16,7 +16,7 @@ struct SegmentProto {
   struct SegmentSynapse {
     srcCellCol @0 :UInt32;
     srcCellIdx @1 :UInt32;
-    permanence @1 :Float64;
+    permanence @2 :Float64;
   }
   synapses @7 :List(SegmentSynapse);
 }
@@ -64,7 +64,7 @@ struct BacktrackingTMProto {
   activeColumns @26 :List(UInt32);
 
   # First list indexed by column, inner list indexed by cell in the column
-  cells @27 :List(List(SegmentProto));
+  cells @27 :List(List(List(SegmentProto)));
 
   lrnIterationIdx @28 :UInt32;
   iterationIdx @29 :UInt32;
@@ -82,16 +82,16 @@ struct BacktrackingTMProto {
   prevLrnPatterns @38 :List(List(UInt32));
   prevInfPatterns @39 :List(List(UInt32));
 
-  struct _SegmentUpdateWrapperProto {
+  struct SegmentUpdateWrapperProto {
     lrnIterationIdx @0 :UInt32;
     segmentUpdate @1 :SegmentUpdateProto;
   }
-  struct _CellSegmentUpdatesProto {
+  struct CellSegmentUpdatesProto {
     columnIdx @0 :UInt32;
     cellIdx @1 :UInt32;
     segmentUpdates @2 :List(SegmentUpdateWrapperProto);
   }
-  segmentUpdates @40 :List(_CellSegmentUpdatesProto);
+  segmentUpdates @40 :List(CellSegmentUpdatesProto);
 
   cellConfidenceT @41 :List(Float32);
   cellConfidenceT1 @42 :List(Float32);

--- a/src/nupic/algorithms/backtracking_tm.capnp
+++ b/src/nupic/algorithms/backtracking_tm.capnp
@@ -69,7 +69,7 @@ struct BacktrackingTMProto {
   lrnIterationIdx @28 :UInt32;
   iterationIdx @29 :UInt32;
   segID @30 :UInt32;
-  currentOutput @31 :List(Bool);
+  currentOutput @31 :List(List(Bool));
 
   pamCounter @32 :UInt32;
   collectSequenceStats @33 :Bool;
@@ -93,29 +93,29 @@ struct BacktrackingTMProto {
   }
   segmentUpdates @40 :List(CellSegmentUpdatesProto);
 
-  cellConfidenceT @41 :List(Float32);
-  cellConfidenceT1 @42 :List(Float32);
-  cellConfidenceCandidate @43 :List(Float32);
+  cellConfidenceT @41 :List(List(Float32));
+  cellConfidenceT1 @42 :List(List(Float32));
+  cellConfidenceCandidate @43 :List(List(Float32));
 
   colConfidenceT @44 :List(Float32);
   colConfidenceT1 @45 :List(Float32);
   colConfidenceCandidate @46 :List(Float32);
 
-  lrnActiveStateT @47 :List(Int8);
-  lrnActiveStateT1 @48 :List(Int8);
+  lrnActiveStateT @47 :List(List(Int8));
+  lrnActiveStateT1 @48 :List(List(Int8));
 
-  infActiveStateT @49 :List(Int8);
-  infActiveStateT1 @50 :List(Int8);
-  infActiveStateBackup @51 :List(Int8);
-  infActiveStateCandidate @52 :List(Int8);
+  infActiveStateT @49 :List(List(Int8));
+  infActiveStateT1 @50 :List(List(Int8));
+  infActiveStateBackup @51 :List(List(Int8));
+  infActiveStateCandidate @52 :List(List(Int8));
 
-  lrnPredictedStateT @53 :List(Int8);
-  lrnPredictedStateT1 @54 :List(Int8);
+  lrnPredictedStateT @53 :List(List(Int8));
+  lrnPredictedStateT1 @54 :List(List(Int8));
 
-  infPredictedStateT @55 :List(Int8);
-  infPredictedStateT1 @56 :List(Int8);
-  infPredictedStateBackup @57 :List(Int8);
-  infPredictedStateCandidate @58 :List(Int8);
+  infPredictedStateT @55 :List(List(Int8));
+  infPredictedStateT1 @56 :List(List(Int8));
+  infPredictedStateBackup @57 :List(List(Int8));
+  infPredictedStateCandidate @58 :List(List(Int8));
 
   # From mixin class
   consolePrinterVerbosity @59 :UInt8;

--- a/src/nupic/algorithms/backtracking_tm.capnp
+++ b/src/nupic/algorithms/backtracking_tm.capnp
@@ -16,7 +16,7 @@ struct SegmentProto {
   struct SegmentSynapse {
     srcCellCol @0 :UInt32;
     srcCellIdx @1 :UInt32;
-    permanence @2 :Float64;
+    permanence @2 :Float32;
   }
   synapses @7 :List(SegmentSynapse);
 }
@@ -40,7 +40,7 @@ struct BacktrackingTMProto {
   #numberOfCells
   initialPerm @4 :Float32;
   connectedPerm @5 :Float32;
-  minThreshold @6 :Float64;
+  minThreshold @6 :UInt32;
   newSynapseCount @7 :UInt32;
   permanenceInc @8 :Float32;
   permanenceDec @9 :Float32;
@@ -57,8 +57,8 @@ struct BacktrackingTMProto {
   maxInfBacktrack @20 :UInt32;
   maxLrnBacktrack @21 :UInt32;
   maxSeqLength @22 :UInt32;
-  maxSegmentsPerCell @23 :UInt32;
-  maxSynapsesPerSegment @24 :UInt32;
+  maxSegmentsPerCell @23 :Int64;
+  maxSynapsesPerSegment @24 :Int64;
   outputType @25 :Text;
 
   activeColumns @26 :List(UInt32);
@@ -69,7 +69,7 @@ struct BacktrackingTMProto {
   lrnIterationIdx @28 :UInt32;
   iterationIdx @29 :UInt32;
   segID @30 :UInt32;
-  currentOutput @31 :List(Float32);
+  currentOutput @31 :List(Bool);
 
   pamCounter @32 :UInt32;
   collectSequenceStats @33 :Bool;

--- a/src/nupic/algorithms/backtracking_tm.py
+++ b/src/nupic/algorithms/backtracking_tm.py
@@ -635,11 +635,6 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
     return obj
 
 
-  @staticmethod
-  def _readArray(arrayProto, arr):
-    numpy.copyto(arr, numpy.array(arrayProto, dtype=arr.dtype))
-
-
   def __getattr__(self, name):
     """ @internal
     Patch __getattr__ so that we can catch the first access to 'cells' and load.

--- a/src/nupic/algorithms/backtracking_tm.py
+++ b/src/nupic/algorithms/backtracking_tm.py
@@ -30,11 +30,15 @@ import copy
 import cPickle as pickle
 import itertools
 
-import capnp
+try:
+  import capnp
+except ImportError:
+  capnp = None
 import numpy
 
-from nupic.algorithms.backtracking_tm_capnp import (
-    SegmentProto, SegmentUpdateProto, BacktrackingTMProto)
+if capnp:
+  from nupic.algorithms.backtracking_tm_capnp import (
+      SegmentProto, SegmentUpdateProto, BacktrackingTMProto)
 from nupic.bindings.math import Random
 from nupic.bindings.algorithms import getSegmentActivityLevel, isSegmentActive
 from nupic.math import GetNTAReal

--- a/src/nupic/algorithms/backtracking_tm.py
+++ b/src/nupic/algorithms/backtracking_tm.py
@@ -30,7 +30,9 @@ import copy
 import cPickle as pickle
 import itertools
 
+import capnp
 import numpy
+
 from nupic.algorithms.backtracking_tm_capnp import (
     SegmentProto, SegmentUpdateProto, BacktrackingTMProto)
 from nupic.bindings.math import Random

--- a/src/nupic/algorithms/backtracking_tm.py
+++ b/src/nupic/algorithms/backtracking_tm.py
@@ -453,9 +453,7 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
     proto.maxSynapsesPerSegment = self.maxSynapsesPerSegment
     proto.outputType = self.outputType
 
-    activeColumnsProto = proto.init("activeColumns", len(self.activeColumns))
-    for i, col in enumerate(self.activeColumns):
-      activeColumnsProto[i] = col
+    proto.activeColumns = self.activeColumns
 
     cellListProto = proto.init("cells", len(self.cells))
     for i, columnSegments in enumerate(self.cells):
@@ -468,12 +466,7 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
     proto.lrnIterationIdx = self.lrnIterationIdx
     proto.iterationIdx = self.iterationIdx
     proto.segID = self.segID
-    newArray = numpy.copy(self.currentOutput)
-    newArray.resize((self.currentOutput.size,))
-    currentOutputProto = proto.init("currentOutput", newArray.size)
-    for i, v in enumerate(newArray):
-      currentOutputProto[i] = bool(v)
-
+    proto.currentOutput = self.currentOutput.tolist()
     proto.pamCounter = self.pamCounter
     proto.collectSequenceStats = self.collectSequenceStats
     proto.resetCalled = self.resetCalled
@@ -481,19 +474,8 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
     proto.learnedSeqLength = self.learnedSeqLength
     proto.avgLearnedSeqLength = self.avgLearnedSeqLength
 
-    prevLrnPatternsProto = proto.init("prevLrnPatterns",
-                                      len(self._prevLrnPatterns))
-    for i, pattern in enumerate(self._prevLrnPatterns):
-      prevLrnPatternProto = prevLrnPatternsProto.init(i, len(pattern))
-      for j, v in enumerate(pattern):
-        prevLrnPatternProto[j] = v
-
-    prevInfPatternsProto = proto.init("prevInfPatterns",
-                                      len(self._prevInfPatterns))
-    for i, pattern in enumerate(self._prevInfPatterns):
-      prevInfPatternProto = prevInfPatternsProto.init(i, len(pattern))
-      for j, v in enumerate(pattern):
-        prevInfPatternProto[j] = v
+    proto.prevLrnPatterns = self._prevLrnPatterns
+    proto.prevInfPatterns = self._prevInfPatterns
 
     segmentUpdatesListProto = proto.init("segmentUpdates",
                                          len(self.segmentUpdates))
@@ -509,50 +491,36 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
         segmentUpdate.write(segmentUpdateWrapperProto.segmentUpdate)
 
     # self.cellConfidence
-    self._writeArray(proto, "cellConfidenceT", self.cellConfidence["t"])
-    self._writeArray(proto, "cellConfidenceT1", self.cellConfidence["t-1"])
-    self._writeArray(proto, "cellConfidenceCandidate",
-                self.cellConfidence["candidate"])
+    proto.cellConfidenceT = self.cellConfidence["t"].tolist()
+    proto.cellConfidenceT1 = self.cellConfidence["t-1"].tolist()
+    proto.cellConfidenceCandidate = self.cellConfidence["candidate"].tolist()
 
     # self.colConfidence
-    self._writeArray(proto, "colConfidenceT", self.colConfidence["t"])
-    self._writeArray(proto, "colConfidenceT1", self.colConfidence["t-1"])
-    self._writeArray(proto, "colConfidenceCandidate",
-                self.colConfidence["candidate"])
+    proto.colConfidenceT = self.colConfidence["t"].tolist()
+    proto.colConfidenceT1 = self.colConfidence["t-1"].tolist()
+    proto.colConfidenceCandidate = self.colConfidence["candidate"].tolist()
 
     # self.lrnActiveState
-    self._writeArray(proto, "lrnActiveStateT", self.lrnActiveState["t"])
-    self._writeArray(proto, "lrnActiveStateT1", self.lrnActiveState["t-1"])
+    proto.lrnActiveStateT = self.lrnActiveState["t"].tolist()
+    proto.lrnActiveStateT1 = self.lrnActiveState["t-1"].tolist()
 
     # self.infActiveState
-    self._writeArray(proto, "infActiveStateT", self.infActiveState["t"])
-    self._writeArray(proto, "infActiveStateT1", self.infActiveState["t-1"])
-    self._writeArray(proto, "infActiveStateBackup", self.infActiveState["backup"])
-    self._writeArray(proto, "infActiveStateCandidate",
-                self.infActiveState["candidate"])
+    proto.infActiveStateT = self.infActiveState["t"].tolist()
+    proto.infActiveStateT1 = self.infActiveState["t-1"].tolist()
+    proto.infActiveStateBackup = self.infActiveState["backup"].tolist()
+    proto.infActiveStateCandidate = self.infActiveState["candidate"].tolist()
 
     # self.lrnPredictedState
-    self._writeArray(proto, "lrnPredictedStateT", self.lrnPredictedState["t"])
-    self._writeArray(proto, "lrnPredictedStateT1", self.lrnPredictedState["t-1"])
+    proto.lrnPredictedStateT = self.lrnPredictedState["t"].tolist()
+    proto.lrnPredictedStateT1 = self.lrnPredictedState["t-1"].tolist()
 
     # self.infPredictedState
-    self._writeArray(proto, "infPredictedStateT", self.infPredictedState["t"])
-    self._writeArray(proto, "infPredictedStateT1", self.infPredictedState["t-1"])
-    self._writeArray(proto, "infPredictedStateBackup",
-                self.infPredictedState["backup"])
-    self._writeArray(proto, "infPredictedStateCandidate",
-                self.infPredictedState["candidate"])
+    proto.infPredictedStateT = self.infPredictedState["t"].tolist()
+    proto.infPredictedStateT1 = self.infPredictedState["t-1"].tolist()
+    proto.infPredictedStateBackup = self.infPredictedState["backup"].tolist()
+    proto.infPredictedStateCandidate = self.infPredictedState["candidate"].tolist()
 
     proto.consolePrinterVerbosity = self.consolePrinterVerbosity
-
-
-  @staticmethod
-  def _writeArray(proto, arrayProtoName, array):
-    arrayProto = proto.init(arrayProtoName, array.size)
-    newArray = numpy.copy(array)
-    newArray.resize((array.size,))
-    for i, v in enumerate(newArray):
-      arrayProto[i] = float(v)
 
 
   @classmethod
@@ -587,7 +555,7 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
     obj.maxSynapsesPerSegment = proto.maxSynapsesPerSegment
     obj.outputType = proto.outputType
 
-    obj.activeColumns = [col for col in proto.activeColumns]
+    obj.activeColumns = [int(col) for col in proto.activeColumns]
 
     obj.cells = [[] for _ in xrange(len(proto.cells))]
     for columnSegments, columnSegmentsProto in zip(obj.cells, proto.cells):
@@ -613,10 +581,7 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
     # Initialize various structures
     obj._initEphemerals()
 
-    currentOutputArray = numpy.array([int(v) for v in proto.currentOutput],
-                                     dtype='float32')
-    currentOutputArray.resize(obj.infActiveState['t'].shape)
-    obj.currentOutput = currentOutputArray
+    obj.currentOutput = numpy.array(proto.currentOutput, dtype='float32')
 
     for pattern in proto.prevLrnPatterns:
       obj.prevLrnPatterns.append([v for v in pattern])
@@ -632,35 +597,38 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
       obj.segmentUpdates[key] = value
 
     # cellConfidence
-    obj._readArray(proto.cellConfidenceT, obj.cellConfidence["t"])
-    obj._readArray(proto.cellConfidenceT1, obj.cellConfidence["t-1"])
-    obj._readArray(proto.cellConfidenceCandidate, obj.cellConfidence["candidate"])
+    numpy.copyto(obj.cellConfidence["t"], proto.cellConfidenceT)
+    numpy.copyto(obj.cellConfidence["t-1"], proto.cellConfidenceT1)
+    numpy.copyto(obj.cellConfidence["candidate"],
+                 proto.cellConfidenceCandidate)
 
     # colConfidence
-    obj._readArray(proto.colConfidenceT, obj.colConfidence["t"])
-    obj._readArray(proto.colConfidenceT1, obj.colConfidence["t-1"])
-    obj._readArray(proto.colConfidenceCandidate, obj.colConfidence["candidate"])
+    numpy.copyto(obj.colConfidence["t"], proto.colConfidenceT)
+    numpy.copyto(obj.colConfidence["t-1"], proto.colConfidenceT1)
+    numpy.copyto(obj.colConfidence["candidate"], proto.colConfidenceCandidate)
 
     # lrnActiveState
-    obj._readArray(proto.lrnActiveStateT, obj.lrnActiveState["t"])
-    obj._readArray(proto.lrnActiveStateT1, obj.lrnActiveState["t-1"])
+    numpy.copyto(obj.lrnActiveState["t"], proto.lrnActiveStateT)
+    numpy.copyto(obj.lrnActiveState["t-1"], proto.lrnActiveStateT1)
 
     # infActiveState
-    obj._readArray(proto.infActiveStateT, obj.infActiveState["t"])
-    obj._readArray(proto.infActiveStateT1, obj.infActiveState["t-1"])
-    obj._readArray(proto.infActiveStateBackup, obj.infActiveState["backup"])
-    obj._readArray(proto.infActiveStateCandidate, obj.infActiveState["candidate"])
+    numpy.copyto(obj.infActiveState["t"], proto.infActiveStateT)
+    numpy.copyto(obj.infActiveState["t-1"], proto.infActiveStateT1)
+    numpy.copyto(obj.infActiveState["backup"], proto.infActiveStateBackup)
+    numpy.copyto(obj.infActiveState["candidate"],
+                 proto.infActiveStateCandidate)
 
     # lrnPredictedState
-    obj._readArray(proto.lrnPredictedStateT, obj.lrnPredictedState["t"])
-    obj._readArray(proto.lrnPredictedStateT1, obj.lrnPredictedState["t-1"])
+    numpy.copyto(obj.lrnPredictedState["t"], proto.lrnPredictedStateT)
+    numpy.copyto(obj.lrnPredictedState["t-1"], proto.lrnPredictedStateT1)
 
     # infPredictedState
-    obj._readArray(proto.infPredictedStateT, obj.infPredictedState["t"])
-    obj._readArray(proto.infPredictedStateT1, obj.infPredictedState["t-1"])
-    obj._readArray(proto.infPredictedStateBackup, obj.infPredictedState["backup"])
-    obj._readArray(proto.infPredictedStateCandidate,
-               obj.infPredictedState["candidate"])
+    numpy.copyto(obj.infPredictedState["t"], proto.infPredictedStateT)
+    numpy.copyto(obj.infPredictedState["t-1"], proto.infPredictedStateT1)
+    numpy.copyto(obj.infPredictedState["backup"],
+                 proto.infPredictedStateBackup)
+    numpy.copyto(obj.infPredictedState["candidate"],
+                 proto.infPredictedStateCandidate)
 
     obj.consolePrinterVerbosity = int(proto.consolePrinterVerbosity)
 
@@ -669,9 +637,7 @@ class BacktrackingTM(ConsolePrinterMixin, Serializable):
 
   @staticmethod
   def _readArray(arrayProto, arr):
-    newArray = numpy.array([v for v in arrayProto], dtype=arr.dtype)
-    newArray.resize(arr.shape)
-    numpy.copyto(arr, newArray)
+    numpy.copyto(arr, numpy.array(arrayProto, dtype=arr.dtype))
 
 
   def __getattr__(self, name):

--- a/src/nupic/algorithms/backtracking_tm_cpp.py
+++ b/src/nupic/algorithms/backtracking_tm_cpp.py
@@ -120,6 +120,10 @@ class BacktrackingTMCPP(BacktrackingTM):
     self.makeCells4Ephemeral = True
 
     #---------------------------------------------------------------------------------
+    # Store the seed for constructing Cells4
+    self.seed = seed
+
+    #---------------------------------------------------------------------------------
     # Init the base class
     BacktrackingTM.__init__(self,
                             numberOfCols = numberOfCols,

--- a/src/nupic/algorithms/fdrutilities.py
+++ b/src/nupic/algorithms/fdrutilities.py
@@ -448,7 +448,7 @@ def sameTMParams(tp1, tp2):
   for param in ["numberOfCols", "cellsPerColumn", "initialPerm", "connectedPerm",
                 "minThreshold", "newSynapseCount", "permanenceInc", "permanenceDec",
                 "permanenceMax", "globalDecay", "activationThreshold",
-                "doPooling", "segUpdateValidDuration", "seed",
+                "doPooling", "segUpdateValidDuration",
                 "burnIn", "pamLength", "maxAge"]:
     if getattr(tp1, param) != getattr(tp2,param):
       print param,"is different"

--- a/tests/unit/nupic/algorithms/backtracking_tm_test.py
+++ b/tests/unit/nupic/algorithms/backtracking_tm_test.py
@@ -70,9 +70,14 @@ class BacktrackingTMTest(unittest.TestCase):
         tm1.compute(bottomUpInput, True, True)
 
     # Serialize and deserialized the TM.
+    tmProto = BacktrackingTM.getSchema().new_message()
+    tm1.write(tmProto)
     checkpointPath = os.path.join(self._tmpDir, 'a')
-    tm1.writeToFile(checkpointPath)
-    tm2 = BacktrackingTM.readFromFile(checkpointPath)
+    with open(checkpointPath, "wb") as f:
+      tmProto.write(f)
+    with open(checkpointPath, "rb") as f:
+      tmProto = BacktrackingTM.getSchema().read(f)
+    tm2 = BacktrackingTM.read(tmProto)
 
     # Check that the TMs are the same.
     self.assertTMsEqual(tm1, tm2)
@@ -105,9 +110,14 @@ class BacktrackingTMTest(unittest.TestCase):
         tm1.compute(bottomUpInput, True, True)
 
     # Serialize and deserialized the TM.
+    tmProto = BacktrackingTM.getSchema().new_message()
+    tm1.write(tmProto)
     checkpointPath = os.path.join(self._tmpDir, 'a')
-    tm1.writeToFile(checkpointPath)
-    tm2 = BacktrackingTM.readFromFile(checkpointPath)
+    with open(checkpointPath, "wb") as f:
+      tmProto.write(f)
+    with open(checkpointPath, "rb") as f:
+      tmProto = BacktrackingTM.getSchema().read(f)
+    tm2 = BacktrackingTM.read(tmProto)
 
     # Check that the TMs are the same.
     self.assertTMsEqual(tm1, tm2)
@@ -155,12 +165,22 @@ class BacktrackingTMTest(unittest.TestCase):
     print 'Serializing and deserializing models.'
 
     savePath1 = os.path.join(self._tmpDir, 'tm1.bin')
-    tm1.writeToFile(savePath1)
-    tm3 = BacktrackingTM.readFromFile(savePath1)
+    tmProto1 = BacktrackingTM.getSchema().new_message()
+    tm1.write(tmProto1)
+    with open(savePath1, "wb") as f:
+      tmProto1.write(f)
+    with open(savePath1, "rb") as f:
+      tmProto3 = BacktrackingTM.getSchema().read(f)
+    tm3 = BacktrackingTM.read(tmProto3)
 
     savePath2 = os.path.join(self._tmpDir, 'tm2.bin')
-    tm2.writeToFile(savePath2)
-    tm4 = BacktrackingTM.readFromFile(savePath2)
+    tmProto2 = BacktrackingTM.getSchema().new_message()
+    tm2.write(tmProto2)
+    with open(savePath2, "wb") as f:
+      tmProto2.write(f)
+    with open(savePath2, "rb") as f:
+      tmProto4 = BacktrackingTM.getSchema().read(f)
+    tm4 = BacktrackingTM.read(tmProto4)
 
     self.assertTMsEqual(tm1, tm3)
     self.assertTMsEqual(tm2, tm4)

--- a/tests/unit/nupic/algorithms/backtracking_tm_test.py
+++ b/tests/unit/nupic/algorithms/backtracking_tm_test.py
@@ -30,6 +30,11 @@ import random
 import shutil
 import tempfile
 import unittest2 as unittest
+
+try:
+  import capnp
+except ImportError:
+  capnp = None
 from pkg_resources import resource_filename
 
 from nupic.algorithms import fdrutilities
@@ -57,6 +62,7 @@ class BacktrackingTMTest(unittest.TestCase):
     self.assertTrue(isinstance(BacktrackingTM(), BacktrackingTM))
 
 
+  @unittest.skipUnless(capnp, "pycapnp not installed")
   def testSerializationLearned(self):
     if BacktrackingTM.__name__ == "BacktrackingTMCPP":
       return unittest.skip("CPP version doesn't support capnp yet")
@@ -98,6 +104,7 @@ class BacktrackingTMTest(unittest.TestCase):
         self.assertTrue(numpy.array_equal(result1, result2))
 
 
+  @unittest.skipUnless(capnp, "pycapnp not installed")
   def testSerializationMiddleOfSequence(self):
     if BacktrackingTM.__name__ == "BacktrackingTMCPP":
       return unittest.skip("CPP version doesn't support capnp yet")
@@ -141,6 +148,7 @@ class BacktrackingTMTest(unittest.TestCase):
         self.assertTrue(numpy.array_equal(result1, result2))
 
 
+  @unittest.skipUnless(capnp, "pycapnp not installed")
   def testSerializationMiddleOfSequence2(self):
     """More complex test of checkpointing in the middle of a sequence."""
     if BacktrackingTM.__name__ == "BacktrackingTMCPP":

--- a/tests/unit/nupic/algorithms/backtracking_tm_test.py
+++ b/tests/unit/nupic/algorithms/backtracking_tm_test.py
@@ -58,6 +58,8 @@ class BacktrackingTMTest(unittest.TestCase):
 
 
   def testSerializationLearned(self):
+    if BacktrackingTM.__name__ == "BacktrackingTMCPP":
+      return unittest.skip("CPP version doesn't support capnp yet")
     # Create a model and give it some inputs to learn.
     tm1 = BacktrackingTM(numberOfCols=100, cellsPerColumn=12,
                          verbosity=VERBOSITY)
@@ -97,6 +99,8 @@ class BacktrackingTMTest(unittest.TestCase):
 
 
   def testSerializationMiddleOfSequence(self):
+    if BacktrackingTM.__name__ == "BacktrackingTMCPP":
+      return unittest.skip("CPP version doesn't support capnp yet")
     # Create a model and give it some inputs to learn.
     tm1 = BacktrackingTM(numberOfCols=100, cellsPerColumn=12,
                          verbosity=VERBOSITY)
@@ -139,6 +143,8 @@ class BacktrackingTMTest(unittest.TestCase):
 
   def testSerializationMiddleOfSequence2(self):
     """More complex test of checkpointing in the middle of a sequence."""
+    if BacktrackingTM.__name__ == "BacktrackingTMCPP":
+      return unittest.skip("CPP version doesn't support capnp yet")
     tm1 = BacktrackingTM(2048, 32, 0.21, 0.5, 11, 20, 0.1, 0.1, 1.0, 0.0, 14,
                          False, 5, 2, False, 1960, 0, False, 3, 10, 5, 0, 32,
                          128, 32, 'normal')


### PR DESCRIPTION
Existing checkpoint tests copied and modified to use new serialization. These check all TM attributes as well as output from many TM.compute calls.

fix NUP-2356