### PR TITLE
numenta/nupic.core#1380: Fix SP tests with correct dtype values

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ prettytable==0.7.2
 
 # When updating nupic.bindings, also update any shared dependencies to keep
 # versions in sync.
-nupic.bindings==1.0.0
+nupic.bindings==1.0.3
 numpy==1.12.1

--- a/tests/unit/nupic/algorithms/sp_overlap_test.py
+++ b/tests/unit/nupic/algorithms/sp_overlap_test.py
@@ -130,10 +130,10 @@ class TestSPFrequency(unittest.TestCase):
                                  maxval=maxVal, periodic=False, forced=True) # forced: it's strongly recommended to use w>=21, in the example we force skip the check for readibility
       for y in xrange(numColors):
         temp = enc.encode(rnd.random()*maxVal)
-        colors.append(numpy.array(temp, dtype=realDType))
+        colors.append(numpy.array(temp, dtype=numpy.uint32))
     else:
       for y in xrange(numColors):
-        sdr = numpy.zeros(n, dtype=realDType)
+        sdr = numpy.zeros(n, dtype=numpy.uint32)
         # Randomly setting w out of n bits to 1
         sdr[rnd.sample(xrange(n), w)] = 1
         colors.append(sdr)
@@ -144,7 +144,7 @@ class TestSPFrequency(unittest.TestCase):
     for i in xrange(numColors):
       # TODO: See https://github.com/numenta/nupic/issues/2072
       spInput = colors[i]
-      onCells = numpy.zeros(columnDimensions)
+      onCells = numpy.zeros(columnDimensions, dtype=numpy.uint32)
       spImpl.compute(spInput, True, onCells)
       spOutput.append(onCells.tolist())
       activeCoincIndices = set(onCells.nonzero()[0])

--- a/tests/unit/nupic/algorithms/spatial_pooler_cpp_unit_test.py
+++ b/tests/unit/nupic/algorithms/spatial_pooler_cpp_unit_test.py
@@ -178,6 +178,24 @@ class SpatialPoolerTest(unittest.TestCase):
     self.assertEqual(list(resultOverlapArr2), list(trueOverlapArr2))
 
 
+  def testComputeParametersValidation(self):
+    sp = SpatialPooler(inputDimensions=[5], columnDimensions=[5])
+    inputGood = np.ones(5, dtype=uintDType)
+    outGood = np.zeros(5, dtype=uintDType)
+    inputBad = np.ones(5, dtype=realDType)
+    outBad = np.zeros(5, dtype=realDType)
+
+    # Validate good parameters
+    sp.compute(inputGood, False, outGood)
+
+    # Validate bad input
+    with self.assertRaises(RuntimeError):
+      sp.compute(inputBad, False, outGood)
+
+    # Validate bad output
+    with self.assertRaises(RuntimeError):
+      sp.compute(inputGood, False, outBad)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/tests/unit/nupic/algorithms/spatial_pooler_cpp_unit_test.py
+++ b/tests/unit/nupic/algorithms/spatial_pooler_cpp_unit_test.py
@@ -183,18 +183,32 @@ class SpatialPoolerTest(unittest.TestCase):
     inputGood = np.ones(5, dtype=uintDType)
     outGood = np.zeros(5, dtype=uintDType)
     inputBad = np.ones(5, dtype=realDType)
+    inputBad2D = np.ones((5, 5), dtype=realDType)
     outBad = np.zeros(5, dtype=realDType)
+    outBad2D = np.zeros((5, 5), dtype=realDType)
 
     # Validate good parameters
     sp.compute(inputGood, False, outGood)
+
+    # Validate bad parameters
+    with self.assertRaises(RuntimeError):
+      sp.compute(inputBad, False, outBad)
 
     # Validate bad input
     with self.assertRaises(RuntimeError):
       sp.compute(inputBad, False, outGood)
 
+    # Validate bad 2d input
+    with self.assertRaises(RuntimeError):
+      sp.compute(inputBad2D, False, outGood)
+
     # Validate bad output
     with self.assertRaises(RuntimeError):
       sp.compute(inputGood, False, outBad)
+
+    # Validate bad 2d output
+    with self.assertRaises(RuntimeError):
+      sp.compute(inputGood, False, outBad2D)
 
 
 if __name__ == "__main__":

--- a/tests/unit/nupic/algorithms/spatial_pooler_py_api_test.py
+++ b/tests/unit/nupic/algorithms/spatial_pooler_py_api_test.py
@@ -42,8 +42,8 @@ class SpatialPoolerAPITest(unittest.TestCase):
 
   def testCompute(self):
     # Check that there are no errors in call to compute
-    inputVector = numpy.ones(5)
-    activeArray = numpy.zeros(5)
+    inputVector = numpy.ones(5, dtype=uintType)
+    activeArray = numpy.zeros(5, dtype=uintType)
     self.sp.compute(inputVector, True, activeArray)
 
 


### PR DESCRIPTION
As part of numenta/nupic.core#1380 fix, the `swig` interface now validates the `numpy.array` type making sure it matches the C++ implementation (`nupic::UInt`).  It will now throw an exception when the `compute` method is called with the wrong data type. 
This PR adds a new test checking if cpp SP swig interface is validating the input values and fixes other SP tests affected by this change.

This PR depends on numenta/nupic.core#1385 do not merge until numenta/nupic.core#1385 is merged