### PR TITLE
Changed distribution keyword, casted some attributes to float, remove…

### DIFF
--- a/src/nupic/algorithms/anomaly_likelihood.py
+++ b/src/nupic/algorithms/anomaly_likelihood.py
@@ -271,26 +271,23 @@ class AnomalyLikelihood(Serializable):
       anomalyLikelihood._historicalScores.append((i, score.value,
                                                   score.anomalyScore))
     if proto.distribution.name: # is "" when there is no distribution.
-      anomalyLikelihood._distribution = {}
-      anomalyLikelihood._distribution["name"] = proto.distribution.name
-      anomalyLikelihood._distribution["mean"] = proto.distribution.mean
-      anomalyLikelihood._distribution["variance"] = proto.distribution.variance
-      anomalyLikelihood._distribution["stdev"] = proto.distribution.stdev
+      anomalyLikelihood._distribution = dict()
+      anomalyLikelihood._distribution['distribution'] = dict()
+      anomalyLikelihood._distribution['distribution']["name"] = proto.distribution.name
+      anomalyLikelihood._distribution['distribution']["mean"] = proto.distribution.mean
+      anomalyLikelihood._distribution['distribution']["variance"] = proto.distribution.variance
+      anomalyLikelihood._distribution['distribution']["stdev"] = proto.distribution.stdev
 
       anomalyLikelihood._distribution["movingAverage"] = {}
-      anomalyLikelihood._distribution["movingAverage"]["windowSize"] =\
-        proto.distribution.movingAverage.windowSize
+      anomalyLikelihood._distribution["movingAverage"]["windowSize"] = proto.distribution.movingAverage.windowSize
       anomalyLikelihood._distribution["movingAverage"]["historicalValues"] = []
       for value in proto.distribution.movingAverage.historicalValues:
-        anomalyLikelihood._distribution["movingAverage"]["historicalValues"]\
-          .append(value)
-      anomalyLikelihood._distribution["movingAverage"]["total"] =\
-        proto.distribution.movingAverage.total
+        anomalyLikelihood._distribution["movingAverage"]["historicalValues"].append(value)
+      anomalyLikelihood._distribution["movingAverage"]["total"] = proto.distribution.movingAverage.total
 
       anomalyLikelihood._distribution["historicalLikelihoods"] = []
       for likelihood in proto.distribution.historicalLikelihoods:
-        anomalyLikelihood._distribution["historicalLikelihoods"].append(
-          likelihood)
+        anomalyLikelihood._distribution["historicalLikelihoods"].append(likelihood)
     else:
       anomalyLikelihood._distribution = None
 
