### PR TITLE
Serialize data in binary format, not ascii

### DIFF
--- a/src/nupic/frameworks/opf/model.py
+++ b/src/nupic/frameworks/opf/model.py
@@ -351,7 +351,7 @@ class Model(Serializable):
     with open(modelPickleFilePath, 'wb') as modelPickleFile:
       logger.debug("(%s) Pickling Model instance...", self)
 
-      pickle.dump(self, modelPickleFile)
+      pickle.dump(self, modelPickleFile, protocol=pickle.HIGHEST_PROTOCOL)
 
       logger.debug("(%s) Finished pickling Model instance", self)
 

--- a/src/nupic/frameworks/opf/model.py
+++ b/src/nupic/frameworks/opf/model.py
@@ -387,7 +387,7 @@ class Model(Serializable):
     # Load the model
     modelPickleFilePath = Model._getModelPickleFilePath(savedModelDir)
 
-    with open(modelPickleFilePath, 'r') as modelPickleFile:
+    with open(modelPickleFilePath, 'rb') as modelPickleFile:
       logger.debug("Unpickling Model instance...")
 
       model = pickle.load(modelPickleFile)


### PR DESCRIPTION
I understand that these methods are depreciated, but they are much faster than capnproto....with *this* change its orders of magnitude faster.

Please see: https://stackoverflow.com/questions/23582489/python-pickle-protocol-choice

**Edit: Looks like the contributor validator failed, I have already signed the paper work for this FYI, you got my fingerprints, iris scan etc** 