### PR TITLE
Fix softmax overflow

### DIFF
--- a/src/nupic/algorithms/sdr_classifier.py
+++ b/src/nupic/algorithms/sdr_classifier.py
@@ -374,6 +374,7 @@ class SDRClassifier(Serializable):
     outputActivation = weightMatrix[patternNZ].sum(axis=0)
 
     # softmax normalization
+    outputActivation = outputActivation - numpy.max(outputActivation)
     expOutputActivation = numpy.exp(outputActivation)
     predictDist = expOutputActivation / numpy.sum(expOutputActivation)
     return predictDist


### PR DESCRIPTION
Please look this softmax formula.

<img src="https://latex.codecogs.com/gif.latex?\frac{e^{x_i}}{\sum_j{e^{x_j}}}&space;=&space;\frac{e^{-m}}{e^{-m}}&space;\cdot&space;\frac{e^{x_i}}{\sum_j{e^{x_j}}}&space;=&space;\frac{e^{x_i-m}}{\sum_j{e^{x_j-m}}}" />

If x_i is too big, it occur overflow. It is necessary to subtract constant m. Sometimes people set m to be the maximum of x.