@@ -308,6 +305,7 @@ class AnomalyLikelihood(Serializable):
     :param proto: (Object) capnp proto object specified in
                           nupic.regions.AnomalyLikelihoodRegion.capnp
     """
+
     proto.iteration = self._iteration
 
     pHistScores = proto.init('historicalScores', len(self._historicalScores))
@@ -317,33 +315,27 @@ class AnomalyLikelihood(Serializable):
       record.value = float(value)
       record.anomalyScore = float(anomalyScore)
 
-    if self._distribution:
-      proto.distribution.name = self._distribution["distributionParams"]["name"]
-      proto.distribution.mean = self._distribution["distributionParams"]["mean"]
-      proto.distribution.variance = self._distribution["distributionParams"]\
-        ["variance"]
-      proto.distribution.stdev = self._distribution["distributionParams"]\
-        ["stdev"]
+    proto.distribution.name = self._distribution["distribution"]["name"]
+    proto.distribution.mean = float(self._distribution["distribution"]["mean"])
+    proto.distribution.variance = float(self._distribution["distribution"]["variance"])
+    proto.distribution.stdev = float(self._distribution["distribution"]["stdev"])
 
-      proto.distribution.movingAverage.windowSize = self._distribution\
-        ["movingAverage"]["windowSize"]
+    proto.distribution.movingAverage.windowSize = float(self._distribution["movingAverage"]["windowSize"])
 
-      historicalValues = self._distribution["movingAverage"]["historicalValues"]
-      pHistValues = proto.distribution.movingAverage.init(
-        "historicalValues", len(historicalValues))
-      for i, value in enumerate(historicalValues):
-        pHistValues[i] = float(value)
+    historicalValues = self._distribution["movingAverage"]["historicalValues"]
+    pHistValues = proto.distribution.movingAverage.init(
+      "historicalValues", len(historicalValues))
+    for i, value in enumerate(historicalValues):
+      pHistValues[i] = float(value)
 
-      proto.distribution.movingAverage.historicalValues = self._distribution\
-        ["movingAverage"]["historicalValues"]
-      proto.distribution.movingAverage.total = self._distribution\
-        ["movingAverage"]["total"]
+    #proto.distribution.movingAverage.historicalValues = self._distribution["movingAverage"]["historicalValues"]
+    proto.distribution.movingAverage.total = float(self._distribution["movingAverage"]["total"])
 
-      historicalLikelihoods = self._distribution["historicalLikelihoods"]
-      pHistLikelihoods = proto.distribution.init("historicalLikelihoods",
-                                                 len(historicalLikelihoods))
-      for i, likelihood in enumerate(historicalLikelihoods):
-        pHistLikelihoods[i] = float(likelihood)
+    historicalLikelihoods = self._distribution["historicalLikelihoods"]
+    pHistLikelihoods = proto.distribution.init("historicalLikelihoods",
+                                               len(historicalLikelihoods))
+    for i, likelihood in enumerate(historicalLikelihoods):
+      pHistLikelihoods[i] = float(likelihood)
 
     proto.probationaryPeriod = self._probationaryPeriod
     proto.learningPeriod = self._learningPeriod

--- a/src/nupic/regions/AnomalyLikelihoodRegion.capnp
+++ b/src/nupic/regions/AnomalyLikelihoodRegion.capnp
@@ -16,16 +16,16 @@ struct AnomalyLikelihoodRegionProto {
 
   struct Distribution {
     name @0 :Text;
-    mean @1 :Float32;
-    variance @2 :Float32;
-    stdev @3 :Float32;
+    mean @1 :Float64;
+    variance @2 :Float64;
+    stdev @3 :Float64;
     movingAverage @4 :MovingAverage;
-    historicalLikelihoods @5 :List(Float32);
+    historicalLikelihoods @5 :List(Float64);
 
     struct MovingAverage {
       windowSize @0 :UInt64;
-      historicalValues @1 :List(Float32);
-      total @2 :Float32;
+      historicalValues @1 :List(Float64);
+      total @2 :Float64;
     }
   }
 }


### PR DESCRIPTION
This fixes #3783, but there were other issues discovered underneath these fixes. 

1. The incoming object to be serialized has the structure `self._distribution['distribution']['mean']`, `self._distribution['distribution']['stdev']` etc, but the write method expects `self._distribution['distributionParams']['mean']` (anomaly_likelihood.py line 318-321)

2. The read method did not expect `distribution` or `distributionParams` (anomaly_likelihood.py line 274-279) thus when the serialized object was read back into memory it did not have a matching structure. 

3. The incoming values cannot be serialized by capnproto because they have the type `numpy.float64`, so we cast them to `float` (which is a double) (anomaly_likelihood.py line 318-321)

4. The AnomalyLikelihoodRegion.capnp file uses `Float32` (not a double) instead of `Float64`.

@rhyolight I'm one of the developers working on Grok, we need to use these serialization methods, if you want some time to talk on the phone about these changes I would be happy to do that. There is some confusion here as to how you guys are serializing datetimes, looks like you just save an integer in place of it to preserve order, (why not serialize a timestamp and recreate the datetime object?)
Please do look over this code though, because it throws a fatal KeyError as is. Greatly appreciate all the help given on the forums! 