### PR TITLE
DEVOPS-362 Add mysql to build

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,6 +19,9 @@ machine:
 dependencies:
   override:
     # Install all dependencies
+    - brew install mysql
+    - brew tap homebrew/services
+    - brew services start mysql
     - sudo pip install --upgrade pip
     - pip install --upgrade --user --ignore-installed setuptools wheel
     - pip install --use-wheel --user -r requirements.txt  --quiet || exit


### PR DESCRIPTION
Adds mysql to our CircleCI builds, which fixes all current test errors.