### PR TITLE
Fix some imports in the ipython notebook example

### DIFF
--- a/examples/NuPIC Walkthrough.ipynb
+++ b/examples/NuPIC Walkthrough.ipynb
@@ -332,7 +332,7 @@
    },
    "outputs": [],
    "source": [
-    "from nupic.research.spatial_pooler import SpatialPooler\n",
+    "from nupic.algorithms.spatial_pooler import SpatialPooler\n",
     "\n",
     "print SpatialPooler?"
    ]
@@ -752,7 +752,7 @@
    },
    "outputs": [],
    "source": [
-    "from nupic.research.BacktrackingTM import BacktrackingTM\n",
+    "from nupic.algorithms.backtracking_tm import BacktrackingTM\n",
     "\n",
     "BacktrackingTM?"
    ]


### PR DESCRIPTION
The introductory ipython notebook example imports the spatial pooler and the temporal memory from `nupic.research` and not from `nupic.algorithms`.