### PR TITLE
Fix destruction of synapses when destroying segment

### DIFF
--- a/src/nupic/algorithms/connections.py
+++ b/src/nupic/algorithms/connections.py
@@ -290,9 +290,9 @@ class Connections(Serializable):
     :param segment: (:class:`Segment`) representing the segment to be destroyed.
     """
     # Remove the synapses from all data structures outside this Segment.
-    for synapse in segment._synapses:
-      self._removeSynapseFromPresynapticMap(synapse)
     self._numSynapses -= len(segment._synapses)
+    for synapse in list(segment._synapses):
+      self.destroySynapse(synapse)
 
     # Remove the segment from the cell's list.
     segments = self._cells[segment.cell]._segments


### PR DESCRIPTION
When the **predictedSegmentDecrement** TM parameter is set to some value greater than 0, I was getting this error:

![Captura de tela de 2019-08-07 02-42-00](https://user-images.githubusercontent.com/15933802/62992491-06976600-be2a-11e9-9eab-ce2a554d7fcd.png)

Using the destroySynapse function prevents the error in my tests.
